### PR TITLE
Fix md4 buffer casting

### DIFF
--- a/src/client/ui/demos.cpp
+++ b/src/client/ui/demos.cpp
@@ -243,7 +243,7 @@ static void CalcHash(void **list)
     while (*list) {
         info = *list++;
         len = sizeof(*info) + strlen(info->name) - 1;
-        mdfour_update(&md, (uint8_t *)info, len);
+        mdfour_update(&md, reinterpret_cast<const uint8_t *>(info), len);
     }
     mdfour_result(&md, m_demos.hash);
 }

--- a/src/common/mdfour.cpp
+++ b/src/common/mdfour.cpp
@@ -160,7 +160,7 @@ uint32_t Com_BlockChecksum(const void *buffer, size_t len)
     struct mdfour md;
 
     mdfour_begin(&md);
-    mdfour_update(&md, buffer, len);
+    mdfour_update(&md, static_cast<const uint8_t *>(buffer), len);
     mdfour_tail(&md);
 
     return md.A ^ md.B ^ md.C ^ md.D;

--- a/src/common/tests.cpp
+++ b/src/common/tests.cpp
@@ -683,7 +683,7 @@ static bool mdfour_test(int num, int chunk)
 {
     struct mdfour md;
     std::array<uint8_t, 16> digest;
-    uint8_t *data = (uint8_t *)mdfour_str[num];
+    const uint8_t *data = reinterpret_cast<const uint8_t *>(mdfour_str[num]);
     size_t size = strlen(mdfour_str[num]);
     const char *res = mdfour_res[num];
     int i;
@@ -733,7 +733,7 @@ static void Com_MdfourTest_f(void)
     }
 
     for (int i = 0; i < q_countof(mdfour_str); i++) {
-        uint32_t res = Com_BlockChecksum((uint8_t *)mdfour_str[i], strlen(mdfour_str[i]));
+        uint32_t res = Com_BlockChecksum(mdfour_str[i], strlen(mdfour_str[i]));
         if (res != blocksum_res[i]) {
             Com_EPrintf("String '%s', expected %#x, calculated %#x\n", mdfour_str[i], blocksum_res[i], res);
             errors++;


### PR DESCRIPTION
## Summary
- cast the checksum buffer to a byte pointer before hashing
- fix mdfour callers to use const-correct casts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ece5fa2f548328a0d3d5a1976816a6