### PR TITLE
Move Q_concat_array prototype above C++ template

### DIFF
--- a/inc/shared/shared.h
+++ b/inc/shared/shared.h
@@ -694,6 +694,8 @@ size_t Q_strnlcpy(char *dst, const char *src, size_t count, size_t size);
 size_t Q_strlcat(char *dst, const char *src, size_t size);
 size_t Q_strnlcat(char *dst, const char *src, size_t count, size_t size);
 
+size_t Q_concat_array(char *dest, size_t size, const char **arr);
+
 #if defined(__cplusplus)
 template <typename... Args>
 static inline size_t Q_concat(char *dest, size_t size, Args... args)
@@ -705,7 +707,6 @@ static inline size_t Q_concat(char *dest, size_t size, Args... args)
 #define Q_concat(dest, size, ...) \
     Q_concat_array(dest, size, (const char *[]){__VA_ARGS__, NULL})
 #endif
-size_t Q_concat_array(char *dest, size_t size, const char **arr);
 
 size_t Q_vsnprintf(char *dest, size_t size, const char *fmt, va_list argptr);
 size_t Q_vscnprintf(char *dest, size_t size, const char *fmt, va_list argptr);


### PR DESCRIPTION
## Summary
- move the Q_concat_array declaration ahead of the C++ Q_concat template
- ensure the shared header exposes a single prototype usable from both C and C++

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ece5ed35c88328bf3afad335fadd85