### PR TITLE
Adjust buffer sizes for hex chars and transliteration map

### DIFF
--- a/src/common/unicode_translit.h
+++ b/src/common/unicode_translit.h
@@ -1,4 +1,4 @@
-static const struct { uint16_t code; char remap[4]; } unicode_translit[] = {
+static const struct { uint16_t code; char remap[8]; } unicode_translit[] = {
     { 0x00A0, " " }, // NO-BREAK SPACE
     { 0x00A1, "!" }, // INVERTED EXCLAMATION MARK
     { 0x00A2, "C/" }, // CENT SIGN

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -597,7 +597,7 @@ static int escape_char(int c)
     return 0;
 }
 
-const char com_hexchars[16] = "0123456789ABCDEF";
+const char com_hexchars[] = "0123456789ABCDEF";
 
 size_t Com_EscapeString(char *dst, const char *src, size_t size)
 {


### PR DESCRIPTION
## Summary
- drop the fixed length from the hex digit lookup table declaration
- enlarge the unicode transliteration remap buffer to hold the longest mappings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ece5e547f48328b62bc99e739c5b7e