### PR TITLE
Fix pointer casts for buffer utilities

### DIFF
--- a/src/common/fifo.cpp
+++ b/src/common/fifo.cpp
@@ -91,7 +91,7 @@ bool FIFO_ReadMessage(fifo_t *fifo, size_t msglen)
     size_t len;
     byte *data;
 
-    data = FIFO_Peek(fifo, &len);
+    data = static_cast<byte *>(FIFO_Peek(fifo, &len));
     if (len < msglen) {
         // read in two chunks into message buffer
         if (!FIFO_TryRead(fifo, msg_read_buffer, msglen)) {

--- a/src/common/files.cpp
+++ b/src/common/files.cpp
@@ -1085,7 +1085,7 @@ static int read_zip_file(file_t *file, void *buf, size_t len)
         return 0;
     }
 
-    z->next_out = buf;
+    z->next_out = static_cast<Bytef *>(buf);
     z->avail_out = (uInt)len;
 
     do {

--- a/src/common/msg.cpp
+++ b/src/common/msg.cpp
@@ -96,7 +96,7 @@ void MSG_WriteChar(int c)
     Q_assert(c >= -128 && c <= 127);
 #endif
 
-    buf = SZ_GetSpace(&msg_write, 1);
+    buf = static_cast<byte *>(SZ_GetSpace(&msg_write, 1));
     buf[0] = c;
 }
 
@@ -113,7 +113,7 @@ void MSG_WriteByte(int c)
     Q_assert(c >= 0 && c <= 255);
 #endif
 
-    buf = SZ_GetSpace(&msg_write, 1);
+    buf = static_cast<byte *>(SZ_GetSpace(&msg_write, 1));
     buf[0] = c;
 }
 
@@ -130,7 +130,7 @@ void MSG_WriteShort(int c)
     Q_assert(c >= -0x8000 && c <= 0x7fff);
 #endif
 
-    buf = SZ_GetSpace(&msg_write, 2);
+    buf = static_cast<byte *>(SZ_GetSpace(&msg_write, 2));
     WL16(buf, c);
 }
 
@@ -143,7 +143,7 @@ void MSG_WriteLong(int c)
 {
     byte    *buf;
 
-    buf = SZ_GetSpace(&msg_write, 4);
+    buf = static_cast<byte *>(SZ_GetSpace(&msg_write, 4));
     WL32(buf, c);
 }
 
@@ -156,7 +156,7 @@ void MSG_WriteLong64(int64_t c)
 {
     byte    *buf;
 
-    buf = SZ_GetSpace(&msg_write, 8);
+    buf = static_cast<byte *>(SZ_GetSpace(&msg_write, 8));
     WL64(buf, c);
 }
 
@@ -1701,7 +1701,7 @@ void MSG_BeginReading(void)
 
 byte *MSG_ReadData(size_t len)
 {
-    return SZ_ReadData(&msg_read, len);
+    return static_cast<byte *>(SZ_ReadData(&msg_read, len));
 }
 
 // returns -1 if no more characters are available

--- a/src/common/net/win.h
+++ b/src/common/net/win.h
@@ -115,7 +115,7 @@ static int os_udp_recv(qsocket_t sock, void *data,
     for (tries = 0; tries < MAX_ERROR_RETRIES; tries++) {
         memset(&addr, 0, sizeof(addr));
         addrlen = sizeof(addr);
-        ret = recvfrom(sock, data, len, 0,
+        ret = recvfrom(sock, static_cast<char *>(data), len, 0,
                        (struct sockaddr *)&addr, &addrlen);
 
         NET_SockadrToNetadr(&addr, from);
@@ -153,7 +153,7 @@ static int os_udp_send(qsocket_t sock, const void *data,
 
     addrlen = NET_NetadrToSockadr(to, &addr);
 
-    ret = sendto(sock, data, len, 0,
+    ret = sendto(sock, static_cast<const char *>(data), len, 0,
                  (struct sockaddr *)&addr, addrlen);
 
     if (ret != SOCKET_ERROR)
@@ -185,7 +185,7 @@ static neterr_t os_get_error(void)
 
 static int os_recv(qsocket_t sock, void *data, size_t len, int flags)
 {
-    int ret = recv(sock, data, len, flags);
+    int ret = recv(sock, static_cast<char *>(data), len, flags);
 
     if (ret == SOCKET_ERROR)
         return os_get_error();
@@ -195,7 +195,7 @@ static int os_recv(qsocket_t sock, void *data, size_t len, int flags)
 
 static int os_send(qsocket_t sock, const void *data, size_t len, int flags)
 {
-    int ret = send(sock, data, len, flags);
+    int ret = send(sock, static_cast<const char *>(data), len, flags);
 
     if (ret == SOCKET_ERROR)
         return os_get_error();

--- a/src/common/sizebuf.cpp
+++ b/src/common/sizebuf.cpp
@@ -47,7 +47,7 @@ void SZ_InitGrowable(sizebuf_t *buf, size_t size, const char *tag)
 {
     Q_assert(size <= INT32_MAX);
     memset(buf, 0, sizeof(*buf));
-    buf->data = Z_Malloc(size);
+    buf->data = static_cast<byte *>(Z_Malloc(size));
     buf->maxsize = size;
     buf->tag = tag;
     buf->growable = true;
@@ -71,8 +71,6 @@ void SZ_Clear(sizebuf_t *buf)
 
 void *SZ_GetSpace(sizebuf_t *buf, size_t len)
 {
-    void    *data;
-
     if (buf->cursize > buf->maxsize) {
         Com_Error(ERR_FATAL,
                   "%s: %s: already overflowed",
@@ -88,7 +86,7 @@ void *SZ_GetSpace(sizebuf_t *buf, size_t len)
 
         if (buf->growable) {
             buf->maxsize = max(buf->cursize + len, buf->maxsize * 2);
-            buf->data = Z_Realloc(buf->data, buf->maxsize);
+            buf->data = static_cast<byte *>(Z_Realloc(buf->data, buf->maxsize));
         } else {
             if (!buf->allowoverflow) {
                 Com_Error(ERR_FATAL,
@@ -102,7 +100,7 @@ void *SZ_GetSpace(sizebuf_t *buf, size_t len)
         }
     }
 
-    data = buf->data + buf->cursize;
+    auto    *data = static_cast<byte *>(buf->data) + buf->cursize;
     buf->cursize += len;
     return data;
 }
@@ -111,7 +109,7 @@ void SZ_WriteByte(sizebuf_t *sb, int c)
 {
     byte    *buf;
 
-    buf = SZ_GetSpace(sb, 1);
+    buf = static_cast<byte *>(SZ_GetSpace(sb, 1));
     buf[0] = c;
 }
 
@@ -119,7 +117,7 @@ void SZ_WriteShort(sizebuf_t *sb, int c)
 {
     byte    *buf;
 
-    buf = SZ_GetSpace(sb, 2);
+    buf = static_cast<byte *>(SZ_GetSpace(sb, 2));
     WL16(buf, c);
 }
 
@@ -127,7 +125,7 @@ void SZ_WriteLong(sizebuf_t *sb, int c)
 {
     byte    *buf;
 
-    buf = SZ_GetSpace(sb, 4);
+    buf = static_cast<byte *>(SZ_GetSpace(sb, 4));
     WL32(buf, c);
 }
 
@@ -152,8 +150,6 @@ void SZ_WriteString(sizebuf_t *sb, const char *s)
 
 void *SZ_ReadData(sizebuf_t *buf, size_t len)
 {
-    void    *data;
-
     if (buf->readcount > buf->cursize || len > buf->cursize - buf->readcount) {
         if (!buf->allowunderflow) {
             Com_Error(ERR_DROP, "%s: read past end of message", __func__);
@@ -162,37 +158,37 @@ void *SZ_ReadData(sizebuf_t *buf, size_t len)
         return NULL;
     }
 
-    data = buf->data + buf->readcount;
+    auto    *data = static_cast<byte *>(buf->data) + buf->readcount;
     buf->readcount += len;
     return data;
 }
 
 int SZ_ReadByte(sizebuf_t *sb)
 {
-    byte *buf = SZ_ReadData(sb, 1);
+    byte *buf = static_cast<byte *>(SZ_ReadData(sb, 1));
     return buf ? *buf : -1;
 }
 
 int SZ_ReadShort(sizebuf_t *sb)
 {
-    byte *buf = SZ_ReadData(sb, 2);
+    byte *buf = static_cast<byte *>(SZ_ReadData(sb, 2));
     return buf ? (int16_t)RL16(buf) : -1;
 }
 
 int SZ_ReadWord(sizebuf_t *sb)
 {
-    byte *buf = SZ_ReadData(sb, 2);
+    byte *buf = static_cast<byte *>(SZ_ReadData(sb, 2));
     return buf ? (uint16_t)RL16(buf) : -1;
 }
 
 int SZ_ReadLong(sizebuf_t *sb)
 {
-    byte *buf = SZ_ReadData(sb, 4);
+    byte *buf = static_cast<byte *>(SZ_ReadData(sb, 4));
     return buf ? (int32_t)RL32(buf) : -1;
 }
 
 float SZ_ReadFloat(sizebuf_t *sb)
 {
-    byte *buf = SZ_ReadData(sb, 4);
+    byte *buf = static_cast<byte *>(SZ_ReadData(sb, 4));
     return buf ? LongToFloat(RL32(buf)) : -1.0f;
 }

--- a/src/common/zone.cpp
+++ b/src/common/zone.cpp
@@ -150,7 +150,7 @@ Z_Freep
 */
 void Z_Freep(void *ptr)
 {
-    void **p = ptr;
+    auto p = static_cast<void **>(ptr);
 
     Q_assert(p);
     if (*p) {

--- a/src/shared/shared.cpp
+++ b/src/shared/shared.cpp
@@ -999,8 +999,8 @@ Returns pointer to next byte after 'c' in 'dst', or NULL if 'c' was not found.
 */
 void *Q_memccpy(void *dst, const void *src, int c, size_t size)
 {
-    byte *d = dst;
-    const byte *s = src;
+    auto *d = static_cast<byte *>(dst);
+    const auto *s = static_cast<const byte *>(src);
 
     while (size--) {
         if ((*d++ = *s++) == c) {


### PR DESCRIPTION
## Summary
- cast zone allocator buffers and sizebuf workspace helpers to byte pointers before use
- update messaging, FIFO, and file helpers to convert SZ_*/FIFO pointers and zlib buffers via static_cast
- adjust Windows networking wrappers and Q_memccpy to use typed char/byte pointers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ece5e822a4832888a347959067c411