### PR TITLE
Fix allocator pointer conversions for C++ builds

### DIFF
--- a/inc/common/zone.h
+++ b/inc/common/zone.h
@@ -21,6 +21,30 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define Z_CopyString(string)    Z_TagCopyString(string, TAG_GENERAL)
 #define Z_CopyStruct(ptr)       memcpy(Z_Malloc(sizeof(*ptr)), ptr, sizeof(*ptr))
 
+#ifdef __cplusplus
+struct z_allocation {
+    void *value;
+
+    constexpr z_allocation(void *p = nullptr) noexcept
+        : value(p) {}
+
+    template <typename T>
+    constexpr operator T *() const noexcept
+    {
+        return static_cast<T *>(value);
+    }
+
+    constexpr explicit operator bool() const noexcept
+    {
+        return value != nullptr;
+    }
+};
+
+using z_pointer = z_allocation;
+#else
+typedef void *z_pointer;
+#endif
+
 // memory tags to allow dynamic memory to be cleaned up
 // game DLL has separate tag namespace starting at TAG_MAX
 typedef enum {
@@ -46,16 +70,16 @@ typedef enum {
 void    Z_Init(void);
 void    Z_Free(void *ptr);
 void    Z_Freep(void *ptr);
-void    *Z_Realloc(void *ptr, size_t size);
-void    *Z_ReallocArray(void *ptr, size_t nmemb, size_t size, memtag_t tag);
+z_pointer   Z_Realloc(void *ptr, size_t size);
+z_pointer   Z_ReallocArray(void *ptr, size_t nmemb, size_t size, memtag_t tag);
 q_malloc
-void    *Z_Malloc(size_t size);
+z_pointer   Z_Malloc(size_t size);
 q_malloc
-void    *Z_Mallocz(size_t size);
+z_pointer   Z_Mallocz(size_t size);
 q_malloc
-void    *Z_TagMalloc(size_t size, memtag_t tag);
+z_pointer   Z_TagMalloc(size_t size, memtag_t tag);
 q_malloc
-void    *Z_TagMallocz(size_t size, memtag_t tag);
+z_pointer   Z_TagMallocz(size_t size, memtag_t tag);
 q_malloc
 char    *Z_TagCopyString(const char *in, memtag_t tag);
 void    Z_FreeTags(memtag_t tag);

--- a/src/client/http.cpp
+++ b/src/client/http.cpp
@@ -132,7 +132,7 @@ static size_t recv_func(void *ptr, size_t size, size_t nmemb, void *stream)
     // grow buffer in MIN_DLSIZE chunks. +1 for NUL.
     new_size = Q_ALIGN(dl->position + bytes + 1, MIN_DLSIZE);
     if (new_size > dl->size) {
-        char *buf = realloc(dl->buffer, new_size);
+        char *buf = static_cast<char *>(realloc(dl->buffer, new_size));
         if (!buf)
             return 0;
         dl->size = new_size;

--- a/src/common/cmd.cpp
+++ b/src/common/cmd.cpp
@@ -1283,7 +1283,7 @@ char *Cmd_MacroExpandString(const char *text, bool aliasHack)
 
         // copy off text into static buffer
         if (scan != expanded)
-            scan = memcpy(expanded, text, len + 1);
+            scan = static_cast<char *>(memcpy(expanded, text, len + 1));
 
         // scan out the complete macro
         start = scan + i + 1;

--- a/src/refresh/images.cpp
+++ b/src/refresh/images.cpp
@@ -696,7 +696,7 @@ static int IMG_SaveTGA(const screenshot_t *s)
     if (!fwrite(&header, sizeof(header), 1, s->fp))
         return Q_ERR_FAILURE;
 
-    byte *row = malloc(s->width * 3);
+    byte *row = static_cast<byte *>(malloc(s->width * 3));
     if (!row)
         return Q_ERR(ENOMEM);
 
@@ -890,7 +890,7 @@ static int IMG_SaveJPG(const screenshot_t *s)
     jerr.pub.output_message = my_output_message;
     jerr.filename = s->async ? NULL : s->filename;
 
-    row_pointers = malloc(sizeof(JSAMPROW) * s->height);
+    row_pointers = static_cast<JSAMPARRAY>(malloc(sizeof(JSAMPROW) * s->height));
     if (!row_pointers)
         return Q_ERR(ENOMEM);
 
@@ -1127,7 +1127,7 @@ static int IMG_SavePNG(const screenshot_t *s)
         goto fail;
     }
 
-    row_pointers = malloc(sizeof(png_bytep) * s->height);
+    row_pointers = static_cast<png_bytepp>(malloc(sizeof(png_bytep) * s->height));
     if (!row_pointers) {
         ret = Q_ERR(ENOMEM);
         goto fail;

--- a/src/shared/base85.cpp
+++ b/src/shared/base85.cpp
@@ -252,11 +252,11 @@ base85_context_grow (struct base85_context_t *ctx)
   // TODO: Refine size, and fallback strategy.
   size_t size = ctx->out_cb * 2;
   ptrdiff_t offset = ctx->out_pos - ctx->out;
-  uint8_t *buffer = realloc (ctx->out, size);
+  uint8_t *buffer = static_cast<uint8_t *>(realloc (ctx->out, size));
   if (!buffer)
   {
     // Try a smaller allocation.
-    buffer = realloc (ctx->out, ctx->out_cb + SMALL_DELTA);
+    buffer = static_cast<uint8_t *>(realloc (ctx->out, ctx->out_cb + SMALL_DELTA));
     if (!buffer)
       return B85_E_BAD_ALLOC;
   }
@@ -318,7 +318,7 @@ B85_CONTEXT_INIT (struct base85_context_t *ctx)
   ctx->pos = 0;
   ctx->state = B85_S_START;
 
-  ctx->out = malloc (INITIAL_BUFFER_SIZE);
+  ctx->out = static_cast<uint8_t *>(malloc (INITIAL_BUFFER_SIZE));
   if (!ctx->out)
     return B85_E_BAD_ALLOC;
 


### PR DESCRIPTION
## Summary
- add a z_allocation wrapper so zone allocator APIs remain easy to use under C++
- update the zone allocator implementation and helper routines to return the new wrapper
- cast results from malloc/realloc/memcpy at the few remaining call sites to satisfy C++

## Testing
- meson setup build *(fails: meson is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ec392f90988328929b5e22d32f1252