### PR TITLE
Refactor color helpers and remove designated initializers

### DIFF
--- a/inc/shared/shared.h
+++ b/inc/shared/shared.h
@@ -809,32 +809,52 @@ static inline int32_t SignExtend(uint32_t v, int bits)
 #define COLOR_U32_MAGENTA COLOR_U32_RGB(255,   0, 255)
 #define COLOR_U32_WHITE   COLOR_U32_RGB(255, 255, 255)
 
-// basic construction from rgba/rgb or alpha u8
-#define COLOR_RGBA(ur, ug, ub, ua) ((color_t) { .r = (ur), .g = (ug), .b = (ub), .a = (ua) })
-#define COLOR_RGB(ur, ug, ub)      ((color_t) { .r = (ur), .g = (ug), .b = (ub), .a = 255  })
-#define COLOR_A(ua)                ((color_t) { .r = 0, .g = 0, .b = 0, .a = (ua)  })
+inline constexpr color_t ColorU32(uint32_t value)
+{
+    return color_t{ value };
+}
 
-// color mask macros
-#define COLOR_MASK_ALPHA   COLOR_A(255)
-#define COLOR_MASK_RGB     COLOR_RGBA(255, 255, 255, 0)
+inline constexpr color_t ColorU24(uint32_t value)
+{
+    return ColorU32((value & 0x00FFFFFFu) | 0xFF000000u);
+}
 
-// conversion from 32-bit or 24-bit colors
-#define COLOR_U32(v)               ((color_t) { .u32 = (v) })
-#define COLOR_U24(v)               ((color_t) { .u32 = ((v) & COLOR_MASK_RGB.u32) | (COLOR_MASK_ALPHA.u32) })
+inline constexpr color_t ColorRGBA(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
+{
+    return ColorU32(COLOR_U32_RGBA(r, g, b, a));
+}
 
-// change alpha macros
-#define COLOR_SETA_U8(c, a)   ((color_t) { .u32 = ((((c).u32) & COLOR_MASK_RGB.u32) | (COLOR_A((a)).u32)) })
-#define COLOR_SETA_F(c, f)    COLOR_SETA_U8((c), ((f) * 255))
+inline constexpr color_t ColorRGB(uint8_t r, uint8_t g, uint8_t b)
+{
+    return ColorRGBA(r, g, b, 255);
+}
 
-// built-in color_t's
-#define COLOR_BLACK   COLOR_U32(COLOR_U32_BLACK)
-#define COLOR_RED     COLOR_U32(COLOR_U32_RED)
-#define COLOR_GREEN   COLOR_U32(COLOR_U32_GREEN)
-#define COLOR_YELLOW  COLOR_U32(COLOR_U32_YELLOW)
-#define COLOR_BLUE    COLOR_U32(COLOR_U32_BLUE)
-#define COLOR_CYAN    COLOR_U32(COLOR_U32_CYAN)
-#define COLOR_MAGENTA COLOR_U32(COLOR_U32_MAGENTA)
-#define COLOR_WHITE   COLOR_U32(COLOR_U32_WHITE)
+inline constexpr color_t ColorA(uint8_t a)
+{
+    return ColorRGBA(0, 0, 0, a);
+}
+
+inline constexpr color_t COLOR_MASK_ALPHA = ColorA(255);
+inline constexpr color_t COLOR_MASK_RGB = ColorRGBA(255, 255, 255, 0);
+
+inline constexpr color_t ColorSetAlpha(color_t c, uint8_t a)
+{
+    return ColorU32((c.u32 & COLOR_MASK_RGB.u32) | ColorA(a).u32);
+}
+
+inline constexpr color_t ColorSetAlpha(color_t c, float alpha)
+{
+    return ColorSetAlpha(c, static_cast<uint8_t>(alpha * 255.0f));
+}
+
+inline constexpr color_t COLOR_BLACK = ColorU32(COLOR_U32_BLACK);
+inline constexpr color_t COLOR_RED = ColorU32(COLOR_U32_RED);
+inline constexpr color_t COLOR_GREEN = ColorU32(COLOR_U32_GREEN);
+inline constexpr color_t COLOR_YELLOW = ColorU32(COLOR_U32_YELLOW);
+inline constexpr color_t COLOR_BLUE = ColorU32(COLOR_U32_BLUE);
+inline constexpr color_t COLOR_CYAN = ColorU32(COLOR_U32_CYAN);
+inline constexpr color_t COLOR_MAGENTA = ColorU32(COLOR_U32_MAGENTA);
+inline constexpr color_t COLOR_WHITE = ColorU32(COLOR_U32_WHITE);
 
 //=============================================
 

--- a/q2proto/inc/q2proto/q2proto_string.h
+++ b/q2proto/inc/q2proto/q2proto_string.h
@@ -42,7 +42,7 @@ typedef struct q2proto_string_s {
 /// Helper: Create a q2proto_string_t from a null-terminated string
 static inline q2proto_string_t q2proto_make_string(const char *s)
 {
-    q2proto_string_t q2p_str = {.str = s, .len = s ? strlen(s) : 0};
+    q2proto_string_t q2p_str{ s, s ? strlen(s) : 0 };
     return q2p_str;
 }
 

--- a/src/client/console.cpp
+++ b/src/client/console.cpp
@@ -421,7 +421,7 @@ static void con_timestampscolor_changed(cvar_t *self)
     if (!SCR_ParseColor(self->string, &con.ts_color)) {
         Com_WPrintf("Invalid value '%s' for '%s'\n", self->string, self->name);
         Cvar_Reset(self);
-        con.ts_color = COLOR_RGB(170, 170, 170);
+        con.ts_color = ColorRGB(170, 170, 170);
     }
 }
 
@@ -701,7 +701,7 @@ static int Con_DrawLine(int v, int row, float alpha, bool notify)
     if (notify) {
         s += line->ts_len;
     } else if (line->ts_len) {
-        color = COLOR_SETA_F(con.ts_color, alpha);
+        color = ColorSetAlpha(con.ts_color, alpha);
         x = R_DrawString(x, v, 0, line->ts_len, s, color, con.charsetImage);
         s += line->ts_len;
         w -= line->ts_len;
@@ -842,7 +842,7 @@ static void Con_DrawSolidConsole(void)
 // draw arrows to show the buffer is backscrolled
     if (con.display != con.current) {
         for (i = 1; i < con.linewidth / 2; i += 4) {
-            R_DrawChar(i * CONCHAR_WIDTH, y, 0, '^', COLOR_SETA_U8(COLOR_RED, color.a), con.charsetImage);
+            R_DrawChar(i * CONCHAR_WIDTH, y, 0, '^', ColorSetAlpha(COLOR_RED, color.a), con.charsetImage);
         }
 
         y -= CONCHAR_HEIGHT;

--- a/src/client/screen.cpp
+++ b/src/client/screen.cpp
@@ -1365,7 +1365,7 @@ void SCR_StatTableSize(int key_width, int value_width)
 void SCR_StatKeyValue(const char *key, const char *value)
 {
     int c = (stat_state.key_id & 1) ? 24 : 0;
-    R_DrawFill32(stat_state.x, stat_state.y, CONCHAR_WIDTH * (stat_state.key_width + stat_state.value_width) + (STAT_MARGIN * 2), CONCHAR_HEIGHT + (STAT_MARGIN * 2), COLOR_RGBA(c, c, c, 127));
+    R_DrawFill32(stat_state.x, stat_state.y, CONCHAR_WIDTH * (stat_state.key_width + stat_state.value_width) + (STAT_MARGIN * 2), CONCHAR_HEIGHT + (STAT_MARGIN * 2), ColorRGBA(c, c, c, 127));
     SCR_DrawString(stat_state.x + STAT_MARGIN, stat_state.y + STAT_MARGIN, UI_DROPSHADOW, COLOR_WHITE, key);
     stat_state.x += CONCHAR_WIDTH * stat_state.key_width;
     SCR_DrawString(stat_state.x + STAT_MARGIN, stat_state.y + STAT_MARGIN, UI_DROPSHADOW, COLOR_WHITE, value);
@@ -1668,7 +1668,7 @@ static void SCR_DrawHitMarker(color_t base_color)
     int x = (scr.hud_width - w) / 2;
     int y = (scr.hud_height - h) / 2;
 
-    color_t color = COLOR_RGBA(255, 0, 0, base_color.a * alpha);
+    color_t color = ColorRGBA(255, 0, 0, base_color.a * alpha);
 
     R_DrawStretchPic(x + ch_x->integer,
                      y + ch_y->integer,
@@ -1733,7 +1733,7 @@ static void SCR_DrawDamageDisplays(color_t base_color)
         float damage_yaw = angles[YAW];
         float yaw_diff = DEG2RAD((my_yaw - damage_yaw) - 180);
 
-        color_t color = COLOR_RGBA(
+        color_t color = ColorRGBA(
             (int) (entry->color[0] * 255.f),
             (int) (entry->color[1] * 255.f),
             (int) (entry->color[2] * 255.f),
@@ -2069,7 +2069,7 @@ static void SCR_Draw2D(void)
     SCR_SetupHUD();
 
     // The rest of 2D elements share common alpha
-    color_t color = COLOR_SETA_F(COLOR_WHITE, Cvar_ClampValue(scr_alpha, 0, 1));
+    color_t color = ColorSetAlpha(COLOR_WHITE, Cvar_ClampValue(scr_alpha, 0, 1));
 
     // CALL THE NEW FPS COUNTER FUNCTION HERE
     SCR_DrawFPS(color);

--- a/src/client/ui/menu.cpp
+++ b/src/client/ui/menu.cpp
@@ -1590,7 +1590,7 @@ static void MenuList_Draw(menuList_t *l)
         s = (char *)l->items[i] + l->extrasize;
 
         if (l->mlFlags & MLF_COLOR) {
-            color = COLOR_U32(*((uint32_t *)(s - 4)));
+            color = ColorU32(*((uint32_t *)(s - 4)));
         }
 
         xx = x;

--- a/src/client/ui/ui.cpp
+++ b/src/client/ui/ui.cpp
@@ -311,13 +311,13 @@ void UI_DrawString(int x, int y, int flags, color_t color, const char *string)
         x -= strlen(string) * CONCHAR_WIDTH;
     }
 
-    R_DrawString(x, y, flags, MAX_STRING_CHARS, string, COLOR_SETA_U8(color, 255), uis.fontHandle);
+    R_DrawString(x, y, flags, MAX_STRING_CHARS, string, ColorSetAlpha(color, static_cast<uint8_t>(255)), uis.fontHandle);
 }
 
 // nb: all UI chars are drawn at full alpha
 void UI_DrawChar(int x, int y, int flags, color_t color, int ch)
 {
-    R_DrawChar(x, y, flags, ch, COLOR_SETA_U8(color, 255), uis.fontHandle);
+    R_DrawChar(x, y, flags, ch, ColorSetAlpha(color, static_cast<uint8_t>(255)), uis.fontHandle);
 }
 
 void UI_StringDimensions(vrect_t *rc, int flags, const char *string)
@@ -620,11 +620,11 @@ void UI_Init(void)
         uis.bitmapCursors[i] = R_RegisterPic(va("m_cursor%d", i));
     }
 
-    uis.color.background    = COLOR_RGBA(0,   0,   0,   255);
-    uis.color.normal        = COLOR_RGBA(15,  128, 235, 100);
-    uis.color.active        = COLOR_RGBA(15,  128, 235, 100);
-    uis.color.selection     = COLOR_RGBA(15,  128, 235, 100);
-    uis.color.disabled      = COLOR_RGBA(127, 127, 127, 255);
+    uis.color.background    = ColorRGBA(0,   0,   0,   255);
+    uis.color.normal        = ColorRGBA(15,  128, 235, 100);
+    uis.color.active        = ColorRGBA(15,  128, 235, 100);
+    uis.color.selection     = ColorRGBA(15,  128, 235, 100);
+    uis.color.disabled      = ColorRGBA(127, 127, 127, 255);
 
     strcpy(uis.weaponModel, "w_railgun.md2");
 

--- a/src/client/wheel.cpp
+++ b/src/client/wheel.cpp
@@ -110,8 +110,8 @@ static void CL_Carousel_Open(void)
 
 static void R_DrawStretchPicShadowAlpha(int x, int y, int w, int h, qhandle_t pic, int shadow_offset, float alpha)
 {
-    R_DrawStretchPic(x + shadow_offset, y + shadow_offset, w, h, COLOR_SETA_F(COLOR_BLACK, alpha), pic);
-    R_DrawStretchPic(x, y, w, h, COLOR_SETA_F(COLOR_WHITE, alpha), pic);
+    R_DrawStretchPic(x + shadow_offset, y + shadow_offset, w, h, ColorSetAlpha(COLOR_BLACK, alpha), pic);
+    R_DrawStretchPic(x, y, w, h, ColorSetAlpha(COLOR_WHITE, alpha), pic);
 }
 
 static void R_DrawPicShadow(int x, int y, qhandle_t pic, int shadow_offset)
@@ -153,9 +153,9 @@ void CL_Carousel_Draw(void)
             int count = cgame->GetWeaponWheelAmmoCount(&cl.frame.ps, weap->ammo_index);
             color_t color;
             if (count <= weap->quantity_warn)
-                color = selected ? COLOR_RGB(255, 83, 83) : COLOR_RED;
+                color = selected ? ColorRGB(255, 83, 83) : COLOR_RED;
             else
-                color = selected ? COLOR_RGB(255, 255, 83) : COLOR_WHITE;
+                color = selected ? ColorRGB(255, 255, 83) : COLOR_WHITE;
 
             draw_count(carousel_x + (CAROUSEL_ICON_SIZE / 2), carousel_y + CAROUSEL_ICON_SIZE + 2, wc_ammo_scale->value, UI_DROPSHADOW | UI_CENTER, color, count);
         }
@@ -451,7 +451,7 @@ static color_t slot_count_color(bool selected, bool warn_low)
     color_t count_color;
     if (selected) {
         // "Selected" color is based off the tint for "selected" wheel icons in rerelease
-        count_color = warn_low ? COLOR_RGB(255, 62, 33) : COLOR_RGB(255, 248, 134);
+        count_color = warn_low ? ColorRGB(255, 62, 33) : ColorRGB(255, 248, 134);
     } else
         count_color = warn_low ? COLOR_RED : COLOR_WHITE;
     return count_color;
@@ -514,7 +514,7 @@ static void draw_wheel_slot(int slot_idx, int center_x, int center_y, int wheel_
 
     int min_count = slot->is_powerup ? 2 : 0;
     if (count != -1 && count >= min_count) {
-        draw_count(center_x + p[0] + size, center_y + p[1] + size, ww_ammo_scale->value * scale, UI_CENTER | UI_DROPSHADOW, COLOR_SETA_F(count_color, wheel_alpha), count);
+        draw_count(center_x + p[0] + size, center_y + p[1] + size, ww_ammo_scale->value * scale, UI_CENTER | UI_DROPSHADOW, ColorSetAlpha(count_color, wheel_alpha), count);
     }
 
     // We may need it later
@@ -541,7 +541,7 @@ void CL_Wheel_Draw(void)
     float t = 1.0f - cl.wheel.timer;
     float tween = 0.5f - (cos((t * t) * M_PIf) * 0.5f);
     float wheel_alpha = 1.0f - tween;
-    color_t base_color = COLOR_SETA_F(COLOR_WHITE, wheel_alpha);
+    color_t base_color = ColorSetAlpha(COLOR_WHITE, wheel_alpha);
     int wheel_draw_size = get_wheel_draw_size();
 
     R_DrawStretchPic(center_x - (wheel_draw_size / 2), center_y - (wheel_draw_size / 2), wheel_draw_size, wheel_draw_size, base_color, scr.wheel_circle);
@@ -586,7 +586,7 @@ void CL_Wheel_Draw(void)
             R_DrawStretchPicShadowAlpha(center_x - (24 * 3) / 2, center_y - ((24 * 3) / 2), (24 * 3), (24 * 3), ammo->icons.wheel, 2, wheel_alpha);
 
             color_t color = slot_count_color(false, warn_low); // don't use selected color inside the wheel
-            SCR_DrawString(center_x, center_y + 32, UI_CENTER | UI_DROPSHADOW, COLOR_SETA_F(color, wheel_alpha), va("%i", count));
+            SCR_DrawString(center_x, center_y + 32, UI_CENTER | UI_DROPSHADOW, ColorSetAlpha(color, wheel_alpha), va("%i", count));
         }
     }
 
@@ -596,7 +596,7 @@ void CL_Wheel_Draw(void)
                      (int)((center_y / scr.hud_scale) + cl.wheel.position[1] - (wheel_button_draw_size / 2)),
                      wheel_button_draw_size,
                      wheel_button_draw_size,
-                     COLOR_SETA_F(COLOR_WHITE, wheel_alpha * 0.5f), scr.wheel_button);
+                     ColorSetAlpha(COLOR_WHITE, wheel_alpha * 0.5f), scr.wheel_button);
 }
 
 void CL_Wheel_Precache(void)

--- a/src/common/net/win.h
+++ b/src/common/net/win.h
@@ -358,7 +358,8 @@ static neterr_t os_connect_hack(struct pollfd *e)
     FD_ZERO(&fd);
     FD_SET(e->fd, &fd);
 
-    ret = select(1, NULL, NULL, &fd, &(struct timeval){ 0 });
+    timeval tv{};
+    ret = select(1, NULL, NULL, &fd, &tv);
     if (ret == SOCKET_ERROR) {
         net_error = WSAGetLastError();
         return NET_ERROR;
@@ -385,12 +386,11 @@ static void os_net_init(void)
 
     Com_DPrintf("Winsock initialized\n");
 
-    OSVERSIONINFOEXA vi = {
-        .dwOSVersionInfoSize = sizeof(vi),
-        .dwMajorVersion = 10,
-        .dwMinorVersion = 0,
-        .dwBuildNumber = 19041,
-    };
+    OSVERSIONINFOEXA vi{};
+    vi.dwOSVersionInfoSize = sizeof(vi);
+    vi.dwMajorVersion = 10;
+    vi.dwMinorVersion = 0;
+    vi.dwBuildNumber = 19041;
 
     ULONGLONG mask = 0;
     VER_SET_CONDITION(mask, VER_MAJORVERSION, VER_GREATER_EQUAL);

--- a/src/common/zone.cpp
+++ b/src/common/zone.cpp
@@ -51,14 +51,25 @@ typedef struct {
 static list_t       z_chain;
 static zstats_t     z_stats[TAG_MAX];
 
-#define S(d) \
-    { .z = { .magic = Z_MAGIC, .tag = TAG_STATIC, .size = sizeof(zstatic_t) }, .data = d }
+template <size_t N>
+static constexpr zstatic_t MakeZStatic(const char (&d)[N])
+{
+    zstatic_t value{};
+    static_assert(N <= sizeof(value.data), "zstatic_t data buffer must fit string literal");
+    value.z.magic = Z_MAGIC;
+    value.z.tag = TAG_STATIC;
+    value.z.size = sizeof(zstatic_t);
+    for (size_t i = 0; i < sizeof(value.data) && i < N; ++i) {
+        value.data[i] = d[i];
+    }
+    return value;
+}
 
-static const zstatic_t z_static[11] = {
-    S("0"), S("1"), S("2"), S("3"), S("4"), S("5"), S("6"), S("7"), S("8"), S("9"), S("")
+static constexpr zstatic_t z_static[11] = {
+    MakeZStatic("0"), MakeZStatic("1"), MakeZStatic("2"), MakeZStatic("3"), MakeZStatic("4"),
+    MakeZStatic("5"), MakeZStatic("6"), MakeZStatic("7"), MakeZStatic("8"), MakeZStatic("9"),
+    MakeZStatic("")
 };
-
-#undef S
 
 static const char *const z_tagnames[TAG_MAX] = {
     "game",

--- a/src/refresh/draw.cpp
+++ b/src/refresh/draw.cpp
@@ -217,7 +217,7 @@ void GL_Blend(void)
         outer.b = glr.fd.damage_blend[2] * 255;
         outer.a = glr.fd.damage_blend[3] * 255;
 
-        inner = COLOR_SETA_U8(outer, 0);
+        inner = ColorSetAlpha(outer, 0);
 
         if (gl_damageblend_frac->value > 0)
             GL_DrawVignette(Cvar_ClampValue(gl_damageblend_frac, 0, 0.5f), outer, inner);
@@ -387,7 +387,7 @@ void R_DrawFill8(int x, int y, int w, int h, int c)
 {
     if (!w || !h)
         return;
-    GL_StretchPic_(x, y, w, h, 0, 0, 1, 1, COLOR_U32(d_8to24table[c & 0xff]), TEXNUM_WHITE, 0);
+    GL_StretchPic_(x, y, w, h, 0, 0, 1, 1, ColorU32(d_8to24table[c & 0xff]), TEXNUM_WHITE, 0);
 }
 
 void R_DrawFill32(int x, int y, int w, int h, color_t color)
@@ -414,7 +414,7 @@ static inline void draw_char(int x, int y, int w, int h, int flags, int c, color
     t = (c >> 4) * 0.0625f;
 
     if (flags & UI_DROPSHADOW && c != 0x83) {
-        color_t black = COLOR_A(color.a);
+        color_t black = ColorA(color.a);
 
         GL_StretchPic(x + 1, y + 1, w, h, s, t,
                       s + 0.0625f, t + 0.0625f, black, image);
@@ -425,7 +425,7 @@ static inline void draw_char(int x, int y, int w, int h, int flags, int c, color
     }
 
     if (c >> 7)
-        color = COLOR_SETA_U8(COLOR_WHITE, color.a);
+        color = ColorSetAlpha(COLOR_WHITE, color.a);
 
     GL_StretchPic(x, y, w, h, s, t,
                   s + 0.0625f, t + 0.0625f, color, image);
@@ -492,7 +492,7 @@ static inline int draw_kfont_char(int x, int y, int scale, int flags, uint32_t c
     if ((flags & UI_DROPSHADOW) || gl_fontshadow->integer > 0) {
         shadow_offset = (1 * scale);
         
-        color_t black = COLOR_A(color.a);
+        color_t black = ColorA(color.a);
 
         GL_StretchPic(x + shadow_offset, y + shadow_offset, w, h, s, t,
                       s + sw, t + sh, black, image);

--- a/src/refresh/images.cpp
+++ b/src/refresh/images.cpp
@@ -158,7 +158,7 @@ static int IMG_Unpack8(uint32_t *out, const uint8_t *in, int width, int height)
                 else
                     p = 0;
                 // copy rgb components
-                *out = COLOR_SETA_U8(COLOR_U32(d_8to24table[p]), 0).u32;
+                *out = ColorSetAlpha(ColorU32(d_8to24table[p]), 0).u32;
             } else {
                 *out = d_8to24table[p];
             }
@@ -400,16 +400,16 @@ static uint32_t tga_unpack_pixel(const byte *in, int bpp)
     switch (bpp) {
     case 1:
         r = in[0];
-        return COLOR_RGB(r, r, r).u32;
+        return ColorRGB(r, r, r).u32;
     case 2:
         r = (in[1] & 0x7C) >> 2;
         g = ((in[1] & 0x03) << 3) | ((in[0] & 0xE0) >> 5);
         b = (in[0] & 0x1F);
-        return COLOR_RGB(r << 3, g << 3, b << 3).u32;
+        return ColorRGB(r << 3, g << 3, b << 3).u32;
     case 3:
-        return COLOR_RGB(in[2], in[1], in[0]).u32;
+        return ColorRGB(in[2], in[1], in[0]).u32;
     case 4:
-        return COLOR_RGBA(in[2], in[1], in[0], in[3]).u32;
+        return ColorRGBA(in[2], in[1], in[0], in[3]).u32;
     default:
         q_unreachable();
     }
@@ -2230,10 +2230,10 @@ void IMG_GetPalette(void)
         goto fail;
 
     for (i = 0, src = pal; i < 255; i++, src += 3)
-        d_8to24table[i] = COLOR_RGB(src[0], src[1], src[2]).u32;
+        d_8to24table[i] = ColorRGB(src[0], src[1], src[2]).u32;
 
     // 255 is transparent
-    d_8to24table[i] = COLOR_RGBA(src[0], src[1], src[2], 0).u32;
+    d_8to24table[i] = ColorRGBA(src[0], src[1], src[2], 0).u32;
     return;
 
 fail:

--- a/src/refresh/texture.cpp
+++ b/src/refresh/texture.cpp
@@ -966,9 +966,9 @@ static void GL_BuildIntensityTable(void)
         j = 255.0f / f;
     }
 
-    gl_static.inverse_intensity_33 = COLOR_RGBA(j, j, j, 85).u32;
-    gl_static.inverse_intensity_66 = COLOR_RGBA(j, j, j, 170).u32;
-    gl_static.inverse_intensity_100 = COLOR_RGB(j, j, j).u32;
+    gl_static.inverse_intensity_33 = ColorRGBA(j, j, j, 85).u32;
+    gl_static.inverse_intensity_66 = ColorRGBA(j, j, j, 170).u32;
+    gl_static.inverse_intensity_100 = ColorRGB(j, j, j).u32;
 }
 
 static void GL_BuildGammaTables(void)

--- a/src/server/nav.cpp
+++ b/src/server/nav.cpp
@@ -864,8 +864,8 @@ static void Nav_DebugPath(const PathInfo *path, const PathRequest *request)
 
     int time = (request->debugging.drawTime * 1000) + 6000;
     
-    color_t path_color = COLOR_SETA_U8(COLOR_RED, 64);
-    color_t arrow_color = COLOR_SETA_U8(COLOR_YELLOW, 64);
+    color_t path_color = ColorSetAlpha(COLOR_RED, 64);
+    color_t arrow_color = ColorSetAlpha(COLOR_YELLOW, 64);
 
     R_AddDebugSphere(request->start, 8.0f, path_color, time, false);
     R_AddDebugSphere(request->goal, 8.0f, path_color, time, false);
@@ -1197,10 +1197,10 @@ static void Nav_RenderLink(const nav_node_t *node, int node_id, const vec3_t nod
     bool link_disabled = ((node->flags | link->target->flags) & NodeFlag_Disabled);
     uint8_t link_alpha = link_disabled ? (alpha * 0.5f) : alpha;
             
-    color_t line_color = COLOR_SETA_U8(link_disabled ? COLOR_RED : COLOR_WHITE, link_alpha);
-    color_t traversal_color = COLOR_SETA_U8(link_disabled ? COLOR_RED : COLOR_BLUE, link_alpha);
-    color_t arrow_color = COLOR_SETA_U8(COLOR_RED, link_alpha);
-    color_t one_way_line_color = COLOR_SETA_U8(link_disabled ? COLOR_RED : COLOR_CYAN, link_alpha);
+    color_t line_color = ColorSetAlpha(link_disabled ? COLOR_RED : COLOR_WHITE, link_alpha);
+    color_t traversal_color = ColorSetAlpha(link_disabled ? COLOR_RED : COLOR_BLUE, link_alpha);
+    color_t arrow_color = ColorSetAlpha(COLOR_RED, link_alpha);
+    color_t one_way_line_color = ColorSetAlpha(link_disabled ? COLOR_RED : COLOR_CYAN, link_alpha);
     
     vec3_t ctrl;
 
@@ -1274,7 +1274,7 @@ static void Nav_Debug(void)
 
         const uint8_t alpha = Q_clipf((1.0f - ((len - 32.f) / (nav_debug_range->value - 32.f))), 0.0f, 1.0f) * 255.f;
 
-        Nav_AddDebugCircle(node->origin, node->radius, COLOR_SETA_U8(COLOR_CYAN, alpha));
+        Nav_AddDebugCircle(node->origin, node->radius, ColorSetAlpha(COLOR_CYAN, alpha));
 
         vec3_t mins, maxs, origin;
         Nav_GetNodeBounds(node, mins, maxs);
@@ -1283,7 +1283,7 @@ static void Nav_Debug(void)
         VectorAdd(mins, origin, mins);
         VectorAdd(maxs, origin, maxs);
 
-        Nav_AddDebugBounds(mins, maxs, COLOR_SETA_U8((node->flags & NodeFlag_Disabled) ? COLOR_RED : COLOR_YELLOW, alpha));
+        Nav_AddDebugBounds(mins, maxs, ColorSetAlpha((node->flags & NodeFlag_Disabled) ? COLOR_RED : COLOR_YELLOW, alpha));
 
         if (node->flags & NodeFlag_CheckHasFloor) {
             vec3_t floormins, floormaxs;
@@ -1294,20 +1294,20 @@ static void Nav_Debug(void)
             floormins[2] = origin[2] - NavFloorDistance;
             floormaxs[2] = mins_z;
 
-            Nav_AddDebugBounds(floormins, floormaxs, COLOR_SETA_U8(COLOR_RED, alpha * 0.5f));
+            Nav_AddDebugBounds(floormins, floormaxs, ColorSetAlpha(COLOR_RED, alpha * 0.5f));
         }
 
         const vec3_t s = { node->origin[0], node->origin[1], node->origin[2] + 24.f };
 
-        Nav_AddDebugLine(node->origin, s, COLOR_SETA_U8(COLOR_CYAN, alpha));
+        Nav_AddDebugLine(node->origin, s, ColorSetAlpha(COLOR_CYAN, alpha));
 
         vec3_t t = { node->origin[0], node->origin[1], node->origin[2] + 64.f };
 
-        Nav_AddDebugText(t, NULL, va("%td", node - nav_data.nodes), 0.25f, COLOR_SETA_U8(COLOR_CYAN, alpha));
+        Nav_AddDebugText(t, NULL, va("%td", node - nav_data.nodes), 0.25f, ColorSetAlpha(COLOR_CYAN, alpha));
 
         t[2] -= 18;
 
-        R_AddDebugText(t, NULL, Nav_NodeFlagsToString(node->flags), 0.1f, COLOR_SETA_U8(COLOR_GREEN, alpha), SV_FRAMETIME, false);
+        R_AddDebugText(t, NULL, Nav_NodeFlagsToString(node->flags), 0.1f, ColorSetAlpha(COLOR_GREEN, alpha), SV_FRAMETIME, false);
         
         for (const nav_link_t *link = node->links; link != node->links + node->num_links; link++)
             Nav_RenderLink(node, i, s, link, alpha);

--- a/src/shared/shared.cpp
+++ b/src/shared/shared.cpp
@@ -1454,95 +1454,96 @@ void Info_Print(const char *infostring)
 =====================================================================
 */
 
-const cs_remap_t cs_remap_old = {
-    .extended    = false,
+static constexpr cs_remap_t make_cs_remap_old()
+{
+    cs_remap_t remap{};
+    remap.extended = false;
+    remap.max_edicts = MAX_EDICTS_OLD;
+    remap.max_models = MAX_MODELS_OLD;
+    remap.max_sounds = MAX_SOUNDS_OLD;
+    remap.max_images = MAX_IMAGES_OLD;
+    remap.max_shadowlights = 0;
+    remap.max_wheelitems = 0;
+    remap.airaccel = CS_AIRACCEL_OLD;
+    remap.maxclients = CS_MAXCLIENTS_OLD;
+    remap.mapchecksum = CS_MAPCHECKSUM_OLD;
+    remap.models = CS_MODELS_OLD;
+    remap.sounds = CS_SOUNDS_OLD;
+    remap.images = CS_IMAGES_OLD;
+    remap.lights = CS_LIGHTS_OLD;
+    remap.shadowlights = static_cast<uint16_t>(-1);
+    remap.items = CS_ITEMS_OLD;
+    remap.playerskins = CS_PLAYERSKINS_OLD;
+    remap.general = CS_GENERAL_OLD;
+    remap.wheelweapons = static_cast<uint16_t>(-1);
+    remap.wheelammo = static_cast<uint16_t>(-1);
+    remap.wheelpowerups = static_cast<uint16_t>(-1);
+    remap.cdloopcount = static_cast<uint16_t>(-1);
+    remap.gamestyle = static_cast<uint16_t>(-1);
+    remap.end = MAX_CONFIGSTRINGS_OLD;
+    return remap;
+}
 
-    .max_edicts  = MAX_EDICTS_OLD,
-    .max_models  = MAX_MODELS_OLD,
-    .max_sounds  = MAX_SOUNDS_OLD,
-    .max_images  = MAX_IMAGES_OLD,
-    .max_shadowlights = 0,
-    .max_wheelitems = 0,
+static constexpr cs_remap_t make_cs_remap_rerelease()
+{
+    cs_remap_t remap{};
+    remap.extended = true;
+    remap.max_edicts = MAX_EDICTS;
+    remap.max_models = MAX_MODELS;
+    remap.max_sounds = MAX_SOUNDS;
+    remap.max_images = MAX_IMAGES;
+    remap.max_shadowlights = MAX_SHADOW_LIGHTS;
+    remap.max_wheelitems = MAX_WHEEL_ITEMS;
+    remap.airaccel = CS_AIRACCEL;
+    remap.maxclients = CS_MAXCLIENTS;
+    remap.mapchecksum = CS_MAPCHECKSUM;
+    remap.models = CS_MODELS;
+    remap.sounds = CS_SOUNDS;
+    remap.images = CS_IMAGES;
+    remap.lights = CS_LIGHTS;
+    remap.shadowlights = CS_SHADOWLIGHTS;
+    remap.items = CS_ITEMS;
+    remap.playerskins = CS_PLAYERSKINS;
+    remap.general = CS_GENERAL;
+    remap.wheelweapons = CS_WHEEL_WEAPONS;
+    remap.wheelammo = CS_WHEEL_AMMO;
+    remap.wheelpowerups = CS_WHEEL_POWERUPS;
+    remap.cdloopcount = CS_CD_LOOP_COUNT;
+    remap.gamestyle = CS_GAME_STYLE;
+    remap.end = MAX_CONFIGSTRINGS;
+    return remap;
+}
 
-    .airaccel    = CS_AIRACCEL_OLD,
-    .maxclients  = CS_MAXCLIENTS_OLD,
-    .mapchecksum = CS_MAPCHECKSUM_OLD,
+static constexpr cs_remap_t make_cs_remap_q2pro_new()
+{
+    cs_remap_t remap{};
+    remap.extended = true;
+    remap.max_edicts = MAX_EDICTS;
+    remap.max_models = MAX_MODELS;
+    remap.max_sounds = MAX_SOUNDS;
+    remap.max_images = MAX_IMAGES_EX;
+    remap.max_shadowlights = 0;
+    remap.max_wheelitems = 0;
+    remap.airaccel = CS_AIRACCEL_EX;
+    remap.maxclients = CS_MAXCLIENTS_EX;
+    remap.mapchecksum = CS_MAPCHECKSUM_EX;
+    remap.models = CS_MODELS_EX;
+    remap.sounds = CS_SOUNDS_EX;
+    remap.images = CS_IMAGES_EX;
+    remap.lights = CS_LIGHTS_EX;
+    remap.shadowlights = static_cast<uint16_t>(-1);
+    remap.items = CS_ITEMS_EX;
+    remap.playerskins = CS_PLAYERSKINS_EX;
+    remap.general = CS_GENERAL_EX;
+    remap.wheelweapons = static_cast<uint16_t>(-1);
+    remap.wheelammo = static_cast<uint16_t>(-1);
+    remap.wheelpowerups = static_cast<uint16_t>(-1);
+    remap.cdloopcount = static_cast<uint16_t>(-1);
+    remap.gamestyle = static_cast<uint16_t>(-1);
+    remap.end = MAX_CONFIGSTRINGS_EX;
+    return remap;
+}
 
-    .models      = CS_MODELS_OLD,
-    .sounds      = CS_SOUNDS_OLD,
-    .images      = CS_IMAGES_OLD,
-    .lights      = CS_LIGHTS_OLD,
-    .shadowlights = -1,
-    .items       = CS_ITEMS_OLD,
-    .playerskins = CS_PLAYERSKINS_OLD,
-    .general     = CS_GENERAL_OLD,
-    .wheelweapons = -1,
-    .wheelammo   = -1,
-    .wheelpowerups = -1,
-    .cdloopcount = -1,
-    .gamestyle   = -1,
-
-    .end         = MAX_CONFIGSTRINGS_OLD
-};
-
-const cs_remap_t cs_remap_rerelease = {
-    .extended    = true,
-
-    .max_edicts  = MAX_EDICTS,
-    .max_models  = MAX_MODELS,
-    .max_sounds  = MAX_SOUNDS,
-    .max_images  = MAX_IMAGES,
-    .max_shadowlights = MAX_SHADOW_LIGHTS,
-    .max_wheelitems = MAX_WHEEL_ITEMS,
-
-    .airaccel    = CS_AIRACCEL,
-    .maxclients  = CS_MAXCLIENTS,
-    .mapchecksum = CS_MAPCHECKSUM,
-
-    .models      = CS_MODELS,
-    .sounds      = CS_SOUNDS,
-    .images      = CS_IMAGES,
-    .lights      = CS_LIGHTS,
-    .shadowlights = CS_SHADOWLIGHTS,
-    .items       = CS_ITEMS,
-    .playerskins = CS_PLAYERSKINS,
-    .general     = CS_GENERAL,
-    .wheelweapons = CS_WHEEL_WEAPONS,
-    .wheelammo   = CS_WHEEL_AMMO,
-    .wheelpowerups = CS_WHEEL_POWERUPS,
-    .cdloopcount = CS_CD_LOOP_COUNT,
-    .gamestyle   = CS_GAME_STYLE,
-
-    .end         = MAX_CONFIGSTRINGS
-};
-
-const cs_remap_t cs_remap_q2pro_new = {
-    .extended    = true,
-
-    .max_edicts  = MAX_EDICTS,
-    .max_models  = MAX_MODELS,
-    .max_sounds  = MAX_SOUNDS,
-    .max_images  = MAX_IMAGES_EX,
-    .max_shadowlights = 0,
-    .max_wheelitems = 0,
-
-    .airaccel    = CS_AIRACCEL_EX,
-    .maxclients  = CS_MAXCLIENTS_EX,
-    .mapchecksum = CS_MAPCHECKSUM_EX,
-
-    .models      = CS_MODELS_EX,
-    .sounds      = CS_SOUNDS_EX,
-    .images      = CS_IMAGES_EX,
-    .lights      = CS_LIGHTS_EX,
-    .shadowlights = -1,
-    .items       = CS_ITEMS_EX,
-    .playerskins = CS_PLAYERSKINS_EX,
-    .general     = CS_GENERAL_EX,
-    .wheelweapons = -1,
-    .wheelammo   = -1,
-    .wheelpowerups = -1,
-    .cdloopcount = -1,
-    .gamestyle   = -1,
-
-    .end         = MAX_CONFIGSTRINGS_EX
-};
+const cs_remap_t cs_remap_old = make_cs_remap_old();
+const cs_remap_t cs_remap_rerelease = make_cs_remap_rerelease();
+const cs_remap_t cs_remap_q2pro_new = make_cs_remap_q2pro_new();


### PR DESCRIPTION
## Summary
- replace the color helper macros with constexpr builders and update callers
- rewrite the config string remap and mapdb tables without designated initializers
- clean up q2proto string construction and Windows networking struct setup

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ece5d4f65c83288cad6465cfbd88be