### PR TITLE
Use std::array in Unix platform code

### DIFF
--- a/src/unix/tty.cpp
+++ b/src/unix/tty.cpp
@@ -36,6 +36,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <errno.h>
 #include <poll.h>
 
+#include <array>
+
 enum {
     CTRL_A = 1, CTRL_B = 2, CTRL_D = 4, CTRL_E = 5, CTRL_F = 6, CTRL_H = 8,
     TAB = 9, ENTER = 10, CTRL_K = 11, CTRL_L = 12, CTRL_N = 14, CTRL_P = 16,
@@ -114,15 +116,15 @@ static void tty_write(const char *buf, size_t len)
 q_printf(1, 2)
 static void tty_printf(const char *fmt, ...)
 {
-    char buf[MAX_STRING_CHARS];
+    std::array<char, MAX_STRING_CHARS> buf{};
     va_list ap;
     size_t len;
 
     va_start(ap, fmt);
-    len = Q_vscnprintf(buf, sizeof(buf), fmt, ap);
+    len = Q_vscnprintf(buf.data(), buf.size(), fmt, ap);
     va_end(ap);
 
-    tty_write(buf, len);
+    tty_write(buf.data(), len);
 }
 
 static int tty_get_width(void)
@@ -675,7 +677,7 @@ void Sys_ConsoleOutput(const char *text, size_t len)
 
 void Sys_SetConsoleTitle(const char *title)
 {
-    char buf[MAX_STRING_CHARS];
+    std::array<char, MAX_STRING_CHARS> buf{};
     size_t len;
 
     if (!tty_enabled) {
@@ -697,12 +699,12 @@ void Sys_SetConsoleTitle(const char *title)
 
     buf[len++] = '\007';
 
-    tty_write(buf, len);
+    tty_write(buf.data(), len);
 }
 
 void Sys_SetConsoleColor(color_index_t color)
 {
-    char buf[5];
+    std::array<char, 5> buf{};
     size_t len;
 
     if (!tty_enabled) {
@@ -734,7 +736,7 @@ void Sys_SetConsoleColor(color_index_t color)
     if (color != COLOR_INDEX_NONE) {
         tty_hide_input();
     }
-    tty_write(buf, len);
+    tty_write(buf.data(), len);
     if (color == COLOR_INDEX_NONE) {
         tty_show_input();
     }

--- a/src/unix/video/sdl.cpp
+++ b/src/unix/video/sdl.cpp
@@ -35,6 +35,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "../res/q2pro.xbm"
 #include <SDL.h>
 
+#include <array>
+
 static struct {
     SDL_Window      *window;
     SDL_GLContext   *context;
@@ -183,14 +185,14 @@ static void set_clipboard_data(const char *data)
 
 static void update_gamma(const byte *table)
 {
-    Uint16 ramp[256];
+    std::array<Uint16, 256> ramp{};
     int i;
 
     if (sdl.flags & QVF_GAMMARAMP) {
         for (i = 0; i < 256; i++) {
             ramp[i] = table[i] << 8;
         }
-        SDL_SetWindowGammaRamp(sdl.window, ramp, ramp, ramp);
+        SDL_SetWindowGammaRamp(sdl.window, ramp.data(), ramp.data(), ramp.data());
     }
 }
 
@@ -305,11 +307,11 @@ static bool init(void)
     SDL_Surface *icon = SDL_CreateRGBSurfaceWithFormatFrom(q2icon_bits, q2icon_width, q2icon_height,
                                                            1, q2icon_width / 8, SDL_PIXELFORMAT_INDEX1LSB);
     if (icon) {
-        SDL_Color colors[2] = {
+        std::array<SDL_Color, 2> colors{{
             { 255, 255, 255 },
             {   0, 128, 128 }
-        };
-        SDL_SetPaletteColors(icon->format->palette, colors, 0, 2);
+        }};
+        SDL_SetPaletteColors(icon->format->palette, colors.data(), 0, 2);
         SDL_SetColorKey(icon, SDL_TRUE, 0);
         SDL_SetWindowIcon(sdl.window, icon);
         SDL_FreeSurface(icon);
@@ -317,10 +319,10 @@ static bool init(void)
 
     cvar_t *vid_hwgamma = Cvar_Get("vid_hwgamma", "0", CVAR_REFRESH);
     if (vid_hwgamma->integer) {
-        Uint16  gamma[3][256];
+        std::array<std::array<Uint16, 256>, 3> gamma{};
 
-        if (SDL_GetWindowGammaRamp(sdl.window, gamma[0], gamma[1], gamma[2]) == 0 &&
-            SDL_SetWindowGammaRamp(sdl.window, gamma[0], gamma[1], gamma[2]) == 0) {
+        if (SDL_GetWindowGammaRamp(sdl.window, gamma[0].data(), gamma[1].data(), gamma[2].data()) == 0 &&
+            SDL_SetWindowGammaRamp(sdl.window, gamma[0].data(), gamma[1].data(), gamma[2].data()) == 0) {
             Com_Printf("...enabling hardware gamma\n");
             sdl.flags |= QVF_GAMMARAMP;
         } else {

--- a/src/unix/video/x11.cpp
+++ b/src/unix/video/x11.cpp
@@ -39,6 +39,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include <GL/glx.h>
 
+#include <array>
+
 #include <poll.h>
 
 #define XA(x)   XInternAtom(x11.dpy, #x, False)
@@ -395,7 +397,7 @@ static bool init(void)
             glXCreateContextAttribsARB = get_proc_addr("glXCreateContextAttribsARB");
 
         if (glXCreateContextAttribsARB) {
-            int ctx_attr[9];
+            std::array<int, 9> ctx_attr{};
             int i = 0;
 
             if (cfg.profile) {
@@ -414,7 +416,7 @@ static bool init(void)
             }
             ctx_attr[i] = None;
 
-            if (!(x11.ctx = glXCreateContextAttribsARB(x11.dpy, fbc, NULL, True, ctx_attr)))
+            if (!(x11.ctx = glXCreateContextAttribsARB(x11.dpy, fbc, NULL, True, ctx_attr.data())))
                 Com_EPrintf("Failed to create GL context with attributes\n");
         } else {
             Com_WPrintf("GLX_ARB_create_context not found\n");
@@ -781,13 +783,13 @@ static bool init_mouse(void)
         return false;
     }
 
-    uint8_t mask[4] = { 0 };
+    std::array<uint8_t, 4> mask{};
     XIEventMask eventmask = {
         .deviceid = XIAllMasterDevices,
-        .mask_len = sizeof(mask),
-        .mask = mask
+        .mask_len = static_cast<int>(mask.size()),
+        .mask = reinterpret_cast<unsigned char *>(mask.data())
     };
-    XISetMask(mask, XI_RawMotion);
+    XISetMask(reinterpret_cast<unsigned char *>(mask.data()), XI_RawMotion);
     XISelectEvents(x11.dpy, x11.root, &eventmask, 1);
 
     Com_Printf("XInput2 mouse initialized\n");


### PR DESCRIPTION
## Summary
- replace stack-allocated C arrays with `std::array` in the Unix tty and video backends
- update buffer handling to pass pointers from the C++ containers and include the required headers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ec3e37d6d88328ae54253886f43a59