### PR TITLE
Use explicit cast for cvar generator context

### DIFF
--- a/src/common/cvar.cpp
+++ b/src/common/cvar.cpp
@@ -142,7 +142,7 @@ void Cvar_Variable_g(genctx_t *ctx)
 
 void Cvar_Default_g(genctx_t *ctx)
 {
-    cvar_t *c = ctx->data;
+    auto *c = static_cast<cvar_t *>(ctx->data);
 
     if (c) {
         if (strcmp(c->string, c->default_string)) {


### PR DESCRIPTION
## Summary
- replace the implicit cvar generator context cast with an explicit static_cast to satisfy stricter compilers

## Testing
- meson setup builddir *(fails: meson not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ecec008be48328aa1fafbc1a4a6f15