### PR TITLE
Refactor Windows support arrays to use std::array

### DIFF
--- a/src/windows/client.cpp
+++ b/src/windows/client.cpp
@@ -19,6 +19,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "client.h"
 #include <hidusage.h>
 
+#include <array>
+
 win_state_t     win;
 
 static cvar_t   *vid_flip_on_switch;
@@ -554,7 +556,7 @@ static void win_disablewinkey_changed(cvar_t *self)
     }
 }
 
-static const byte scantokey[2][96] = {
+static const std::array<std::array<byte, 96>, 2> scantokey = { {
     {
 //      0               1           2           3               4           5               6           7
 //      8               9           A           B               C           D               E           F
@@ -585,7 +587,7 @@ static const byte scantokey[2][96] = {
         K_DOWNARROW,    K_PGDN,     K_INS,      K_DEL,          0,          0,              0,          0,
         0,              0,          0,          K_LWINKEY,      K_RWINKEY,  K_MENU,         0,          0,          // 5
     }
-};
+} };
 
 // Map from windows to quake keynums
 static void legacy_key_event(WPARAM wParam, LPARAM lParam, bool down)
@@ -709,18 +711,18 @@ static void raw_mouse_event(const RAWMOUSE *rm)
 
 static void raw_input_event(HRAWINPUT handle)
 {
-    BYTE buffer[64];
+    std::array<BYTE, 64> buffer;
     UINT len, ret;
     PRAWINPUT ri;
 
-    len = sizeof(buffer);
-    ret = GetRawInputData(handle, RID_INPUT, buffer, &len, sizeof(RAWINPUTHEADER));
+    len = static_cast<UINT>(buffer.size());
+    ret = GetRawInputData(handle, RID_INPUT, buffer.data(), &len, sizeof(RAWINPUTHEADER));
     if (ret == (UINT)-1) {
         Com_EPrintf("GetRawInputData failed with error %#lx\n", GetLastError());
         return;
     }
 
-    ri = (PRAWINPUT)buffer;
+    ri = reinterpret_cast<PRAWINPUT>(buffer.data());
     if (ri->header.dwType == RIM_TYPEMOUSE) {
         raw_mouse_event(&ri->data.mouse);
     }

--- a/src/windows/egl.cpp
+++ b/src/windows/egl.cpp
@@ -19,6 +19,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "client.h"
 #include <EGL/egl.h>
 
+#include <array>
+
 static struct {
     void        *handle;
     EGLDisplay  dpy;
@@ -55,7 +57,7 @@ static void print_error(const char *what)
 
 static bool choose_config(r_opengl_config_t cfg, EGLConfig *config)
 {
-    EGLint cfg_attr[] = {
+    std::array<EGLint, 19> cfg_attr = {
         EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
         EGL_RENDERABLE_TYPE, EGL_OPENGL_ES3_BIT,
         EGL_RED_SIZE, 5,
@@ -63,13 +65,13 @@ static bool choose_config(r_opengl_config_t cfg, EGLConfig *config)
         EGL_BLUE_SIZE, 5,
         EGL_DEPTH_SIZE, cfg.depthbits,
         EGL_STENCIL_SIZE, cfg.stencilbits,
-        EGL_SAMPLE_BUFFERS, (bool)cfg.multisamples,
+        EGL_SAMPLE_BUFFERS, static_cast<EGLint>((bool)cfg.multisamples),
         EGL_SAMPLES, cfg.multisamples,
         EGL_NONE
     };
 
     EGLint num_configs;
-    if (!qeglChooseConfig(egl.dpy, cfg_attr, config, 1, &num_configs)) {
+    if (!qeglChooseConfig(egl.dpy, cfg_attr.data(), config, 1, &num_configs)) {
         print_error("eglChooseConfig");
         return false;
     }
@@ -133,12 +135,12 @@ static bool egl_init(void)
         goto fail;
     }
 
-    EGLint ctx_attr[] = {
+    std::array<EGLint, 5> ctx_attr = {
         EGL_CONTEXT_MAJOR_VERSION, 3,
         EGL_CONTEXT_OPENGL_DEBUG, cfg.debug,
         EGL_NONE
     };
-    egl.ctx = qeglCreateContext(egl.dpy, config, EGL_NO_CONTEXT, ctx_attr);
+    egl.ctx = qeglCreateContext(egl.dpy, config, EGL_NO_CONTEXT, ctx_attr.data());
     if (!egl.ctx) {
         print_error("eglCreateContext");
         goto fail;

--- a/src/windows/wgl.cpp
+++ b/src/windows/wgl.cpp
@@ -21,6 +21,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <GL/gl.h>
 #include <GL/wglext.h>
 
+#include <array>
+
 static struct {
     HGLRC       context;        // handle to GL rendering context
     HMODULE     handle;         // handle to GL library
@@ -89,7 +91,7 @@ static int wgl_setup_gl(r_opengl_config_t cfg)
 
     // choose pixel format
     if (wgl.ChoosePixelFormatARB && cfg.multisamples) {
-        int attr[] = {
+        const std::array<int, 19> attr = {
             WGL_DRAW_TO_WINDOW_ARB, TRUE,
             WGL_SUPPORT_OPENGL_ARB, TRUE,
             WGL_DOUBLE_BUFFER_ARB, TRUE,
@@ -103,7 +105,7 @@ static int wgl_setup_gl(r_opengl_config_t cfg)
         };
         UINT num_formats;
 
-        if (!wgl.ChoosePixelFormatARB(win.dc, attr, NULL, 1, &pixelformat, &num_formats)) {
+        if (!wgl.ChoosePixelFormatARB(win.dc, attr.data(), NULL, 1, &pixelformat, &num_formats)) {
             print_error("wglChoosePixelFormatARB");
             goto soft;
         }
@@ -155,7 +157,7 @@ static int wgl_setup_gl(r_opengl_config_t cfg)
 
     // startup the OpenGL subsystem by creating a context and making it current
     if (wgl.CreateContextAttribsARB && (cfg.debug || cfg.profile)) {
-        int attr[9];
+        std::array<int, 9> attr{};
         int i = 0;
 
         if (cfg.profile) {
@@ -177,7 +179,7 @@ static int wgl_setup_gl(r_opengl_config_t cfg)
         }
         attr[i] = 0;
 
-        if (!(wgl.context = wgl.CreateContextAttribsARB(win.dc, NULL, attr))) {
+        if (!(wgl.context = wgl.CreateContextAttribsARB(win.dc, NULL, attr.data()))) {
             print_error("wglCreateContextAttribsARB");
             goto soft;
         }


### PR DESCRIPTION
## Summary
- replace Windows system console, service, and path helper buffers with std::array for safer handling
- update Windows client input tables and raw input buffer to std::array
- migrate EGL and WGL attribute lists to std::array before passing to platform APIs

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ec3e3eec8c8328bf24f9b82c67e634