### PR TITLE
Refine enum handling across protocol parsing

### DIFF
--- a/src/common/math.cpp
+++ b/src/common/math.cpp
@@ -461,16 +461,16 @@ box_plane_t BoxOnPlaneSide(const vec3_t emins, const vec3_t emaxs, const cplane_
 
     vec_t       dist1 = P(i ^ 1, j ^ 1, k ^ 1);
     vec_t       dist2 = P(i, j, k);
-    box_plane_t sides = 0;
+    int         mask = 0;
 
 #undef P
 
     if (dist1 >= p->dist)
-        sides = BOX_INFRONT;
+        mask |= static_cast<int>(BOX_INFRONT);
     if (dist2 < p->dist)
-        sides |= BOX_BEHIND;
+        mask |= static_cast<int>(BOX_BEHIND);
 
-    return sides;
+    return static_cast<box_plane_t>(mask);
 }
 
 #if USE_REF

--- a/src/common/msg.cpp
+++ b/src/common/msg.cpp
@@ -2349,44 +2349,47 @@ static void MSG_ReadColor(vec3_t color)
 
 static void MSG_ReadFog(player_fogchange_t *fog_change)
 {
-    q2pro_fog_bits_t bits = MSG_ReadByte();
+    const int protocolBits = MSG_ReadByte();
+    unsigned fogBits = 0;
 
-    if (bits & Q2PRO_FOG_BIT_COLOR) {
+    if (protocolBits & Q2PRO_FOG_BIT_COLOR) {
         MSG_ReadColor(fog_change->linear.color);
-        fog_change->bits |= FOG_BIT_R | FOG_BIT_G | FOG_BIT_B;
+        fogBits |= FOG_BIT_R | FOG_BIT_G | FOG_BIT_B;
     }
-    if (bits & Q2PRO_FOG_BIT_DENSITY) {
+    if (protocolBits & Q2PRO_FOG_BIT_DENSITY) {
         fog_change->linear.density    = MSG_ReadWord() / 65535.0f;
         fog_change->linear.sky_factor = MSG_ReadWord() / 65535.0f;
-        fog_change->bits |= FOG_BIT_DENSITY;
+        fogBits |= FOG_BIT_DENSITY;
     }
 
-    if (bits & Q2PRO_FOG_BIT_HEIGHT_DENSITY) {
+    if (protocolBits & Q2PRO_FOG_BIT_HEIGHT_DENSITY) {
         fog_change->height.density = MSG_ReadWord() / 65535.0f;
-        fog_change->bits |= FOG_BIT_HEIGHTFOG_DENSITY;
+        fogBits |= FOG_BIT_HEIGHTFOG_DENSITY;
     }
-    if (bits & Q2PRO_FOG_BIT_HEIGHT_FALLOFF) {
+    if (protocolBits & Q2PRO_FOG_BIT_HEIGHT_FALLOFF) {
         fog_change->height.falloff = MSG_ReadWord() / 65535.0f;
-        fog_change->bits |= FOG_BIT_HEIGHTFOG_FALLOFF;
+        fogBits |= FOG_BIT_HEIGHTFOG_FALLOFF;
     }
 
-    if (bits & Q2PRO_FOG_BIT_HEIGHT_START_COLOR) {
+    if (protocolBits & Q2PRO_FOG_BIT_HEIGHT_START_COLOR) {
         MSG_ReadColor(fog_change->height.start.color);
-        fog_change->bits |= FOG_BIT_HEIGHTFOG_START_R | FOG_BIT_HEIGHTFOG_START_G | FOG_BIT_HEIGHTFOG_START_B;
+        fogBits |= FOG_BIT_HEIGHTFOG_START_R | FOG_BIT_HEIGHTFOG_START_G | FOG_BIT_HEIGHTFOG_START_B;
     }
-    if (bits & Q2PRO_FOG_BIT_HEIGHT_END_COLOR) {
+    if (protocolBits & Q2PRO_FOG_BIT_HEIGHT_END_COLOR) {
         MSG_ReadColor(fog_change->height.end.color);
-        fog_change->bits |= FOG_BIT_HEIGHTFOG_END_R | FOG_BIT_HEIGHTFOG_END_G | FOG_BIT_HEIGHTFOG_END_B;
+        fogBits |= FOG_BIT_HEIGHTFOG_END_R | FOG_BIT_HEIGHTFOG_END_G | FOG_BIT_HEIGHTFOG_END_B;
     }
 
-    if (bits & Q2PRO_FOG_BIT_HEIGHT_START_DIST) {
+    if (protocolBits & Q2PRO_FOG_BIT_HEIGHT_START_DIST) {
         fog_change->height.start.dist = MSG_ReadExtCoord();
-        fog_change->bits |= FOG_BIT_HEIGHTFOG_START_DIST;
+        fogBits |= FOG_BIT_HEIGHTFOG_START_DIST;
     }
-    if (bits & Q2PRO_FOG_BIT_HEIGHT_END_DIST) {
+    if (protocolBits & Q2PRO_FOG_BIT_HEIGHT_END_DIST) {
         fog_change->height.end.dist = MSG_ReadExtCoord();
-        fog_change->bits |= FOG_BIT_HEIGHTFOG_END_DIST;
+        fogBits |= FOG_BIT_HEIGHTFOG_END_DIST;
     }
+
+    fog_change->bits = static_cast<fog_bits_t>(fogBits);
 }
 
 #if USE_CLIENT
@@ -2415,10 +2418,11 @@ void MSG_ParseDeltaPlayerstate_Default(const player_state_t *from,
     // parse the pmove_state_t
     //
     if (flags & PS_M_TYPE) {
+        const int pmTypeByte = MSG_ReadByte();
         if (flags & MSG_PS_RERELEASE)
-            to->pmove.pm_type = MSG_ReadByte();
+            to->pmove.pm_type = static_cast<pmtype_t>(pmTypeByte);
         else
-            to->pmove.pm_type = pmtype_from_game3(MSG_ReadByte());
+            to->pmove.pm_type = pmtype_from_game3(static_cast<game3_pmtype_t>(pmTypeByte));
     }
 
     if (flags & PS_M_ORIGIN) {
@@ -2557,10 +2561,11 @@ void MSG_ParseDeltaPlayerstate_Enhanced(const player_state_t    *from,
     // parse the pmove_state_t
     //
     if (flags & PS_M_TYPE) {
+        const int pmTypeByte = MSG_ReadByte();
         if (psflags & MSG_PS_RERELEASE)
-            to->pmove.pm_type = MSG_ReadByte();
+            to->pmove.pm_type = static_cast<pmtype_t>(pmTypeByte);
         else
-            to->pmove.pm_type = pmtype_from_game3(MSG_ReadByte());
+            to->pmove.pm_type = pmtype_from_game3(static_cast<game3_pmtype_t>(pmTypeByte));
     }
 
     if (flags & PS_M_ORIGIN) {
@@ -2726,10 +2731,11 @@ void MSG_ParseDeltaPlayerstate_Packet(player_state_t        *to,
     // parse the pmove_state_t
     //
     if (flags & PPS_M_TYPE) {
+        const int pmTypeByte = MSG_ReadByte();
         if (psflags & MSG_PS_RERELEASE)
-            to->pmove.pm_type = MSG_ReadByte();
+            to->pmove.pm_type = static_cast<pmtype_t>(pmTypeByte);
         else
-            to->pmove.pm_type = pmtype_from_game3(MSG_ReadByte());
+            to->pmove.pm_type = pmtype_from_game3(static_cast<game3_pmtype_t>(pmTypeByte));
     }
 
     if (flags & PPS_M_ORIGIN) {

--- a/src/common/net/net.cpp
+++ b/src/common/net/net.cpp
@@ -1222,15 +1222,14 @@ NET_Config
 */
 void NET_Config(netflag_t flag)
 {
-    netsrc_t sock;
-
     if (flag == net_active) {
         return;
     }
 
     if (flag == NET_NONE) {
         // shut down any existing sockets
-        for (sock = 0; sock < NS_COUNT; sock++) {
+        for (int index = 0; index < NS_COUNT; ++index) {
+            const netsrc_t sock = static_cast<netsrc_t>(index);
             if (udp_sockets[sock]) {
                 NET_CloseSocket(udp_sockets[sock]);
                 udp_sockets[sock] = NULL;
@@ -1256,7 +1255,8 @@ void NET_Config(netflag_t flag)
         NET_OpenServer6();
     }
 
-    net_active |= flag;
+    const unsigned combined = static_cast<unsigned>(net_active) | static_cast<unsigned>(flag);
+    net_active = static_cast<netflag_t>(combined);
 }
 
 /*

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -209,19 +209,17 @@ Returns COLOR_INDEX_NONE in case of error.
 */
 color_index_t Com_ParseColor(const char *s)
 {
-    color_index_t i;
-
     if (COM_IsUint(s)) {
-        i = Q_atoi(s);
-        if (i < 0 || i >= COLOR_INDEX_COUNT) {
+        const int value = Q_atoi(s);
+        if (value < 0 || value >= COLOR_INDEX_COUNT) {
             return COLOR_INDEX_NONE;
         }
-        return i;
+        return static_cast<color_index_t>(value);
     }
 
-    for (i = 0; i < COLOR_INDEX_COUNT; i++) {
-        if (!strcmp(colorNames[i], s)) {
-            return i;
+    for (int index = 0; index < COLOR_INDEX_COUNT; ++index) {
+        if (!strcmp(colorNames[index], s)) {
+            return static_cast<color_index_t>(index);
         }
     }
 


### PR DESCRIPTION
## Summary
- use integer temporaries for color parsing, fog flag accumulation, and pmove type decoding before casting back to enums
- iterate network sockets via integer indices and update the active flag mask through explicit integral operations
- compute BoxOnPlaneSide masks with integers before casting to the enum

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ece5eb97988328a66947643d2cd97b