### PR TITLE
Refine atomic helpers for C++ builds

### DIFF
--- a/inc/shared/atomic.h
+++ b/inc/shared/atomic.h
@@ -18,10 +18,31 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
-#ifdef _MSC_VER
-typedef volatile int atomic_int;
-#define atomic_load(p)      (*(p))
-#define atomic_store(p, v)  (*(p) = (v))
+#ifdef __cplusplus
+#include <atomic>
+
+struct atomic_int {
+    constexpr atomic_int() noexcept = default;
+    constexpr explicit atomic_int(int desired) noexcept
+        : value(desired) {}
+
+    atomic_int(const atomic_int &) = delete;
+    atomic_int &operator=(const atomic_int &) = delete;
+
+    std::atomic<int> value{0};
+};
+
+inline int atomic_load(const atomic_int *p) noexcept
+{
+    return p->value.load(std::memory_order_acquire);
+}
+
+template <typename T>
+inline void atomic_store(atomic_int *p, T desired) noexcept
+{
+    p->value.store(static_cast<int>(desired), std::memory_order_release);
+}
+
 #else
 #include <stdatomic.h>
 #endif


### PR DESCRIPTION
## Summary
- replace the shared atomic helper with a C++ `<atomic>` wrapper so MSVC builds no longer require `stdatomic.h`
- reset HTTP download handles via a helper instead of `memset` so the new atomic wrapper stays well-defined

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ecd9ac454883289c4c9c3cd7a76cf5