### PR TITLE
Fix zip seek chunk size type

### DIFF
--- a/src/common/files.cpp
+++ b/src/common/files.cpp
@@ -1158,8 +1158,9 @@ static int seek_zip_file(file_t *file, int64_t offset, int whence)
     while (file->position < offset) {
         byte buf[ZIP_BUFSIZE];
 
-        int len = min(offset - file->position, sizeof(buf));
-        int ret = read_zip_file(file, buf, len);
+        const int64_t remaining = offset - file->position;
+        const size_t chunk = static_cast<size_t>(min(remaining, static_cast<int64_t>(sizeof(buf))));
+        int ret = read_zip_file(file, buf, chunk);
         if (ret < 0)
             return ret;
         if (ret == 0)


### PR DESCRIPTION
## Summary
- ensure zip seek logic uses a size_t chunk length when rewinding compressed streams to avoid narrowing conversions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68eccf3f00e48328b1c9458e50837c1e