### PR TITLE
Fix MSVC build issues

### DIFF
--- a/embed.py
+++ b/embed.py
@@ -25,7 +25,21 @@ in_contents = in_contents.replace('\n', '\\n')
 in_contents = in_contents.replace('\r', '\\r')
 in_contents = in_contents.replace('"', '\\"')
 
-in_contents = '#include <stddef.h>\nconst char ' + sys.argv[3] + '[] = ' + '\"' + in_contents + '\";\nconst size_t ' + sys.argv[3] + '_size = ' + str(size) + ';'
+var_name = sys.argv[3]
+
+converted = [
+    '#include <stddef.h>',
+    f'const char {var_name}[] ='
+]
+
+chunk_size = 16384
+for i in range(0, len(in_contents), chunk_size):
+    chunk = in_contents[i:i + chunk_size]
+    converted.append(f'"{chunk}"')
+
+converted.append(';')
+converted.append(f'const size_t {var_name}_size = {size};')
+in_contents = '\n'.join(converted)
 
 # write
 out_file = open(output_path, "w")

--- a/inc/common/utils.h
+++ b/inc/common/utils.h
@@ -124,5 +124,6 @@ typedef struct {
 static inline frametime_t Com_ComputeFrametime(int rate)
 {
     int framediv = Q_clip(rate / BASE_FRAMERATE, 1, MAX_FRAMEDIV);
-    return (frametime_t){ .time = BASE_FRAMETIME / framediv, .div = framediv };
+    frametime_t result{ BASE_FRAMETIME / framediv, framediv };
+    return result;
 }

--- a/inc/common/zone.h
+++ b/inc/common/zone.h
@@ -21,7 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define Z_CopyString(string)    Z_TagCopyString(string, TAG_GENERAL)
 #define Z_CopyStruct(ptr)       memcpy(Z_Malloc(sizeof(*ptr)), ptr, sizeof(*ptr))
 
-#ifdef __cplusplus
+#if defined(__cplusplus) && !defined(_MSC_VER)
 struct z_allocation {
     void *value;
 

--- a/inc/shared/platform.h
+++ b/inc/shared/platform.h
@@ -83,6 +83,18 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define R_OK    4
 #endif
 
+#if defined(__cplusplus)
+#   if defined(_MSC_VER)
+#       ifndef restrict
+#           define restrict __restrict
+#       endif
+#   elif defined(__GNUC__)
+#       ifndef restrict
+#           define restrict __restrict__
+#       endif
+#   endif
+#endif
+
 #ifdef __has_builtin
 #define q_has_builtin(x)    __has_builtin(x)
 #else

--- a/inc/shared/shared.h
+++ b/inc/shared/shared.h
@@ -694,8 +694,17 @@ size_t Q_strnlcpy(char *dst, const char *src, size_t count, size_t size);
 size_t Q_strlcat(char *dst, const char *src, size_t size);
 size_t Q_strnlcat(char *dst, const char *src, size_t count, size_t size);
 
+#if defined(__cplusplus)
+template <typename... Args>
+static inline size_t Q_concat(char *dest, size_t size, Args... args)
+{
+    const char *parts[] = { args..., nullptr };
+    return Q_concat_array(dest, size, parts);
+}
+#else
 #define Q_concat(dest, size, ...) \
     Q_concat_array(dest, size, (const char *[]){__VA_ARGS__, NULL})
+#endif
 size_t Q_concat_array(char *dest, size_t size, const char **arr);
 
 size_t Q_vsnprintf(char *dest, size_t size, const char *fmt, va_list argptr);

--- a/src/common/bsp.cpp
+++ b/src/common/bsp.cpp
@@ -437,7 +437,7 @@ static void BSP_ParseDecoupledLM(bsp_t *bsp, const byte *in, size_t filelen)
         out->lm_height = BSP_Short();
 
         uint32_t offset = BSP_Long();
-        if (offset == std::numeric_limits<uint32_t>::max())
+        if (offset == (std::numeric_limits<uint32_t>::max)())
             out->lightmap = nullptr;
         else if (offset < bsp->numlightmapbytes)
             out->lightmap = bsp->lightmap + offset;
@@ -827,6 +827,9 @@ int BSP_Load(const char *name, bsp_t **bsp_p)
     uint32_t        lump_count[q_countof(bsp_lumps)];
     size_t          memsize;
     bool            extended = false;
+#if USE_REF
+    lump_t          ext[q_countof(bspx_lumps)] = {};
+#endif
 
     Q_assert(name);
     Q_assert(bsp_p);
@@ -918,7 +921,6 @@ int BSP_Load(const char *name, bsp_t **bsp_p)
     bsp->extended = extended;
 
 #if USE_REF
-    lump_t ext[q_countof(bspx_lumps)] = { 0 };
     memsize += BSP_ParseExtensionHeader(bsp, ext, buf, maxpos, filelen);
 #endif
 

--- a/src/common/cmd.cpp
+++ b/src/common/cmd.cpp
@@ -29,6 +29,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "client/client.h"
 
 #include <array>
+#include <algorithm>
 
 #define Cmd_Malloc(size)        Z_TagMalloc(size, TAG_CMD)
 #define Cmd_CopyString(string)  Z_TagCopyString(string, TAG_CMD)
@@ -834,7 +835,7 @@ static list_t   cmd_hash[CMD_HASH_SIZE];
 
 static int      cmd_argc;
 static char     *cmd_argv[MAX_STRING_TOKENS]; // pointers to cmd_data[]
-static char     *cmd_null_string = "";
+static char     cmd_null_string[1] = "";
 
 // complete command string, left untouched
 static char     cmd_string[MAX_STRING_CHARS];
@@ -1510,7 +1511,7 @@ Cmd_AddCommand
 */
 void Cmd_AddCommand(const char *name, xcommand_t function)
 {
-    cmdreg_t reg = { .name = name, .function = function };
+    cmdreg_t reg{ name, function, nullptr };
     Cmd_RegCommand(&reg);
 }
 

--- a/src/common/cmodel.cpp
+++ b/src/common/cmodel.cpp
@@ -32,7 +32,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 mtexinfo_t nulltexinfo;
 
-const mleaf_t       nullleaf = { .cluster = -1 };
+const mleaf_t nullleaf = [] {
+    mleaf_t leaf{};
+    leaf.cluster = -1;
+    return leaf;
+}();
 
 static unsigned     floodvalid;
 static unsigned     checkcount;
@@ -144,7 +148,7 @@ void CM_LoadOverride(cm_t *cm, char *server, size_t server_size)
         goto fail;
 
     if (bits & OVERRIDE_NAME) {
-        if (!(buf = SZ_ReadData(&sz, MAX_QPATH)))
+        if (!(buf = static_cast<char *>(SZ_ReadData(&sz, MAX_QPATH))))
             goto fail;
         if (!memchr(buf, 0, MAX_QPATH))
             goto fail;
@@ -159,7 +163,7 @@ void CM_LoadOverride(cm_t *cm, char *server, size_t server_size)
         len = SZ_ReadLong(&sz);
         if (len <= 0)
             goto fail;
-        if (!(buf = SZ_ReadData(&sz, len)))
+        if (!(buf = static_cast<char *>(SZ_ReadData(&sz, len))))
             goto fail;
         cm->entitystring = Z_TagMalloc(len + 1, TAG_CMODEL);
         memcpy(cm->entitystring, buf, len);

--- a/src/common/common.cpp
+++ b/src/common/common.cpp
@@ -697,7 +697,7 @@ static size_t Com_MapList_m(char *buffer, size_t size)
 
     list = FS_ListFiles("maps", ".bsp", FS_SEARCH_STRIPEXT, &numFiles);
     for (i = 0; i < numFiles && total < SIZE_MAX; i++) {
-        len = strlen(list[i]);
+        len = strlen(static_cast<const char *>(list[i]));
         if (i)
             total++;
         total += len = min(len, SIZE_MAX - total);


### PR DESCRIPTION
## Summary
- split embedded resource generation into manageable C++ string chunks to avoid MSVC literal limits
- replace C99-style designated initializers and adjust casts for C++17 compliance in common code
- update shared headers to cooperate with MSVC by guarding z_pointer, defining restrict, and providing a C++ Q_concat helper

## Testing
- python3 embed.py src/client/ui/worr.menu.json /tmp/worr.menu.cpp embedded_data

------
https://chatgpt.com/codex/tasks/task_e_68ecd2307b3c83289c23a9849eb55688