### PR TITLE
Fix MSVC compilation issues in filesystem code

### DIFF
--- a/inc/common/zone.h
+++ b/inc/common/zone.h
@@ -21,7 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define Z_CopyString(string)    Z_TagCopyString(string, TAG_GENERAL)
 #define Z_CopyStruct(ptr)       memcpy(Z_Malloc(sizeof(*ptr)), ptr, sizeof(*ptr))
 
-#if defined(__cplusplus) && !defined(_MSC_VER)
+#ifdef __cplusplus
 struct z_allocation {
     void *value;
 

--- a/src/client/sound/ogg.cpp
+++ b/src/client/sound/ogg.cpp
@@ -584,7 +584,9 @@ static void add_music_dir(const char *path, unsigned flags)
     if (len >= sizeof(fullpath))
         return;
 
-    listfiles_t list = { .filter = extensions, .flags = flags };
+    listfiles_t list{};
+    list.filter = extensions;
+    list.flags = flags;
     Sys_ListFiles_r(&list, fullpath, 0);
     FS_FinalizeList(&list);
 
@@ -594,7 +596,7 @@ static void add_music_dir(const char *path, unsigned flags)
     }
 
     for (int i = 0; i < list.count; i++) {
-        char *val = list.files[i];
+        char *val = static_cast<char *>(list.files[i]);
         char base[MAX_OSPATH];
 
         COM_StripExtension(base, val + len + 1, sizeof(base));

--- a/src/common/steam.cpp
+++ b/src/common/steam.cpp
@@ -169,17 +169,16 @@ bool Steam_FindQuake2Path(rerelease_mode_t rr_mode, char *out_dir, size_t out_di
     Q_strlcat(out_dir, "/steamapps/common/Quake 2", out_dir_length);
 
     // found Steam dir - see if the mode we want is available
-    listfiles_t list = {
-        .flags = FS_SEARCH_DIRSONLY,
-        .baselen = strlen(out_dir) + 1,
-    };
+    listfiles_t list{};
+    list.flags = FS_SEARCH_DIRSONLY;
+    list.baselen = strlen(out_dir) + 1;
 
     Sys_ListFiles_r(&list, out_dir, 0);
 
     bool has_rerelease = false;
 
     for (int i = 0; i < list.count; i++) {
-        char *s = list.files[i];
+        char *s = static_cast<char *>(list.files[i]);
 
         if (!Q_stricmp(s, "rerelease")) {
             has_rerelease = true;


### PR DESCRIPTION
## Summary
- allow C++ builds on MSVC to use the z_allocation helper so zone pointers convert cleanly
- add explicit casts for gz/zip handles and filesystem list entries, replace designated initializers, and fix string/enumeration usage for MSVC compatibility
- adjust Steam and OGG helpers to use portable list initialization and pointer casts

## Testing
- meson setup build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ecd5bc57288328abebecac565be390