### PR TITLE
Refactor client buffers to std::array

### DIFF
--- a/src/client/client.h
+++ b/src/client/client.h
@@ -20,6 +20,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
+#include <array>
+
 #include "shared/shared.h"
 #include "shared/list.h"
 #include "shared/game.h"
@@ -653,7 +655,7 @@ typedef struct {
 extern client_static_t      cls;
 
 extern cmdbuf_t     cl_cmdbuf;
-extern char         cl_cmdbuf_text[MAX_STRING_CHARS];
+extern std::array<char, MAX_STRING_CHARS> cl_cmdbuf_text;
 
 //=============================================================================
 


### PR DESCRIPTION
## Summary
- include `<array>` in the client headers and transition the shared command buffer storage to `std::array`
- replace stack string buffers in the main client code with `std::array` wrappers and update all consumers to use `.data()`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ec3d9c02d08328bd1553cb01c7380c