### PR TITLE
Adjust variable declarations to avoid goto initialization issues

### DIFF
--- a/src/common/loc.cpp
+++ b/src/common/loc.cpp
@@ -367,6 +367,8 @@ void Loc_ReloadFile(void)
         loc.num_arguments = 0;
         loc.next = loc.hash_next = NULL;
 
+        uint32_t hash = 0;
+
         if (!Loc_Parse(&loc)) {
             goto line_error;
         }
@@ -376,7 +378,7 @@ void Loc_ReloadFile(void)
         memcpy(*tail, &loc, sizeof(loc));
 
         // hash
-        uint32_t hash = Com_HashString(loc.key, LOC_HASH_SIZE) & (LOC_HASH_SIZE - 1);
+        hash = Com_HashString(loc.key, LOC_HASH_SIZE) & (LOC_HASH_SIZE - 1);
         if (!loc_hash[hash]) {
             loc_hash[hash] = *tail;
         } else {

--- a/src/common/steam.cpp
+++ b/src/common/steam.cpp
@@ -140,6 +140,8 @@ static bool find_steam_app_path(const char *app_id, char *out_dir, size_t out_di
     char *file_contents = Z_Malloc(len + 1);
     file_contents[len] = '\0';
 
+    char *parse_contents = file_contents;
+
     size_t file_read = fread((void *) file_contents, 1, len, libraryfolders);
 
     fclose(libraryfolders);
@@ -149,8 +151,6 @@ static bool find_steam_app_path(const char *app_id, char *out_dir, size_t out_di
         result = false;
         goto exit;
     }
-
-    char *parse_contents = file_contents;
 
     result = parse_vdf_libraryfolders((const char **) &parse_contents, app_id, out_dir, out_dir_length);
 


### PR DESCRIPTION
## Summary
- declare the localization hash variable before any goto targets to avoid crossing its initialization
- move the VDF parse buffer declaration ahead of error handling in the Steam helper to prevent skipping initialization

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ece5efc9648328806720df9053367a