### PR TITLE
Use adjacent string literals for size formats

### DIFF
--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -546,13 +546,13 @@ size_t Com_FormatSize(char *dest, size_t destsize, int64_t bytes)
         return Q_scnprintf(dest, destsize, "%.1fG", bytes * 1e-9);
     }
     if (bytes >= 10000000) {
-        return Q_scnprintf(dest, destsize, "%"PRId64"M", bytes / 1000000);
+        return Q_scnprintf(dest, destsize, "%"PRId64 "M", bytes / 1000000);
     }
     if (bytes >= 1000000) {
         return Q_scnprintf(dest, destsize, "%.1fM", bytes * 1e-6);
     }
     if (bytes >= 1000) {
-        return Q_scnprintf(dest, destsize, "%"PRId64"K", bytes / 1000);
+        return Q_scnprintf(dest, destsize, "%"PRId64 "K", bytes / 1000);
     }
     if (bytes >= 0) {
         return Q_scnprintf(dest, destsize, "%"PRId64, bytes);
@@ -566,16 +566,16 @@ size_t Com_FormatSizeLong(char *dest, size_t destsize, int64_t bytes)
         return Q_scnprintf(dest, destsize, "%.1f GB", bytes * 1e-9);
     }
     if (bytes >= 10000000) {
-        return Q_scnprintf(dest, destsize, "%"PRId64" MB", bytes / 1000000);
+        return Q_scnprintf(dest, destsize, "%"PRId64 " MB", bytes / 1000000);
     }
     if (bytes >= 1000000) {
         return Q_scnprintf(dest, destsize, "%.1f MB", bytes * 1e-6);
     }
     if (bytes >= 1000) {
-        return Q_scnprintf(dest, destsize, "%"PRId64" kB", bytes / 1000);
+        return Q_scnprintf(dest, destsize, "%"PRId64 " kB", bytes / 1000);
     }
     if (bytes >= 0) {
-        return Q_scnprintf(dest, destsize, "%"PRId64" byte%s",
+        return Q_scnprintf(dest, destsize, "%"PRId64 " byte%s",
                            bytes, bytes == 1 ? "" : "s");
     }
     return Q_scnprintf(dest, destsize, "unknown size");


### PR DESCRIPTION
## Summary
- refactor size-formatting helpers to use adjacent string literals with PRI macros
- ensure Q_scnprintf calls pass macro-expanded formats as string literals and numeric arguments separately

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ece5dc237083288b27b1c2aff631ed