### PR TITLE
Add Vulkan renderer scaffold

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -9,6 +9,11 @@ project('worr', ['cpp', 'c'],
   ],
 )
 
+renderer_opt = get_option('renderer')
+if renderer_opt not in ['refresh', 'refresh-vk']
+  error('Unknown renderer option: @0@'.format(renderer_opt))
+endif
+
 common_src = [
   'src/common/bsp.cpp',
   'src/common/cmd.cpp',
@@ -189,31 +194,38 @@ ui_src = [
   'src/client/ui/ui.h',
 ]
 
-refresh_src = [
-  'src/refresh/draw.cpp',
-  'src/refresh/hq2x.cpp',
-  'src/refresh/images.cpp',
-  'src/refresh/legacy.cpp',
-  'src/refresh/main.cpp',
-  'src/refresh/mesh.cpp',
-  'src/refresh/models.cpp',
-  'src/refresh/qgl.cpp',
-  'src/refresh/shader.cpp',
-  'src/refresh/sky.cpp',
-  'src/refresh/state.cpp',
-  'src/refresh/surf.cpp',
-  'src/refresh/tess.cpp',
-  'src/refresh/texture.cpp',
-  'src/refresh/world.cpp',
-  'src/refresh/debug.cpp',
-  'src/refresh/debug_text.cpp',
-  'src/refresh/arbfp.h',
-  'src/refresh/gl.h',
-  'src/refresh/images.h',
-  'src/refresh/qgl.h',
+if renderer_opt == 'refresh'
+  refresh_src = [
+    'src/refresh/draw.cpp',
+    'src/refresh/hq2x.cpp',
+    'src/refresh/images.cpp',
+    'src/refresh/legacy.cpp',
+    'src/refresh/main.cpp',
+    'src/refresh/mesh.cpp',
+    'src/refresh/models.cpp',
+    'src/refresh/qgl.cpp',
+    'src/refresh/shader.cpp',
+    'src/refresh/sky.cpp',
+    'src/refresh/state.cpp',
+    'src/refresh/surf.cpp',
+    'src/refresh/tess.cpp',
+    'src/refresh/texture.cpp',
+    'src/refresh/world.cpp',
+    'src/refresh/debug.cpp',
+    'src/refresh/debug_text.cpp',
+    'src/refresh/arbfp.h',
+    'src/refresh/gl.h',
+    'src/refresh/images.h',
+    'src/refresh/qgl.h',
+  ]
+elif renderer_opt == 'refresh-vk'
+  refresh_src = [
+    'src/refresh-vk/main.cpp',
+    'src/refresh-vk/renderer.cpp',
+  ]
+endif
 
-  'inc/refresh/refresh.h',
-]
+refresh_src += 'inc/refresh/refresh.h'
 
 server_src = [
   'src/client/null.cpp',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -121,6 +121,11 @@ option('opengl-es1',
   value: false,
   description: 'Build OpenGL ES 1 compatible renderer')
 
+option('renderer',
+  type: 'string',
+  value: 'refresh',
+  description: 'Select renderer backend (refresh or refresh-vk)')
+
 option('packetdup-hack',
   type: 'boolean',
   value: false,

--- a/src/refresh-vk/main.cpp
+++ b/src/refresh-vk/main.cpp
@@ -1,0 +1,150 @@
+#include "renderer.h"
+
+namespace {
+    refresh::vk::VulkanRenderer g_renderer;
+}
+
+bool R_Init(bool total) {
+    return g_renderer.init(total);
+}
+
+void R_Shutdown(bool total) {
+    g_renderer.shutdown(total);
+}
+
+void R_BeginRegistration(const char *map) {
+    g_renderer.beginRegistration(map);
+}
+
+qhandle_t R_RegisterModel(const char *name) {
+    return g_renderer.registerModel(name);
+}
+
+qhandle_t R_RegisterImage(const char *name, imagetype_t type, imageflags_t flags) {
+    return g_renderer.registerImage(name, type, flags);
+}
+
+void R_SetSky(const char *name, float rotate, bool autorotate, const vec3_t axis) {
+    g_renderer.setSky(name, rotate, autorotate, axis);
+}
+
+void R_EndRegistration(void) {
+    g_renderer.endRegistration();
+}
+
+void R_RenderFrame(const refdef_t *fd) {
+    g_renderer.renderFrame(fd);
+}
+
+void R_LightPoint(const vec3_t origin, vec3_t light) {
+    g_renderer.lightPoint(origin, light);
+}
+
+void R_SetClipRect(const clipRect_t *clip) {
+    g_renderer.setClipRect(clip);
+}
+
+float R_ClampScale(cvar_t *var) {
+    return g_renderer.clampScale(var);
+}
+
+void R_SetScale(float scale) {
+    g_renderer.setScale(scale);
+}
+
+int get_auto_scale(void) {
+    return g_renderer.autoScale();
+}
+
+void R_DrawChar(int x, int y, int flags, int ch, color_t color, qhandle_t font) {
+    g_renderer.drawChar(x, y, flags, ch, color, font);
+}
+
+void R_DrawStretchChar(int x, int y, int w, int h, int flags, int ch, color_t color, qhandle_t font) {
+    g_renderer.drawStretchChar(x, y, w, h, flags, ch, color, font);
+}
+
+int R_DrawStringStretch(int x, int y, int scale, int flags, size_t maxChars,
+                        const char *string, color_t color, qhandle_t font) {
+    return g_renderer.drawStringStretch(x, y, scale, flags, maxChars, string, color, font);
+}
+
+int R_DrawKFontChar(int x, int y, int scale, int flags, uint32_t codepoint, color_t color, const kfont_t *kfont) {
+    return g_renderer.drawKFontChar(x, y, scale, flags, codepoint, color, kfont);
+}
+
+const kfont_char_t *SCR_KFontLookup(const kfont_t *kfont, uint32_t codepoint) {
+    return g_renderer.lookupKFontChar(kfont, codepoint);
+}
+
+void SCR_LoadKFont(kfont_t *font, const char *filename) {
+    g_renderer.loadKFont(font, filename);
+}
+
+bool R_GetPicSize(int *w, int *h, qhandle_t pic) {
+    return g_renderer.getPicSize(w, h, pic);
+}
+
+void R_DrawPic(int x, int y, color_t color, qhandle_t pic) {
+    g_renderer.drawPic(x, y, color, pic);
+}
+
+void R_DrawStretchPic(int x, int y, int w, int h, color_t color, qhandle_t pic) {
+    g_renderer.drawStretchPic(x, y, w, h, color, pic);
+}
+
+void R_DrawStretchRotatePic(int x, int y, int w, int h, color_t color, float angle, int pivot_x, int pivot_y, qhandle_t pic) {
+    g_renderer.drawStretchRotatePic(x, y, w, h, color, angle, pivot_x, pivot_y, pic);
+}
+
+void R_DrawKeepAspectPic(int x, int y, int w, int h, color_t color, qhandle_t pic) {
+    g_renderer.drawKeepAspectPic(x, y, w, h, color, pic);
+}
+
+void R_DrawStretchRaw(int x, int y, int w, int h) {
+    g_renderer.drawStretchRaw(x, y, w, h);
+}
+
+void R_UpdateRawPic(int pic_w, int pic_h, const uint32_t *pic) {
+    g_renderer.updateRawPic(pic_w, pic_h, pic);
+}
+
+void R_TileClear(int x, int y, int w, int h, qhandle_t pic) {
+    g_renderer.tileClear(x, y, w, h, pic);
+}
+
+void R_DrawFill8(int x, int y, int w, int h, int c) {
+    g_renderer.drawFill8(x, y, w, h, c);
+}
+
+void R_DrawFill32(int x, int y, int w, int h, color_t color) {
+    g_renderer.drawFill32(x, y, w, h, color);
+}
+
+void R_BeginFrame(void) {
+    g_renderer.beginFrame();
+}
+
+void R_EndFrame(void) {
+    g_renderer.endFrame();
+}
+
+void R_ModeChanged(int width, int height, int flags) {
+    g_renderer.modeChanged(width, height, flags);
+}
+
+bool R_VideoSync(void) {
+    return g_renderer.videoSync();
+}
+
+void GL_ExpireDebugObjects(void) {
+    g_renderer.expireDebugObjects();
+}
+
+bool R_SupportsPerPixelLighting(void) {
+    return g_renderer.supportsPerPixelLighting();
+}
+
+r_opengl_config_t R_GetGLConfig(void) {
+    return g_renderer.getGLConfig();
+}

--- a/src/refresh-vk/renderer.cpp
+++ b/src/refresh-vk/renderer.cpp
@@ -1,0 +1,406 @@
+#include "renderer.h"
+
+#include <algorithm>
+#include <cmath>
+
+refcfg_t r_config = {};
+unsigned r_registration_sequence = 0;
+
+namespace refresh::vk {
+
+namespace {
+    constexpr int kDefaultCharWidth = 8;
+    constexpr int kDefaultCharHeight = 8;
+
+    int countPrintable(std::string_view value, size_t maxChars) {
+        size_t count = 0;
+        for (char ch : value) {
+            if (ch == '\0') {
+                break;
+            }
+            if (maxChars && count >= maxChars) {
+                break;
+            }
+            ++count;
+        }
+        return static_cast<int>(count);
+    }
+
+    constexpr uint16_t defaultKFontWidth() {
+        return 16;
+    }
+
+    constexpr uint16_t defaultKFontHeight() {
+        return 16;
+    }
+}
+
+VulkanRenderer::VulkanRenderer()
+    : handleCounter_{1} {
+}
+
+VulkanRenderer::~VulkanRenderer() = default;
+
+qhandle_t VulkanRenderer::nextHandle() {
+    return handleCounter_.fetch_add(1, std::memory_order_relaxed);
+}
+
+qhandle_t VulkanRenderer::registerResource(NameLookup &lookup, std::string_view name) {
+    if (name.empty()) {
+        return 0;
+    }
+
+    std::string key{name};
+
+    if (auto it = lookup.find(key); it != lookup.end()) {
+        return it->second;
+    }
+
+    qhandle_t handle = nextHandle();
+    lookup.emplace(std::move(key), handle);
+    return handle;
+}
+
+void VulkanRenderer::resetTransientState() {
+    clipRect_.reset();
+    scale_ = 1.0f;
+    autoScaleValue_ = 1;
+}
+
+bool VulkanRenderer::init(bool total) {
+    if (!total) {
+        frameActive_ = false;
+        return true;
+    }
+
+    if (initialized_) {
+        return true;
+    }
+
+    Com_Printf("------- refresh-vk init -------\n");
+
+    r_config.width = SCREEN_WIDTH;
+    r_config.height = SCREEN_HEIGHT;
+    r_config.flags = {};
+
+    resetTransientState();
+
+    models_.clear();
+    images_.clear();
+    modelLookup_.clear();
+    imageLookup_.clear();
+    rawPic_ = {};
+
+    initialized_ = true;
+    r_registration_sequence = 1;
+
+    Com_Printf("refresh-vk initialized (placeholder implementation).\n");
+    Com_Printf("------------------------------\n");
+
+    return true;
+}
+
+void VulkanRenderer::shutdown(bool total) {
+    if (!initialized_) {
+        return;
+    }
+
+    if (frameActive_) {
+        endFrame();
+    }
+
+    if (total) {
+        models_.clear();
+        images_.clear();
+        modelLookup_.clear();
+        imageLookup_.clear();
+        rawPic_.pixels.clear();
+        currentMap_.clear();
+        resetTransientState();
+        initialized_ = false;
+    }
+}
+
+void VulkanRenderer::beginRegistration(const char *map) {
+    if (map) {
+        currentMap_ = map;
+    } else {
+        currentMap_.clear();
+    }
+
+    ++r_registration_sequence;
+}
+
+qhandle_t VulkanRenderer::registerModel(const char *name) {
+    if (!name || !*name) {
+        return 0;
+    }
+
+    qhandle_t handle = registerResource(modelLookup_, name);
+    auto &record = models_[handle];
+    record.handle = handle;
+    record.name = name;
+    record.registrationSequence = r_registration_sequence;
+
+    return handle;
+}
+
+qhandle_t VulkanRenderer::registerImage(const char *name, imagetype_t type, imageflags_t flags) {
+    if (!name || !*name) {
+        return 0;
+    }
+
+    qhandle_t handle = registerResource(imageLookup_, name);
+    auto &record = images_[handle];
+    record.handle = handle;
+    record.name = name;
+    record.type = type;
+    record.flags = flags;
+    record.registrationSequence = r_registration_sequence;
+    record.transparent = (flags & IF_TRANSPARENT) != 0;
+
+    if (flags & IF_SPECIAL) {
+        record.width = 1;
+        record.height = 1;
+    }
+
+    return handle;
+}
+
+void VulkanRenderer::setSky(const char *name, float rotate, bool autorotate, const vec3_t axis) {
+    sky_.name = name ? name : "";
+    sky_.rotate = rotate;
+    sky_.autorotate = autorotate;
+    if (axis) {
+        std::copy_n(axis, sky_.axis.size(), sky_.axis.begin());
+    }
+}
+
+void VulkanRenderer::endRegistration() {
+    auto predicate = [](auto &pair) {
+        return pair.second.registrationSequence != r_registration_sequence;
+    };
+
+    std::erase_if(models_, predicate);
+    std::erase_if(images_, predicate);
+}
+
+void VulkanRenderer::beginFrame() {
+    if (!initialized_) {
+        return;
+    }
+
+    if (vid && vid->pump_events) {
+        vid->pump_events();
+    }
+
+    frameActive_ = true;
+}
+
+void VulkanRenderer::endFrame() {
+    if (!initialized_ || !frameActive_) {
+        return;
+    }
+
+    if (vid && vid->swap_buffers) {
+        vid->swap_buffers();
+    }
+
+    frameActive_ = false;
+}
+
+void VulkanRenderer::renderFrame(const refdef_t *fd) {
+    if (!initialized_ || !fd) {
+        return;
+    }
+
+    // Placeholder implementation: update auto-scale using viewport height.
+    if (fd->height > 0) {
+        autoScaleValue_ = std::max(1, fd->height / SCREEN_HEIGHT);
+    }
+}
+
+void VulkanRenderer::lightPoint(const vec3_t origin, vec3_t light) const {
+    if (!light) {
+        return;
+    }
+
+    light[0] = 0.0f;
+    light[1] = 0.0f;
+    light[2] = 0.0f;
+}
+
+void VulkanRenderer::setClipRect(const clipRect_t *clip) {
+    if (clip) {
+        clipRect_ = *clip;
+    } else {
+        clipRect_.reset();
+    }
+}
+
+float VulkanRenderer::clampScale(cvar_t *var) const {
+    if (!var) {
+        return 1.0f;
+    }
+
+    float value = var->value;
+    if (!std::isfinite(value)) {
+        value = 1.0f;
+    }
+
+    constexpr float kMinScale = 0.25f;
+    constexpr float kMaxScale = 4.0f;
+    return std::clamp(value, kMinScale, kMaxScale);
+}
+
+void VulkanRenderer::setScale(float scale) {
+    if (!std::isfinite(scale)) {
+        scale_ = 1.0f;
+    } else {
+        scale_ = std::clamp(scale, 0.25f, 4.0f);
+    }
+}
+
+int VulkanRenderer::autoScale() const {
+    return autoScaleValue_;
+}
+
+void VulkanRenderer::drawChar(int x, int y, int flags, int ch, color_t color, qhandle_t font) {
+    drawStretchChar(x, y, kDefaultCharWidth, kDefaultCharHeight, flags, ch, color, font);
+}
+
+void VulkanRenderer::drawStretchChar(int, int, int, int, int, int, color_t, qhandle_t) {
+    // Intentionally left blank – drawing is handled by Vulkan backend in the future.
+}
+
+int VulkanRenderer::drawStringStretch(int x, int, int scale, int, size_t maxChars,
+                                      const char *string, color_t, qhandle_t) {
+    if (!string || !*string) {
+        return x;
+    }
+
+    std::string_view view{string};
+    int printable = countPrintable(view, maxChars);
+    int charWidth = std::max(1, scale) * kDefaultCharWidth;
+    return x + printable * charWidth;
+}
+
+int VulkanRenderer::drawKFontChar(int x, int, int scale, int, uint32_t codepoint,
+                                  color_t, const kfont_t *kfont) {
+    if (!kfont) {
+        return x;
+    }
+
+    const kfont_char_t *metrics = lookupKFontChar(kfont, codepoint);
+    if (!metrics) {
+        return x;
+    }
+
+    int advance = std::max(1, scale) * static_cast<int>(metrics->w);
+    return x + advance;
+}
+
+bool VulkanRenderer::getPicSize(int *w, int *h, qhandle_t pic) const {
+    auto it = images_.find(pic);
+    if (it == images_.end()) {
+        return false;
+    }
+
+    if (w) {
+        *w = it->second.width;
+    }
+    if (h) {
+        *h = it->second.height;
+    }
+    return it->second.transparent;
+}
+
+void VulkanRenderer::drawPic(int, int, color_t, qhandle_t) {
+}
+
+void VulkanRenderer::drawStretchPic(int, int, int, int, color_t, qhandle_t) {
+}
+
+void VulkanRenderer::drawStretchRotatePic(int, int, int, int, color_t, float, int, int, qhandle_t) {
+}
+
+void VulkanRenderer::drawKeepAspectPic(int, int, int, int, color_t, qhandle_t) {
+}
+
+void VulkanRenderer::drawStretchRaw(int, int, int, int) {
+}
+
+void VulkanRenderer::updateRawPic(int pic_w, int pic_h, const uint32_t *pic) {
+    if (pic_w <= 0 || pic_h <= 0 || !pic) {
+        rawPic_ = {};
+        return;
+    }
+
+    rawPic_.width = pic_w;
+    rawPic_.height = pic_h;
+    rawPic_.pixels.assign(pic, pic + (static_cast<size_t>(pic_w) * static_cast<size_t>(pic_h)));
+}
+
+void VulkanRenderer::tileClear(int, int, int, int, qhandle_t) {
+}
+
+void VulkanRenderer::drawFill8(int, int, int, int, int) {
+}
+
+void VulkanRenderer::drawFill32(int, int, int, int, color_t) {
+}
+
+void VulkanRenderer::modeChanged(int width, int height, int flags) {
+    r_config.width = width;
+    r_config.height = height;
+    r_config.flags = static_cast<vidFlags_t>(flags);
+}
+
+bool VulkanRenderer::videoSync() const {
+    return false;
+}
+
+void VulkanRenderer::expireDebugObjects() {
+}
+
+bool VulkanRenderer::supportsPerPixelLighting() const {
+    return false;
+}
+
+r_opengl_config_t VulkanRenderer::getGLConfig() const {
+    return {};
+}
+
+void VulkanRenderer::loadKFont(kfont_t *font, const char *filename) {
+    if (!font) {
+        return;
+    }
+
+    font->pic = registerImage(filename && *filename ? filename : "_kfont", IT_FONT, IF_PERMANENT);
+
+    uint16_t x = 0;
+    uint16_t y = 0;
+    for (auto &glyph : font->chars) {
+        glyph = { x, y, defaultKFontWidth(), defaultKFontHeight() };
+        x = static_cast<uint16_t>(x + glyph.w);
+    }
+
+    font->line_height = defaultKFontHeight();
+    font->sw = 1.0f;
+    font->sh = 1.0f;
+}
+
+const kfont_char_t *VulkanRenderer::lookupKFontChar(const kfont_t *kfont, uint32_t codepoint) const {
+    if (!kfont) {
+        return nullptr;
+    }
+
+    if (codepoint < KFONT_ASCII_MIN || codepoint > KFONT_ASCII_MAX) {
+        return nullptr;
+    }
+
+    size_t index = static_cast<size_t>(codepoint - KFONT_ASCII_MIN);
+    return &kfont->chars[index];
+}
+
+} // namespace refresh::vk

--- a/src/refresh-vk/renderer.h
+++ b/src/refresh-vk/renderer.h
@@ -1,0 +1,131 @@
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+#include "client/video.h"
+#include "common/cvar.h"
+#include "common/math.h"
+#include "common/common.h"
+#include "refresh/refresh.h"
+
+namespace refresh::vk {
+
+class VulkanRenderer {
+public:
+    VulkanRenderer();
+    ~VulkanRenderer();
+
+    bool init(bool total);
+    void shutdown(bool total);
+
+    void beginRegistration(const char *map);
+    qhandle_t registerModel(const char *name);
+    qhandle_t registerImage(const char *name, imagetype_t type, imageflags_t flags);
+    void setSky(const char *name, float rotate, bool autorotate, const vec3_t axis);
+    void endRegistration();
+
+    void beginFrame();
+    void endFrame();
+    void renderFrame(const refdef_t *fd);
+    void lightPoint(const vec3_t origin, vec3_t light) const;
+
+    void setClipRect(const clipRect_t *clip);
+    float clampScale(cvar_t *var) const;
+    void setScale(float scale);
+    int autoScale() const;
+
+    void drawChar(int x, int y, int flags, int ch, color_t color, qhandle_t font);
+    void drawStretchChar(int x, int y, int w, int h, int flags, int ch, color_t color, qhandle_t font);
+    int drawStringStretch(int x, int y, int scale, int flags, size_t maxChars,
+                          const char *string, color_t color, qhandle_t font);
+    int drawKFontChar(int x, int y, int scale, int flags, uint32_t codepoint,
+                      color_t color, const kfont_t *kfont);
+
+    bool getPicSize(int *w, int *h, qhandle_t pic) const;
+    void drawPic(int x, int y, color_t color, qhandle_t pic);
+    void drawStretchPic(int x, int y, int w, int h, color_t color, qhandle_t pic);
+    void drawStretchRotatePic(int x, int y, int w, int h, color_t color, float angle,
+                              int pivot_x, int pivot_y, qhandle_t pic);
+    void drawKeepAspectPic(int x, int y, int w, int h, color_t color, qhandle_t pic);
+    void drawStretchRaw(int x, int y, int w, int h);
+    void updateRawPic(int pic_w, int pic_h, const uint32_t *pic);
+    void tileClear(int x, int y, int w, int h, qhandle_t pic);
+    void drawFill8(int x, int y, int w, int h, int c);
+    void drawFill32(int x, int y, int w, int h, color_t color);
+
+    void modeChanged(int width, int height, int flags);
+    bool videoSync() const;
+    void expireDebugObjects();
+    bool supportsPerPixelLighting() const;
+    r_opengl_config_t getGLConfig() const;
+
+    void loadKFont(kfont_t *font, const char *filename);
+    const kfont_char_t *lookupKFontChar(const kfont_t *kfont, uint32_t codepoint) const;
+
+private:
+    struct SkyDefinition {
+        std::string name;
+        float rotate = 0.0f;
+        bool autorotate = false;
+        std::array<float, 3> axis{ 0.0f, 0.0f, 1.0f };
+    };
+
+    struct ModelRecord {
+        qhandle_t handle = 0;
+        std::string name;
+        unsigned registrationSequence = 0;
+    };
+
+    struct ImageRecord {
+        qhandle_t handle = 0;
+        std::string name;
+        imagetype_t type = IT_PIC;
+        imageflags_t flags = IF_NONE;
+        int width = 0;
+        int height = 0;
+        bool transparent = false;
+        unsigned registrationSequence = 0;
+    };
+
+    struct RawPicState {
+        int width = 0;
+        int height = 0;
+        std::vector<uint32_t> pixels;
+    };
+
+    using ModelMap = std::unordered_map<qhandle_t, ModelRecord>;
+    using ImageMap = std::unordered_map<qhandle_t, ImageRecord>;
+    using NameLookup = std::unordered_map<std::string, qhandle_t>;
+
+    qhandle_t nextHandle();
+    qhandle_t registerResource(NameLookup &lookup, std::string_view name);
+
+    void resetTransientState();
+
+    std::atomic<qhandle_t> handleCounter_;
+    bool initialized_ = false;
+    bool frameActive_ = false;
+
+    SkyDefinition sky_{};
+    std::string currentMap_;
+
+    std::optional<clipRect_t> clipRect_;
+    float scale_ = 1.0f;
+    int autoScaleValue_ = 1;
+
+    ModelMap models_;
+    ImageMap images_;
+    NameLookup modelLookup_;
+    NameLookup imageLookup_;
+    RawPicState rawPic_;
+};
+
+} // namespace refresh::vk
+
+


### PR DESCRIPTION
## Summary
- add a Meson option to pick between the legacy OpenGL renderer and a new refresh-vk backend
- implement the refresh-vk scaffold that stubs out the renderer entry points while keeping the API compatible

## Testing
- not run (meson unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ed44276de8832896ac9315cf97de4b