### PR TITLE
Refactor refresh arrays to std::array

### DIFF
--- a/src/refresh/debug.cpp
+++ b/src/refresh/debug.cpp
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "shared/list.h"
 #include "common/prompt.h"
 #include <assert.h>
+#include <array>
 
 #define DEBUG_VERTEX_SIZE   4 // 3*float coord + 1 u32 color
 #define MAX_DEBUG_VERTICES  (q_countof(tess.vertices) / DEBUG_VERTEX_SIZE)
@@ -134,11 +135,12 @@ void R_AddDebugPoint(const vec3_t point, float size, color_t color, uint32_t tim
 
 void R_AddDebugAxis(const vec3_t origin, const vec3_t angles, float size, uint32_t time, qboolean depth_test)
 {
-    vec3_t axis[3], end;
+    std::array<vec3_t, 3> axis{};
+    vec3_t end;
     color_t color;
 
     if (angles) {
-        AnglesToAxis(angles, axis);
+        AnglesToAxis(angles, axis.data());
     } else {
         VectorSet(axis[0], 1, 0, 0);
         VectorSet(axis[1], 0, 1, 0);
@@ -178,7 +180,7 @@ void R_AddDebugBounds(const vec3_t mins, const vec3_t maxs, color_t color, uint3
 // https://danielsieger.com/blog/2021/03/27/generating-spheres.html
 void R_AddDebugSphere(const vec3_t origin, float radius, color_t color, uint32_t time, qboolean depth_test)
 {
-    vec3_t verts[160];
+    std::array<vec3_t, 160> verts{};
     const int n_stacks = min(4 + radius / 32, 10);
     const int n_slices = min(6 + radius / 32, 16);
     const int v0 = 0;

--- a/src/refresh/draw.cpp
+++ b/src/refresh/draw.cpp
@@ -17,6 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "gl.h"
+#include <array>
 
 drawStatic_t draw;
 
@@ -70,7 +71,8 @@ static inline void GL_StretchPic_(
     float s1, float t1, float s2, float t2,
     color_t color, int texnum, int flags)
 {
-    vec2_t vertices[4], texcoords[4];
+    std::array<vec2_t, 4> vertices{};
+    std::array<vec2_t, 4> texcoords{};
 
     Vector2Set(vertices[0], x,     y    );
     Vector2Set(vertices[1], x + w, y    );
@@ -82,7 +84,7 @@ static inline void GL_StretchPic_(
     Vector2Set(texcoords[2], s2, t2);
     Vector2Set(texcoords[3], s1, t2);
 
-    GL_DrawPic(vertices, texcoords, color, texnum, flags);
+    GL_DrawPic(vertices.data(), texcoords.data(), color, texnum, flags);
 }
 
 #define GL_StretchPic(x,y,w,h,s1,t1,s2,t2,color,image) \
@@ -94,7 +96,8 @@ static inline void GL_StretchRotatePic_(
     float angle, float pivot_x, float pivot_y,
     color_t color, int texnum, int flags)
 {
-    vec2_t vertices[4], texcoords[4];
+    std::array<vec2_t, 4> vertices{};
+    std::array<vec2_t, 4> texcoords{};
 
     float hw = w / 2.0f;
     float hh = h / 2.0f;
@@ -120,7 +123,7 @@ static inline void GL_StretchRotatePic_(
         vertices[i][1] = (vert_x * s + vert_y * c) + y;
     }
 
-    GL_DrawPic(vertices, texcoords, color, texnum, flags);
+    GL_DrawPic(vertices.data(), texcoords.data(), color, texnum, flags);
 }
 
 #define GL_StretchRotatePic(x,y,w,h,s1,t1,s2,t2,angle,px,py,color,image) \

--- a/src/refresh/main.cpp
+++ b/src/refresh/main.cpp
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
  */
 
 #include "gl.h"
+#include <array>
 
 glRefdef_t glr;
 glStatic_t gl_static;
@@ -182,7 +183,7 @@ glCullResult_t GL_CullSphere(const vec3_t origin, float radius)
 
 glCullResult_t GL_CullLocalBox(const vec3_t origin, const vec3_t bounds[2])
 {
-    vec3_t points[8];
+    std::array<vec3_t, 8> points{};
     const cplane_t *p;
     int i, j;
     vec_t dot;

--- a/src/refresh/mesh.cpp
+++ b/src/refresh/mesh.cpp
@@ -17,6 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "gl.h"
+#include <array>
 
 typedef enum {
     SHADOW_NO,
@@ -275,7 +276,7 @@ static void tess_lerped_plain(const maliasmesh_t *mesh)
 static glCullResult_t cull_static_model(const model_t *model)
 {
     const maliasframe_t *newframe = &model->frames[newframenum];
-    vec3_t bounds[2];
+    std::array<vec3_t, 2> bounds{};
     glCullResult_t cull;
 
     if (glr.ent->flags & RF_WEAPONMODEL) {
@@ -296,7 +297,7 @@ static glCullResult_t cull_static_model(const model_t *model)
     } else {
         VectorAdd(newframe->bounds[0], origin, bounds[0]);
         VectorAdd(newframe->bounds[1], origin, bounds[1]);
-        cull = GL_CullBox(bounds);
+        cull = GL_CullBox(bounds.data());
         if (cull == CULL_OUT) {
             c.boxesCulled++;
             return cull;
@@ -310,7 +311,7 @@ static glCullResult_t cull_lerped_model(const model_t *model)
 {
     const maliasframe_t *newframe = &model->frames[newframenum];
     const maliasframe_t *oldframe = &model->frames[oldframenum];
-    vec3_t bounds[2];
+    std::array<vec3_t, 2> bounds{};
     glCullResult_t cull;
 
     if (glr.ent->flags & RF_WEAPONMODEL) {
@@ -321,19 +322,19 @@ static glCullResult_t cull_lerped_model(const model_t *model)
             c.spheresCulled++;
             return cull;
         }
-        UnionBounds(newframe->bounds, oldframe->bounds, bounds);
+        UnionBounds(newframe->bounds, oldframe->bounds, bounds.data());
         if (cull == CULL_CLIP) {
-            cull = GL_CullLocalBox(origin, bounds);
+            cull = GL_CullLocalBox(origin, bounds.data());
             if (cull == CULL_OUT) {
                 c.rotatedBoxesCulled++;
                 return cull;
             }
         }
     } else {
-        UnionBounds(newframe->bounds, oldframe->bounds, bounds);
+        UnionBounds(newframe->bounds, oldframe->bounds, bounds.data());
         VectorAdd(bounds[0], origin, bounds[0]);
         VectorAdd(bounds[1], origin, bounds[1]);
-        cull = GL_CullBox(bounds);
+        cull = GL_CullBox(bounds.data());
         if (cull == CULL_OUT) {
             c.boxesCulled++;
             return cull;

--- a/src/refresh/sky.cpp
+++ b/src/refresh/sky.cpp
@@ -17,6 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "gl.h"
+#include <array>
 
 static float    skyrotate;
 static bool     skyautorotate;
@@ -138,10 +139,10 @@ static void ClipSkyPolygon(int nump, vec3_t vecs, int stage)
     const float *v, *norm;
     bool        front, back;
     float       d, e;
-    float       dists[MAX_CLIP_VERTS];
-    int         sides[MAX_CLIP_VERTS];
-    vec3_t      newv[2][MAX_CLIP_VERTS];
-    int         newc[2];
+    std::array<float, MAX_CLIP_VERTS> dists{};
+    std::array<int, MAX_CLIP_VERTS> sides{};
+    std::array<std::array<vec3_t, MAX_CLIP_VERTS>, 2> newv{};
+    std::array<int, 2> newc{};
     int         i, j;
 
     if (nump > MAX_CLIP_VERTS - 2) {

--- a/src/refresh/surf.cpp
+++ b/src/refresh/surf.cpp
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
  */
 #include "gl.h"
 #include "common/mdfour.h"
+#include <array>
 
 lightmap_builder_t lm;
 static byte lm_buffer[0x4000000];
@@ -821,17 +822,17 @@ static void build_surface_light(mface_t *surf, vec_t *vbo)
 
 static void calc_surface_hash(mface_t *surf)
 {
-    uint32_t args[] = {
-        surf->texinfo->image - r_images,
-        surf->light_m ? surf->light_m - lm.lightmaps : 0,
+    std::array<uint32_t, 3> args = {
+        static_cast<uint32_t>(surf->texinfo->image - r_images),
+        static_cast<uint32_t>(surf->light_m ? surf->light_m - lm.lightmaps : 0),
         surf->statebits
     };
     struct mdfour md;
-    uint8_t out[16];
+    std::array<uint8_t, 16> out{};
 
     mdfour_begin(&md);
-    mdfour_update(&md, (uint8_t *)args, sizeof(args));
-    mdfour_result(&md, out);
+    mdfour_update(&md, reinterpret_cast<const uint8_t *>(args.data()), sizeof(uint32_t) * args.size());
+    mdfour_result(&md, out.data());
 
     surf->hash = 0;
     for (int i = 0; i < 16; i++)

--- a/src/refresh/tess.cpp
+++ b/src/refresh/tess.cpp
@@ -17,6 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "gl.h"
+#include <array>
 
 tesselator_t tess;
 
@@ -161,7 +162,7 @@ static void GL_FlushBeamSegments(void)
 static void GL_DrawPolyBeam(const vec3_t *segments, int num_segments, color_t color, float width)
 {
     int i, j, k, firstvert;
-    vec3_t points[BEAM_POINTS];
+    std::array<vec3_t, BEAM_POINTS> points{};
     vec3_t dir, right, up;
     vec_t *dst_vert;
     glIndex_t *dst_indices;
@@ -262,7 +263,8 @@ static void GL_DrawSimpleBeam(const vec3_t start, const vec3_t end, color_t colo
 
 static void GL_DrawLightningBeam(const vec3_t start, const vec3_t end, color_t color, float width)
 {
-    vec3_t dir, segments[MAX_LIGHTNING_SEGMENTS + 1];
+    vec3_t dir;
+    std::array<vec3_t, MAX_LIGHTNING_SEGMENTS + 1> segments{};
     vec3_t right, up;
     vec_t length, segment_length;
     int i, num_segments, max_segments;
@@ -298,7 +300,7 @@ static void GL_DrawLightningBeam(const vec3_t start, const vec3_t end, color_t c
     VectorCopy(end, segments[i]);
 
     if (gl_beamstyle->integer) {
-        GL_DrawPolyBeam(segments, num_segments, color, width);
+        GL_DrawPolyBeam(segments.data(), num_segments, color, width);
     } else {
         for (i = 0; i < num_segments; i++)
             GL_DrawSimpleBeam(segments[i], segments[i + 1], color, width);
@@ -307,7 +309,7 @@ static void GL_DrawLightningBeam(const vec3_t start, const vec3_t end, color_t c
 
 void GL_DrawBeams(void)
 {
-    vec3_t segs[2];
+    std::array<vec3_t, 2> segs{};
     color_t color;
     float width, scale;
     const entity_t *ent;
@@ -746,7 +748,7 @@ static void GL_DrawFace(const mface_t *surf)
     const int numtris = surf->numsurfedges - 2;
     const int numindices = numtris * 3;
     glStateBits_t state = surf->statebits;
-    GLuint texnum[MAX_TMUS] = { 0 };
+    std::array<GLuint, MAX_TMUS> texnum{};
     glIndex_t *dst_indices;
     int i, j;
 
@@ -768,7 +770,7 @@ static void GL_DrawFace(const mface_t *surf)
         }
     }
 
-    if (memcmp(tess.texnum, texnum, sizeof(texnum)) ||
+    if (memcmp(tess.texnum, texnum.data(), texnum.size() * sizeof(texnum[0])) ||
         tess.flags != state ||
         tess.numindices + numindices > TESS_MAX_INDICES) {
         GL_Flush3D();

--- a/src/refresh/texture.cpp
+++ b/src/refresh/texture.cpp
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "gl.h"
 #include "common/prompt.h"
+#include <array>
 
 static int gl_filter_min;
 static int gl_filter_max;
@@ -202,7 +203,8 @@ static void IMG_ResampleTexture(const byte *in, int inwidth, int inheight,
     int         i, j;
     const byte  *inrow1, *inrow2;
     unsigned    frac, fracstep;
-    unsigned    p1[MAX_TEXTURE_SIZE], p2[MAX_TEXTURE_SIZE];
+    std::array<unsigned, MAX_TEXTURE_SIZE> p1{};
+    std::array<unsigned, MAX_TEXTURE_SIZE> p2{};
     const byte  *pix1, *pix2, *pix3, *pix4;
     float       heightScale;
 
@@ -892,7 +894,7 @@ void IMG_Load(image_t *image, byte *pic)
 void IMG_Unload(image_t *image)
 {
     if (image->texnum && !(image->flags & IF_SCRAP)) {
-        GLuint tex[2] = { image->texnum, image->texnum2 };
+        std::array<GLuint, 2> tex = { image->texnum, image->texnum2 };
 
         // invalidate bindings
         for (int i = 0; i < MAX_TMUS; i++)
@@ -902,7 +904,7 @@ void IMG_Unload(image_t *image)
         if (gls.texnumcube == tex[0])
             gls.texnumcube = 0;
 
-        qglDeleteTextures(tex[1] ? 2 : 1, tex);
+        qglDeleteTextures(tex[1] ? 2 : 1, tex.data());
         image->texnum = image->texnum2 = 0;
     }
 }

--- a/src/refresh/world.cpp
+++ b/src/refresh/world.cpp
@@ -17,6 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "gl.h"
+#include <array>
 
 void GL_SampleLightPoint(vec3_t color)
 {
@@ -69,8 +70,8 @@ void GL_SampleLightPoint(vec3_t color)
 static bool GL_LightGridPoint(const lightgrid_t *grid, const vec3_t start, vec3_t color)
 {
     vec3_t point, avg;
-    uint32_t point_i[3];
-    vec3_t samples[8];
+    std::array<uint32_t, 3> point_i{};
+    std::array<vec3_t, 8> samples{};
     int i, j, mask, numsamples;
 
     if (!grid->numleafs || !gl_lightgrid->integer)
@@ -84,13 +85,13 @@ static bool GL_LightGridPoint(const lightgrid_t *grid, const vec3_t start, vec3_
     VectorClear(avg);
 
     for (i = mask = numsamples = 0; i < 8; i++) {
-        uint32_t tmp[3];
+        std::array<uint32_t, 3> tmp{};
 
         tmp[0] = point_i[0] + ((i >> 0) & 1);
         tmp[1] = point_i[1] + ((i >> 1) & 1);
         tmp[2] = point_i[2] + ((i >> 2) & 1);
 
-        const lightgrid_sample_t *s = BSP_LookupLightgrid(grid, tmp);
+        const lightgrid_sample_t *s = BSP_LookupLightgrid(grid, tmp.data());
         if (!s)
             continue;
 
@@ -123,8 +124,8 @@ static bool GL_LightGridPoint(const lightgrid_t *grid, const vec3_t start, vec3_
     // trilinear interpolation
     float fx, fy, fz;
     float bx, by, bz;
-    vec3_t lerp_x[4];
-    vec3_t lerp_y[2];
+    std::array<vec3_t, 4> lerp_x{};
+    std::array<vec3_t, 2> lerp_y{};
 
     fx = point[0] - point_i[0];
     fy = point[1] - point_i[1];
@@ -384,7 +385,7 @@ static void GL_MarkLeaves(void)
 void GL_DrawBspModel(mmodel_t *model)
 {
     mface_t *face;
-    vec3_t bounds[2];
+    std::array<vec3_t, 2> bounds{};
     vec_t dot;
     vec3_t transformed, temp;
     entity_t *ent = glr.ent;
@@ -404,7 +405,7 @@ void GL_DrawBspModel(mmodel_t *model)
         if (cull == CULL_CLIP) {
             VectorCopy(model->mins, bounds[0]);
             VectorCopy(model->maxs, bounds[1]);
-            cull = GL_CullLocalBox(ent->origin, bounds);
+            cull = GL_CullLocalBox(ent->origin, bounds.data());
             if (cull == CULL_OUT) {
                 c.rotatedBoxesCulled++;
                 return;
@@ -415,7 +416,7 @@ void GL_DrawBspModel(mmodel_t *model)
     } else {
         VectorAdd(model->mins, ent->origin, bounds[0]);
         VectorAdd(model->maxs, ent->origin, bounds[1]);
-        cull = GL_CullBox(bounds);
+        cull = GL_CullBox(bounds.data());
         if (cull == CULL_OUT) {
             c.boxesCulled++;
             return;


### PR DESCRIPTION
## Summary
- replace local C-style arrays in the refresh module with std::array to improve C++ compliance
- update associated code to use the new containers and ensure correct API calls

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ec419737748328b662a6e827343f1f