### PR TITLE
Improve hash map casting for C++ compliance

### DIFF
--- a/src/common/hash_map.cpp
+++ b/src/common/hash_map.cpp
@@ -47,7 +47,8 @@ HashMap_GetKeyImpl
 */
 void *HashMap_GetKeyImpl(const hash_map_t *map, uint32_t index)
 {
-    return (byte *)map->keys + (map->key_size * index);
+    const auto *keys = static_cast<const byte *>(map->keys);
+    return const_cast<byte *>(keys + (map->key_size * index));
 }
 
 /*
@@ -57,7 +58,8 @@ HashMap_GetValueImpl
 */
 void *HashMap_GetValueImpl(const hash_map_t *map, uint32_t index)
 {
-    return (byte *)map->values + (map->value_size * index);
+    const auto *values = static_cast<const byte *>(map->values);
+    return const_cast<byte *>(values + (map->value_size * index));
 }
 
 /*


### PR DESCRIPTION
## Summary
- replace hash map pointer arithmetic helpers with const-aware conversions
- rework hash helper functions to avoid C-style casts and rely on memcpy for safe bit access

## Testing
- not run (meson unavailable in environment)

------
https://chatgpt.com/codex/tasks/task_e_68ec45cb92c08328abe070428c629a03