### PR TITLE
Refactor server buffers to use std::array

### DIFF
--- a/src/server/ac.cpp
+++ b/src/server/ac.cpp
@@ -22,6 +22,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "server.h"
 
+#include <array>
+
 typedef enum {
     ACS_BAD,
     ACS_CLIENTACK,
@@ -225,7 +227,7 @@ static void AC_ParseHash(char *data, int linenum, const char *path)
     char *pstr, *hstr;
     size_t pathlen, hashlen;
     int flags;
-    byte hash[20];
+    std::array<byte, 20> hash{};
     ac_file_t *file;
     int i;
 
@@ -277,7 +279,7 @@ badhash:
     }
 
     file = SV_Malloc(sizeof(*file) + pathlen);
-    memcpy(file->hash, hash, sizeof(file->hash));
+    memcpy(file->hash, hash.data(), hash.size());
     memcpy(file->path, pstr, pathlen + 1);
     file->flags = flags;
     file->next = acs.files;
@@ -287,7 +289,8 @@ badhash:
 
 static void AC_ParseCvar(char *data, int linenum, const char *path)
 {
-    char *values[256], *p;
+    std::array<char *, 256> values{};
+    char *p;
     char *name, *opstr, *val, *def;
     size_t len, namelen, vallen, deflen;
     ac_cvar_t *cvar;
@@ -515,12 +518,12 @@ REPLY PARSING
 
 static void AC_Retry(void)
 {
-    char buf[MAX_QPATH];
+    std::array<char, MAX_QPATH> buf{};
     time_t clock;
 
-    Com_FormatTimeLong(buf, sizeof(buf), acs.retry_backoff);
+    Com_FormatTimeLong(buf.data(), buf.size(), acs.retry_backoff);
     Com_Printf("ANTICHEAT: Re%s in %s.\n",
-               ac.connected ? "connecting" : "trying", buf);
+               ac.connected ? "connecting" : "trying", buf.data());
     clock = time(NULL);
     acs.retry_time = clock + acs.retry_backoff;
 }
@@ -574,14 +577,14 @@ static void AC_Disable(void)
 static void AC_Announce(client_t *client, const char *fmt, ...)
 {
     va_list     argptr;
-    char        string[MAX_STRING_CHARS];
+    std::array<char, MAX_STRING_CHARS> string{};
     size_t      len;
 
     va_start(argptr, fmt);
-    len = Q_vsnprintf(string, sizeof(string), fmt, argptr);
+    len = Q_vsnprintf(string.data(), string.size(), fmt, argptr);
     va_end(argptr);
 
-    if (len >= sizeof(string)) {
+    if (len >= string.size()) {
         Com_WPrintf("%s: overflow\n", __func__);
         return;
     }
@@ -589,7 +592,7 @@ static void AC_Announce(client_t *client, const char *fmt, ...)
     MSG_WriteByte(svc_print);
     MSG_WriteByte(PRINT_HIGH);
     MSG_WriteData(AC_MESSAGE, sizeof(AC_MESSAGE) - 1);
-    MSG_WriteData(string, len + 1);
+    MSG_WriteData(string.data(), len + 1);
 
     if (client->state == cs_spawned) {
         FOR_EACH_CLIENT(client) {
@@ -641,8 +644,8 @@ static client_t *AC_ParseClient(void)
 static void AC_ParseViolation(void)
 {
     client_t        *cl;
-    char            reason[32];
-    char            clientreason[64];
+    std::array<char, 32> reason{};
+    std::array<char, 64> clientreason{};
 
     cl = AC_ParseClient();
     if (!cl) {
@@ -654,10 +657,10 @@ static void AC_ParseViolation(void)
         return;
     }
 
-    MSG_ReadString(reason, sizeof(reason));
+    MSG_ReadString(reason.data(), reason.size());
 
     if (msg_read.readcount < msg_read.cursize) {
-        MSG_ReadString(clientreason, sizeof(clientreason));
+        MSG_ReadString(clientreason.data(), clientreason.size());
     } else {
         clientreason[0] = 0;
     }
@@ -669,22 +672,22 @@ static void AC_ParseViolation(void)
     // for spawned clients.
 
     // fixme maybe
-    if (strcmp(reason, "disconnected")) {
-        char    showreason[32];
+    if (strcmp(reason.data(), "disconnected")) {
+        std::array<char, 32> showreason{};
 
         if (ac_show_violation_reason->integer)
-            Q_snprintf(showreason, sizeof(showreason), " (%s)", reason);
+            Q_snprintf(showreason.data(), showreason.size(), " (%s)", reason.data());
         else
             showreason[0] = 0;
 
         AC_Announce(cl, "%s was kicked for anticheat violation%s\n",
-                    cl->name, showreason);
+                    cl->name, showreason.data());
 
         Com_Printf("ANTICHEAT VIOLATION: %s[%s] was kicked: %s\n",
-                   cl->name, NET_AdrToString(&cl->netchan.remote_address), reason);
+                   cl->name, NET_AdrToString(&cl->netchan.remote_address), reason.data());
 
         if (clientreason[0])
-            SV_ClientPrintf(cl, PRINT_HIGH, "%s\n", clientreason);
+            SV_ClientPrintf(cl, PRINT_HIGH, "%s\n", clientreason.data());
 
         // hack to fix late zombies race condition
         cl->lastmessage = svs.realtime;
@@ -740,8 +743,8 @@ static void AC_ParseFileViolation(void)
 {
     string_entry_t    *bad;
     client_t    *cl;
-    char        path[MAX_QPATH];
-    char        hash[MAX_QPATH];
+    std::array<char, MAX_QPATH> path{};
+    std::array<char, MAX_QPATH> hash{};
     int         action;
     size_t      pathlen;
     ac_file_t   *f;
@@ -756,23 +759,23 @@ static void AC_ParseFileViolation(void)
         return;
     }
 
-    pathlen = MSG_ReadString(path, sizeof(path));
-    if (pathlen >= sizeof(path)) {
+    pathlen = MSG_ReadString(path.data(), path.size());
+    if (pathlen >= path.size()) {
         Com_WPrintf("ANTICHEAT: Oversize path in %s\n", __func__);
-        pathlen = sizeof(path) - 1;
+        pathlen = path.size() - 1;
     }
 
     if (msg_read.readcount < msg_read.cursize) {
-        MSG_ReadString(hash, sizeof(hash));
+        MSG_ReadString(hash.data(), hash.size());
     } else {
-        strcpy(hash, "no hash?");
+        strcpy(hash.data(), "no hash?");
     }
 
     cl->ac_file_failures++;
 
     action = ac_badfile_action->integer;
     for (f = acs.files; f; f = f->next) {
-        if (!strcmp(f->path, path)) {
+        if (!strcmp(f->path, path.data())) {
             if (f->flags & ACH_REQUIRED) {
                 action = 0;
                 break;
@@ -781,19 +784,19 @@ static void AC_ParseFileViolation(void)
     }
 
     Com_Printf("ANTICHEAT FILE VIOLATION: %s[%s] has a modified %s [%s]\n",
-               cl->name, NET_AdrToString(&cl->netchan.remote_address), path, hash);
+               cl->name, NET_AdrToString(&cl->netchan.remote_address), path.data(), hash.data());
     switch (action) {
     case 0:
-        AC_Announce(cl, "%s was kicked for modified %s\n", cl->name, path);
+        AC_Announce(cl, "%s was kicked for modified %s\n", cl->name, path.data());
         break;
     case 1:
         SV_ClientPrintf(cl, PRINT_HIGH, AC_MESSAGE
                         "Your file %s has been modified. "
-                        "Please replace it with a known valid copy.\n", path);
+                        "Please replace it with a known valid copy.\n", path.data());
         break;
     case 2:
         // spamalicious :)
-        AC_Announce(cl, "%s has a modified %s\n", cl->name, path);
+        AC_Announce(cl, "%s has a modified %s\n", cl->name, path.data());
         break;
     }
 
@@ -814,7 +817,7 @@ static void AC_ParseFileViolation(void)
     }
 
     bad = SV_Malloc(sizeof(*bad) + pathlen);
-    memcpy(bad->string, path, pathlen + 1);
+    memcpy(bad->string, path.data(), pathlen + 1);
     bad->next = cl->ac_bad_files;
     cl->ac_bad_files = bad;
 }
@@ -888,10 +891,10 @@ static void AC_ParseDisconnect(void)
 
 static void AC_ParseError(void)
 {
-    char string[MAX_STRING_CHARS];
+    std::array<char, MAX_STRING_CHARS> string{};
 
-    MSG_ReadString(string, sizeof(string));
-    Com_EPrintf("ANTICHEAT: %s\n", string);
+    MSG_ReadString(string.data(), string.size());
+    Com_EPrintf("ANTICHEAT: %s\n", string.data());
     AC_Disable();
 }
 

--- a/src/server/commands.cpp
+++ b/src/server/commands.cpp
@@ -18,6 +18,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "server.h"
 
+#include <array>
+
 /*
 ===============================================================================
 
@@ -738,7 +740,7 @@ static void dump_protocols(void)
 static void dump_settings(void)
 {
     client_t    *cl;
-    char        opt[8];
+    std::array<char, 8> opt{};
 
     Com_Printf(
         "num name            proto options upd fps\n"
@@ -754,7 +756,7 @@ static void dump_settings(void)
         opt[5] = cl->settings[CLS_NOPREDICT]      ? 'P' : ' ';
         opt[6] = cl->settings[CLS_NOFLARES]       ? 'L' : ' ';
         Com_Printf("%3i %-15.15s %5d %s %3d %3d\n",
-                   cl->number, cl->name, cl->protocol, opt,
+                   cl->number, cl->name, cl->protocol, opt.data(),
                    cl->settings[CLS_PLAYERUPDATES], cl->settings[CLS_FPS]);
     }
 }

--- a/src/server/user.cpp
+++ b/src/server/user.cpp
@@ -19,6 +19,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "server.h"
 
+#include <array>
+
 #define MSG_GAMESTATE   (MSG_RELIABLE | MSG_CLEAR)
 
 /*
@@ -173,7 +175,7 @@ static void stuff_junk(void)
 {
     static const char junkchars[] =
         "!#&'()*+,-./0123456789:<=>?@[\\]^_``````````abcdefghijklmnopqrstuvwxyz|~~~~~~~~~~";
-    char junk[8][16];
+    std::array<std::array<char, 16>, 8> junk{};
     int i, j;
 
     for (i = 0; i < 8; i++) {
@@ -182,24 +184,24 @@ static void stuff_junk(void)
         junk[i][j] = 0;
     }
 
-    Q_strlcpy(sv_client->reconnect_var, junk[2], sizeof(sv_client->reconnect_var));
-    Q_strlcpy(sv_client->reconnect_val, junk[3], sizeof(sv_client->reconnect_val));
+    Q_strlcpy(sv_client->reconnect_var, junk[2].data(), sizeof(sv_client->reconnect_var));
+    Q_strlcpy(sv_client->reconnect_val, junk[3].data(), sizeof(sv_client->reconnect_val));
 
-    SV_ClientCommand(sv_client, "set %s set\n", junk[0]);
-    SV_ClientCommand(sv_client, "$%s %s connect\n", junk[0], junk[1]);
+    SV_ClientCommand(sv_client, "set %s set\n", junk[0].data());
+    SV_ClientCommand(sv_client, "$%s %s connect\n", junk[0].data(), junk[1].data());
     if (Q_rand() & 1) {
-        SV_ClientCommand(sv_client, "$%s %s %s\n", junk[0], junk[2], junk[3]);
-        SV_ClientCommand(sv_client, "$%s %s %s\n", junk[0], junk[4],
+        SV_ClientCommand(sv_client, "$%s %s %s\n", junk[0].data(), junk[2].data(), junk[3].data());
+        SV_ClientCommand(sv_client, "$%s %s %s\n", junk[0].data(), junk[4].data(),
                          sv_force_reconnect->string);
-        SV_ClientCommand(sv_client, "$%s %s %s\n", junk[0], junk[5], junk[6]);
+        SV_ClientCommand(sv_client, "$%s %s %s\n", junk[0].data(), junk[5].data(), junk[6].data());
     } else {
-        SV_ClientCommand(sv_client, "$%s %s %s\n", junk[0], junk[4],
+        SV_ClientCommand(sv_client, "$%s %s %s\n", junk[0].data(), junk[4].data(),
                          sv_force_reconnect->string);
-        SV_ClientCommand(sv_client, "$%s %s %s\n", junk[0], junk[5], junk[6]);
-        SV_ClientCommand(sv_client, "$%s %s %s\n", junk[0], junk[2], junk[3]);
+        SV_ClientCommand(sv_client, "$%s %s %s\n", junk[0].data(), junk[5].data(), junk[6].data());
+        SV_ClientCommand(sv_client, "$%s %s %s\n", junk[0].data(), junk[2].data(), junk[3].data());
     }
-    SV_ClientCommand(sv_client, "$%s %s \"\"\n", junk[0], junk[0]);
-    SV_ClientCommand(sv_client, "$%s $%s\n", junk[1], junk[4]);
+    SV_ClientCommand(sv_client, "$%s %s \"\"\n", junk[0].data(), junk[0].data());
+    SV_ClientCommand(sv_client, "$%s $%s\n", junk[1].data(), junk[4].data());
 }
 
 /*
@@ -401,7 +403,7 @@ SV_BeginDownload_f
 */
 static void SV_BeginDownload_f(void)
 {
-    char    name[MAX_QPATH];
+    std::array<char, MAX_QPATH> name{};
     byte    *download;
     int64_t downloadsize = 0;
     int     maxdownloadsize, result, offset = 0;
@@ -411,17 +413,17 @@ static void SV_BeginDownload_f(void)
     q2proto_download_compress_t download_compress = Q2PROTO_DOWNLOAD_COMPRESS_AUTO;
     q2proto_server_download_state_t *download_state_ptr = NULL;
 
-    if (Cmd_ArgvBuffer(1, name, sizeof(name)) >= sizeof(name)) {
+    if (Cmd_ArgvBuffer(1, name.data(), name.size()) >= name.size()) {
         goto fail1;
     }
 
     // hack for 'status' command
-    if (!strcmp(name, "http")) {
+    if (!strcmp(name.data(), "http")) {
         sv_client->http_download = true;
         return;
     }
 
-    len = FS_NormalizePath(name);
+    len = FS_NormalizePath(name.data());
 
     if (Cmd_Argc() > 2)
         offset = Q_atoi(Cmd_Argv(2));   // downloaded offset
@@ -434,37 +436,37 @@ static void SV_BeginDownload_f(void)
         // check for illegal negative offsets
         || offset < 0
         // don't allow anything with .. path
-        || strstr(name, "..")
+        || strstr(name.data(), "..")
         // leading dots, slashes, etc are no good
         || !Q_ispath(name[0])
         // trailing dots, slashes, etc are no good
         || !Q_ispath(name[len - 1])
         // MUST be in a subdirectory
-        || !strchr(name, '/')) {
-        Com_DPrintf("Refusing download of %s to %s\n", name, sv_client->name);
+        || !strchr(name.data(), '/')) {
+        Com_DPrintf("Refusing download of %s to %s\n", name.data(), sv_client->name);
         goto fail1;
     }
 
-    if (FS_pathcmpn(name, CONST_STR_LEN("players/")) == 0) {
+    if (FS_pathcmpn(name.data(), CONST_STR_LEN("players/")) == 0) {
         allow = allow_download_players;
-    } else if (FS_pathcmpn(name, CONST_STR_LEN("models/")) == 0 ||
-               FS_pathcmpn(name, CONST_STR_LEN("sprites/")) == 0) {
+    } else if (FS_pathcmpn(name.data(), CONST_STR_LEN("models/")) == 0 ||
+               FS_pathcmpn(name.data(), CONST_STR_LEN("sprites/")) == 0) {
         allow = allow_download_models;
-    } else if (FS_pathcmpn(name, CONST_STR_LEN("sound/")) == 0) {
+    } else if (FS_pathcmpn(name.data(), CONST_STR_LEN("sound/")) == 0) {
         allow = allow_download_sounds;
-    } else if (FS_pathcmpn(name, CONST_STR_LEN("maps/")) == 0) {
+    } else if (FS_pathcmpn(name.data(), CONST_STR_LEN("maps/")) == 0) {
         allow = allow_download_maps;
-    } else if (FS_pathcmpn(name, CONST_STR_LEN("textures/")) == 0 ||
-               FS_pathcmpn(name, CONST_STR_LEN("env/")) == 0) {
+    } else if (FS_pathcmpn(name.data(), CONST_STR_LEN("textures/")) == 0 ||
+               FS_pathcmpn(name.data(), CONST_STR_LEN("env/")) == 0) {
         allow = allow_download_textures;
-    } else if (FS_pathcmpn(name, CONST_STR_LEN("pics/")) == 0) {
+    } else if (FS_pathcmpn(name.data(), CONST_STR_LEN("pics/")) == 0) {
         allow = allow_download_pics;
     } else {
         allow = allow_download_others;
     }
 
     if (!allow->integer) {
-        Com_DPrintf("Refusing download of %s to %s\n", name, sv_client->name);
+        Com_DPrintf("Refusing download of %s to %s\n", name.data(), sv_client->name);
         goto fail1;
     }
 
@@ -478,7 +480,7 @@ static void SV_BeginDownload_f(void)
 #if USE_ZLIB
     // prefer raw deflate stream from .pkz if supported
     if (sv_client->q2proto_ctx.features.download_compress_raw && offset == 0) {
-        downloadsize = FS_OpenFile(name, &f, FS_MODE_READ | FS_FLAG_DEFLATE);
+        downloadsize = FS_OpenFile(name.data(), &f, FS_MODE_READ | FS_FLAG_DEFLATE);
         if (f) {
             Com_DPrintf("Serving compressed download to %s\n", sv_client->name);
             download_compress = Q2PROTO_DOWNLOAD_COMPRESS_RAW;
@@ -487,9 +489,9 @@ static void SV_BeginDownload_f(void)
 #endif
 
     if (!f) {
-        downloadsize = FS_OpenFile(name, &f, FS_MODE_READ);
+        downloadsize = FS_OpenFile(name.data(), &f, FS_MODE_READ);
         if (!f) {
-            Com_DPrintf("Couldn't download %s to %s\n", name, sv_client->name);
+            Com_DPrintf("Couldn't download %s to %s\n", name.data(), sv_client->name);
             goto fail1;
         }
     }
@@ -500,7 +502,7 @@ static void SV_BeginDownload_f(void)
 #endif
     int err = q2proto_server_download_begin(&sv_client->q2proto_ctx, downloadsize, download_compress, deflate_args, &sv_client->download_state);
     if (err != Q2P_ERR_SUCCESS) {
-        Com_DPrintf("Couldn't download %s to %s: %s\n", name, sv_client->name, q2proto_error_string(err));
+        Com_DPrintf("Couldn't download %s to %s: %s\n", name.data(), sv_client->name, q2proto_error_string(err));
         goto fail1;
     }
     download_state_ptr = &sv_client->download_state;
@@ -511,7 +513,7 @@ static void SV_BeginDownload_f(void)
     }
 
     if (downloadsize == 0) {
-        Com_DPrintf("Refusing empty download of %s to %s\n", name, sv_client->name);
+        Com_DPrintf("Refusing empty download of %s to %s\n", name.data(), sv_client->name);
         goto fail2;
     }
 
@@ -626,12 +628,12 @@ static void SV_Disconnect_f(void)
 // dumps the serverinfo info string
 static void SV_ShowServerInfo_f(void)
 {
-    char serverinfo[MAX_INFO_STRING];
+    std::array<char, MAX_INFO_STRING> serverinfo{};
 
-    Cvar_BitInfo(serverinfo, CVAR_SERVERINFO);
+    Cvar_BitInfo(serverinfo.data(), CVAR_SERVERINFO);
 
     SV_ClientRedirect();
-    Info_Print(serverinfo);
+    Info_Print(serverinfo.data());
     Com_EndRedirect();
 }
 
@@ -1208,28 +1210,28 @@ Returns matched kickable ban or NULL
 */
 cvarban_t *SV_CheckInfoBans(const char *info, bool match_only)
 {
-    char key[MAX_INFO_STRING];
-    char value[MAX_INFO_STRING];
+    std::array<char, MAX_INFO_STRING> key{};
+    std::array<char, MAX_INFO_STRING> value{};
     cvarban_t *ban;
 
     if (LIST_EMPTY(&sv_infobanlist))
         return NULL;
 
     while (1) {
-        Info_NextPair(&info, key, value);
+        Info_NextPair(&info, key.data(), value.data());
         if (!info)
             return NULL;
 
         LIST_FOR_EACH(cvarban_t, ban, &sv_infobanlist, entry) {
             if (match_only && ban->action != FA_KICK)
                 continue;
-            if (Q_stricmp(ban->var, key))
+            if (Q_stricmp(ban->var, key.data()))
                 continue;
             if (match_only) {
-                if (match_cvar_ban(ban, value))
+                if (match_cvar_ban(ban, value.data()))
                     return ban;
             } else {
-                if (handle_cvar_ban(ban, value))
+                if (handle_cvar_ban(ban, value.data()))
                     return ban;
             }
         }
@@ -1307,7 +1309,8 @@ static void SV_ParseFullUserinfo(const q2proto_clc_userinfo_t *userinfo)
 
 static void SV_ParseDeltaUserinfo(const q2proto_clc_userinfo_delta_t *userinfo_delta)
 {
-    char key[MAX_INFO_KEY], value[MAX_INFO_VALUE];
+    std::array<char, MAX_INFO_KEY> key{};
+    std::array<char, MAX_INFO_VALUE> value{};
 
     // malicious users may try sending too many userinfo updates
     if (userinfoUpdateCount >= MAX_PACKET_USERINFOS) {
@@ -1315,24 +1318,24 @@ static void SV_ParseDeltaUserinfo(const q2proto_clc_userinfo_delta_t *userinfo_d
         return;
     }
 
-    if (q2pslcpy(key, sizeof(key), &userinfo_delta->name) >= sizeof(key)) {
+    if (q2pslcpy(key.data(), key.size(), &userinfo_delta->name) >= key.size()) {
         SV_DropClient(sv_client, "oversize userinfo key");
         return;
     }
 
-    if (q2pslcpy(value, sizeof(value), &userinfo_delta->value) >= sizeof(value)) {
+    if (q2pslcpy(value.data(), value.size(), &userinfo_delta->value) >= value.size()) {
         SV_DropClient(sv_client, "oversize userinfo value");
         return;
     }
 
     if (userinfoUpdateCount < MAX_PACKET_USERINFOS) {
-        if (!Info_SetValueForKey(sv_client->userinfo, key, value)) {
+        if (!Info_SetValueForKey(sv_client->userinfo, key.data(), value.data())) {
             SV_DropClient(sv_client, "malformed userinfo");
             return;
         }
 
         Com_DDPrintf("%s(%s): %s %s [%d]\n", __func__,
-                        sv_client->name, key, value, userinfoUpdateCount);
+                        sv_client->name, key.data(), value.data(), userinfoUpdateCount);
 
         userinfoUpdateCount++;
     } else {
@@ -1406,13 +1409,13 @@ static void SV_ParseClientSetting(const q2proto_clc_setting_t *setting)
 
 static void SV_ParseClientCommand(const q2proto_clc_stringcmd_t *stringcmd)
 {
-    char buffer[MAX_STRING_CHARS];
+    std::array<char, MAX_STRING_CHARS> buffer{};
 
-    if (stringcmd->cmd.len >= sizeof(buffer)) {
+    if (stringcmd->cmd.len >= buffer.size()) {
         SV_DropClient(sv_client, "oversize stringcmd");
         return;
     }
-    q2pslcpy(buffer, sizeof(buffer), &stringcmd->cmd);
+    q2pslcpy(buffer.data(), buffer.size(), &stringcmd->cmd);
 
     // malicious users may try using too many string commands
     if (stringCmdCount >= MAX_PACKET_STRINGCMDS) {
@@ -1420,9 +1423,9 @@ static void SV_ParseClientCommand(const q2proto_clc_stringcmd_t *stringcmd)
         return;
     }
 
-    Com_DDPrintf("%s(%s): %s\n", __func__, sv_client->name, Com_MakePrintable(buffer));
+    Com_DDPrintf("%s(%s): %s\n", __func__, sv_client->name, Com_MakePrintable(buffer.data()));
 
-    SV_ExecuteUserCommand(buffer);
+    SV_ExecuteUserCommand(buffer.data());
     stringCmdCount++;
 }
 


### PR DESCRIPTION
## Summary
- include `<array>` in server sources and replace stack-allocated C arrays with `std::array`
- adjust buffer handling in anticheat, connection management, and user management helpers to use `.data()`/`.size()` accessors
- update string and buffer interactions to maintain compatibility with existing helper utilities

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ec40a5b86c8328b1a625a0ef7ea035