### PR TITLE
Implement Vulkan 2D quad batching

### DIFF
--- a/src/refresh-vk/renderer.cpp
+++ b/src/refresh-vk/renderer.cpp
@@ -6,8 +6,12 @@
 #include <array>
 #include <cmath>
 #include <cstring>
+#include <limits>
 
 #include "common/cmodel.h"
+#include "client/client.h"
+
+extern uint32_t d_8to24table[256];
 
 refcfg_t r_config = {};
 unsigned r_registration_sequence = 0;
@@ -49,6 +53,23 @@ namespace {
 
     std::array<float, 3> toArray(const vec3_t value) {
         return { value[0], value[1], value[2] };
+    }
+
+    std::array<std::array<float, 2>, 4> makeQuadPositions(float x0, float y0, float x1, float y1) {
+        return {{{ { x0, y0 }, { x1, y0 }, { x1, y1 }, { x0, y1 } }}};
+    }
+
+    std::array<std::array<float, 2>, 4> makeQuadUVs(float s0, float t0, float s1, float t1) {
+        return {{{ { s0, t0 }, { s1, t0 }, { s1, t1 }, { s0, t1 } }}};
+    }
+
+    void submitTexturedQuad(float x0, float y0, float x1, float y1,
+                            float s0, float t0, float s1, float t1,
+                            color_t color, qhandle_t texture) {
+        draw2d::submitQuad(makeQuadPositions(x0, y0, x1, y1),
+                           makeQuadUVs(s0, t0, s1, t1),
+                           color.u32,
+                           texture);
     }
 }
 
@@ -198,6 +219,13 @@ const VulkanRenderer::ModelRecord *VulkanRenderer::findModelRecord(qhandle_t han
     return nullptr;
 }
 
+const VulkanRenderer::ImageRecord *VulkanRenderer::findImageRecord(qhandle_t handle) const {
+    if (auto it = images_.find(handle); it != images_.end()) {
+        return &it->second;
+    }
+    return nullptr;
+}
+
 std::string_view VulkanRenderer::classifyModelName(const ModelRecord *record) const {
     if (!record || record->name.empty()) {
         return {};
@@ -332,6 +360,64 @@ void VulkanRenderer::submit2DDraw(const draw2d::Submission &submission) {
                 submission.vertexCount,
                 submission.indexCount,
                 static_cast<int>(submission.texture));
+}
+
+bool VulkanRenderer::canSubmit2D() const {
+    return frameActive_ && draw2d::isActive();
+}
+
+qhandle_t VulkanRenderer::ensureWhiteTexture() {
+    if (whiteTextureHandle_ != 0) {
+        if (images_.find(whiteTextureHandle_) != images_.end()) {
+            return whiteTextureHandle_;
+        }
+        whiteTextureHandle_ = 0;
+    }
+
+    qhandle_t handle = nextHandle();
+    whiteTextureHandle_ = handle;
+
+    ImageRecord record{};
+    record.handle = handle;
+    record.name = "__vk_white";
+    record.type = IT_PIC;
+    record.flags = static_cast<imageflags_t>(IF_SPECIAL | IF_PERMANENT);
+    record.width = 1;
+    record.height = 1;
+    record.transparent = false;
+    record.registrationSequence = r_registration_sequence;
+
+    images_[handle] = record;
+    imageLookup_[record.name] = handle;
+    return handle;
+}
+
+qhandle_t VulkanRenderer::ensureRawTexture() {
+    if (rawTextureHandle_ != 0) {
+        if (auto it = images_.find(rawTextureHandle_); it != images_.end()) {
+            it->second.width = rawPic_.width;
+            it->second.height = rawPic_.height;
+            return rawTextureHandle_;
+        }
+        rawTextureHandle_ = 0;
+    }
+
+    qhandle_t handle = nextHandle();
+    rawTextureHandle_ = handle;
+
+    ImageRecord record{};
+    record.handle = handle;
+    record.name = "__vk_raw";
+    record.type = IT_PIC;
+    record.flags = IF_SPECIAL;
+    record.width = rawPic_.width;
+    record.height = rawPic_.height;
+    record.transparent = true;
+    record.registrationSequence = r_registration_sequence;
+
+    images_[handle] = record;
+    imageLookup_[record.name] = handle;
+    return handle;
 }
 
 bool VulkanRenderer::init(bool total) {
@@ -622,6 +708,20 @@ void VulkanRenderer::lightPoint(const vec3_t origin, vec3_t light) const {
 }
 
 void VulkanRenderer::setClipRect(const clipRect_t *clip) {
+    bool changed = false;
+    if (clip) {
+        if (!clipRect_ || clipRect_->left != clip->left || clipRect_->right != clip->right ||
+            clipRect_->top != clip->top || clipRect_->bottom != clip->bottom) {
+            changed = true;
+        }
+    } else if (clipRect_) {
+        changed = true;
+    }
+
+    if (changed && draw2d::isActive()) {
+        draw2d::flush();
+    }
+
     if (clip) {
         clipRect_ = *clip;
     } else {
@@ -645,11 +745,16 @@ float VulkanRenderer::clampScale(cvar_t *var) const {
 }
 
 void VulkanRenderer::setScale(float scale) {
-    if (!std::isfinite(scale)) {
-        scale_ = 1.0f;
-    } else {
-        scale_ = std::clamp(scale, 0.25f, 4.0f);
+    float newScale = 1.0f;
+    if (std::isfinite(scale)) {
+        newScale = std::clamp(scale, 0.25f, 4.0f);
     }
+
+    if (std::abs(newScale - scale_) > std::numeric_limits<float>::epsilon() && draw2d::isActive()) {
+        draw2d::flush();
+    }
+
+    scale_ = newScale;
 }
 
 int VulkanRenderer::autoScale() const {
@@ -660,24 +765,94 @@ void VulkanRenderer::drawChar(int x, int y, int flags, int ch, color_t color, qh
     drawStretchChar(x, y, kDefaultCharWidth, kDefaultCharHeight, flags, ch, color, font);
 }
 
-void VulkanRenderer::drawStretchChar(int, int, int, int, int, int, color_t, qhandle_t) {
-    // Intentionally left blank – drawing is handled by Vulkan backend in the future.
+void VulkanRenderer::drawStretchChar(int x, int y, int w, int h, int flags, int ch, color_t color, qhandle_t font) {
+    if (!canSubmit2D()) {
+        return;
+    }
+
+    if (w <= 0 || h <= 0) {
+        return;
+    }
+
+    if (!findImageRecord(font)) {
+        return;
+    }
+
+    int glyph = ch & 0xFF;
+    if ((glyph & 127) == 32) {
+        return;
+    }
+
+    if (flags & UI_ALTCOLOR) {
+        glyph |= 0x80;
+    }
+    if (flags & UI_XORCOLOR) {
+        glyph ^= 0x80;
+    }
+
+    constexpr float kCell = 1.0f / 16.0f;
+    float s0 = (glyph & 15) * kCell;
+    float t0 = (glyph >> 4) * kCell;
+    float s1 = s0 + kCell;
+    float t1 = t0 + kCell;
+
+    auto submit = [&](int px, int py, color_t tint) {
+        submitTexturedQuad(static_cast<float>(px), static_cast<float>(py),
+                           static_cast<float>(px + w), static_cast<float>(py + h),
+                           s0, t0, s1, t1, tint, font);
+    };
+
+    if ((flags & UI_DROPSHADOW) && glyph != 0x83) {
+        color_t shadow = ColorA(color.a);
+        submit(x + 1, y + 1, shadow);
+    }
+
+    color_t finalColor = color;
+    if (glyph >> 7) {
+        finalColor = ColorSetAlpha(COLOR_WHITE, color.a);
+    }
+
+    submit(x, y, finalColor);
 }
 
-int VulkanRenderer::drawStringStretch(int x, int, int scale, int, size_t maxChars,
-                                      const char *string, color_t, qhandle_t) {
+int VulkanRenderer::drawStringStretch(int x, int y, int scale, int flags, size_t maxChars,
+                                      const char *string, color_t color, qhandle_t font) {
     if (!string || !*string) {
         return x;
     }
 
-    std::string_view view{string};
-    int printable = countPrintable(view, maxChars);
-    int charWidth = std::max(1, scale) * kDefaultCharWidth;
-    return x + printable * charWidth;
+    if (!canSubmit2D()) {
+        return x;
+    }
+
+    int effectiveScale = std::max(1, scale);
+    int charWidth = effectiveScale * kDefaultCharWidth;
+    int charHeight = effectiveScale * kDefaultCharHeight;
+    int cursorX = x;
+    int cursorY = y;
+    int lineStart = x;
+
+    size_t remaining = maxChars ? maxChars : std::numeric_limits<size_t>::max();
+    size_t processed = 0;
+    while (processed < remaining && string[processed]) {
+        unsigned char ch = static_cast<unsigned char>(string[processed]);
+        ++processed;
+
+        if ((flags & UI_MULTILINE) && ch == '\n') {
+            cursorY += charHeight;
+            cursorX = lineStart;
+            continue;
+        }
+
+        drawStretchChar(cursorX, cursorY, charWidth, charHeight, flags, ch, color, font);
+        cursorX += charWidth;
+    }
+
+    return cursorX;
 }
 
-int VulkanRenderer::drawKFontChar(int x, int, int scale, int, uint32_t codepoint,
-                                  color_t, const kfont_t *kfont) {
+int VulkanRenderer::drawKFontChar(int x, int y, int scale, int flags, uint32_t codepoint,
+                                  color_t color, const kfont_t *kfont) {
     if (!kfont) {
         return x;
     }
@@ -687,8 +862,40 @@ int VulkanRenderer::drawKFontChar(int x, int, int scale, int, uint32_t codepoint
         return x;
     }
 
-    int advance = std::max(1, scale) * static_cast<int>(metrics->w);
-    return x + advance;
+    if (!canSubmit2D()) {
+        return x;
+    }
+
+    int effectiveScale = std::max(1, scale);
+    int w = static_cast<int>(metrics->w) * effectiveScale;
+    int h = static_cast<int>(metrics->h) * effectiveScale;
+    if (w <= 0 || h <= 0) {
+        return x;
+    }
+
+    if (!findImageRecord(kfont->pic)) {
+        return x;
+    }
+
+    float s0 = metrics->x * kfont->sw;
+    float t0 = metrics->y * kfont->sh;
+    float s1 = s0 + metrics->w * kfont->sw;
+    float t1 = t0 + metrics->h * kfont->sh;
+
+    auto submit = [&](int px, int py, color_t tint) {
+        submitTexturedQuad(static_cast<float>(px), static_cast<float>(py),
+                           static_cast<float>(px + w), static_cast<float>(py + h),
+                           s0, t0, s1, t1, tint, kfont->pic);
+    };
+
+    if (flags & UI_DROPSHADOW) {
+        int offset = std::max(1, effectiveScale);
+        color_t shadow = ColorA(color.a);
+        submit(x + offset, y + offset, shadow);
+    }
+
+    submit(x, y, color);
+    return x + w;
 }
 
 bool VulkanRenderer::getPicSize(int *w, int *h, qhandle_t pic) const {
@@ -720,7 +927,7 @@ void VulkanRenderer::drawPic(int x, int y, color_t color, qhandle_t pic) {
 }
 
 void VulkanRenderer::drawStretchPic(int x, int y, int w, int h, color_t color, qhandle_t pic) {
-    if (!frameActive_ || !draw2d::isActive()) {
+    if (!canSubmit2D()) {
         return;
     }
 
@@ -728,33 +935,117 @@ void VulkanRenderer::drawStretchPic(int x, int y, int w, int h, color_t color, q
         return;
     }
 
-    std::array<std::array<float, 2>, 4> positions{{
-        {static_cast<float>(x), static_cast<float>(y)},
-        {static_cast<float>(x + w), static_cast<float>(y)},
-        {static_cast<float>(x + w), static_cast<float>(y + h)},
-        {static_cast<float>(x), static_cast<float>(y + h)}
-    }};
+    if (!findImageRecord(pic)) {
+        return;
+    }
 
-    std::array<std::array<float, 2>, 4> uvs{{
-        {0.0f, 0.0f},
-        {1.0f, 0.0f},
-        {1.0f, 1.0f},
-        {0.0f, 1.0f}
-    }};
-
-    draw2d::submitQuad(positions, uvs, color.u32, pic);
+    submitTexturedQuad(static_cast<float>(x), static_cast<float>(y),
+                       static_cast<float>(x + w), static_cast<float>(y + h),
+                       0.0f, 0.0f, 1.0f, 1.0f,
+                       color, pic);
 }
 
-void VulkanRenderer::drawStretchRotatePic(int, int, int, int, color_t, float, int, int, qhandle_t) {
+void VulkanRenderer::drawStretchRotatePic(int x, int y, int w, int h, color_t color, float angle, int pivot_x, int pivot_y, qhandle_t pic) {
+    if (!canSubmit2D()) {
+        return;
+    }
+
+    if (w <= 0 || h <= 0) {
+        return;
+    }
+
+    if (!findImageRecord(pic)) {
+        return;
+    }
+
+    float x0 = static_cast<float>(x);
+    float y0 = static_cast<float>(y);
+    float x1 = static_cast<float>(x + w);
+    float y1 = static_cast<float>(y + h);
+
+    auto positions = makeQuadPositions(x0, y0, x1, y1);
+    float originX = static_cast<float>(x + pivot_x);
+    float originY = static_cast<float>(y + pivot_y);
+    float radians = DEG2RAD(angle);
+    float sine = std::sin(radians);
+    float cosine = std::cos(radians);
+
+    for (auto &pos : positions) {
+        float dx = pos[0] - originX;
+        float dy = pos[1] - originY;
+        pos[0] = originX + dx * cosine - dy * sine;
+        pos[1] = originY + dx * sine + dy * cosine;
+    }
+
+    draw2d::submitQuad(positions, makeQuadUVs(0.0f, 0.0f, 1.0f, 1.0f), color.u32, pic);
 }
 
-void VulkanRenderer::drawKeepAspectPic(int, int, int, int, color_t, qhandle_t) {
+void VulkanRenderer::drawKeepAspectPic(int x, int y, int w, int h, color_t color, qhandle_t pic) {
+    if (!canSubmit2D()) {
+        return;
+    }
+
+    if (w <= 0 || h <= 0) {
+        return;
+    }
+
+    const ImageRecord *image = findImageRecord(pic);
+    if (!image) {
+        return;
+    }
+
+    if (image->flags & IF_SCRAP) {
+        drawStretchPic(x, y, w, h, color, pic);
+        return;
+    }
+
+    float aspect = 1.0f;
+    if (image->height > 0) {
+        aspect = static_cast<float>(image->width) / static_cast<float>(image->height);
+    }
+
+    float scaleW = static_cast<float>(w);
+    float scaleH = static_cast<float>(h) * aspect;
+    float scale = std::max(scaleW, scaleH);
+    if (scale <= 0.0f) {
+        return;
+    }
+
+    float s = (1.0f - scaleW / scale) * 0.5f;
+    float t = (1.0f - scaleH / scale) * 0.5f;
+    float s1 = 1.0f - s;
+    float t1 = 1.0f - t;
+
+    submitTexturedQuad(static_cast<float>(x), static_cast<float>(y),
+                       static_cast<float>(x + w), static_cast<float>(y + h),
+                       s, t, s1, t1, color, pic);
 }
 
-void VulkanRenderer::drawStretchRaw(int, int, int, int) {
+void VulkanRenderer::drawStretchRaw(int x, int y, int w, int h) {
+    if (!canSubmit2D()) {
+        return;
+    }
+
+    if (w <= 0 || h <= 0) {
+        return;
+    }
+
+    if (rawPic_.width <= 0 || rawPic_.height <= 0 || rawPic_.pixels.empty()) {
+        return;
+    }
+
+    qhandle_t texture = ensureRawTexture();
+    submitTexturedQuad(static_cast<float>(x), static_cast<float>(y),
+                       static_cast<float>(x + w), static_cast<float>(y + h),
+                       0.0f, 0.0f, 1.0f, 1.0f,
+                       COLOR_WHITE, texture);
 }
 
 void VulkanRenderer::updateRawPic(int pic_w, int pic_h, const uint32_t *pic) {
+    if (draw2d::isActive()) {
+        draw2d::flush();
+    }
+
     if (pic_w <= 0 || pic_h <= 0 || !pic) {
         rawPic_ = {};
         return;
@@ -765,13 +1056,64 @@ void VulkanRenderer::updateRawPic(int pic_w, int pic_h, const uint32_t *pic) {
     rawPic_.pixels.assign(pic, pic + (static_cast<size_t>(pic_w) * static_cast<size_t>(pic_h)));
 }
 
-void VulkanRenderer::tileClear(int, int, int, int, qhandle_t) {
+void VulkanRenderer::tileClear(int x, int y, int w, int h, qhandle_t pic) {
+    if (!canSubmit2D()) {
+        return;
+    }
+
+    if (w <= 0 || h <= 0) {
+        return;
+    }
+
+    if (!findImageRecord(pic)) {
+        return;
+    }
+
+    constexpr float kDiv64 = 1.0f / 64.0f;
+    float s0 = static_cast<float>(x) * kDiv64;
+    float t0 = static_cast<float>(y) * kDiv64;
+    float s1 = static_cast<float>(x + w) * kDiv64;
+    float t1 = static_cast<float>(y + h) * kDiv64;
+
+    submitTexturedQuad(static_cast<float>(x), static_cast<float>(y),
+                       static_cast<float>(x + w), static_cast<float>(y + h),
+                       s0, t0, s1, t1,
+                       COLOR_WHITE, pic);
 }
 
-void VulkanRenderer::drawFill8(int, int, int, int, int) {
+void VulkanRenderer::drawFill8(int x, int y, int w, int h, int c) {
+    if (!canSubmit2D()) {
+        return;
+    }
+
+    if (w <= 0 || h <= 0) {
+        return;
+    }
+
+    qhandle_t texture = ensureWhiteTexture();
+    color_t color = ColorU32(d_8to24table[c & 0xFF]);
+
+    submitTexturedQuad(static_cast<float>(x), static_cast<float>(y),
+                       static_cast<float>(x + w), static_cast<float>(y + h),
+                       0.0f, 0.0f, 1.0f, 1.0f,
+                       color, texture);
 }
 
-void VulkanRenderer::drawFill32(int, int, int, int, color_t) {
+void VulkanRenderer::drawFill32(int x, int y, int w, int h, color_t color) {
+    if (!canSubmit2D()) {
+        return;
+    }
+
+    if (w <= 0 || h <= 0) {
+        return;
+    }
+
+    qhandle_t texture = ensureWhiteTexture();
+
+    submitTexturedQuad(static_cast<float>(x), static_cast<float>(y),
+                       static_cast<float>(x + w), static_cast<float>(y + h),
+                       0.0f, 0.0f, 1.0f, 1.0f,
+                       color, texture);
 }
 
 void VulkanRenderer::modeChanged(int width, int height, int flags) {

--- a/src/refresh-vk/renderer.h
+++ b/src/refresh-vk/renderer.h
@@ -231,9 +231,13 @@ private:
     const PipelineDesc &ensurePipeline(PipelineKind kind);
     PipelineKind selectPipelineForEntity(const entity_t &ent) const;
     const ModelRecord *findModelRecord(qhandle_t handle) const;
+    const ImageRecord *findImageRecord(qhandle_t handle) const;
     std::string_view classifyModelName(const ModelRecord *record) const;
 
     void submit2DDraw(const draw2d::Submission &submission);
+    bool canSubmit2D() const;
+    qhandle_t ensureWhiteTexture();
+    qhandle_t ensureRawTexture();
 
     std::atomic<qhandle_t> handleCounter_;
     bool initialized_ = false;
@@ -257,6 +261,8 @@ private:
     NameLookup imageLookup_;
     RawPicState rawPic_;
     FrameState frameState_{};
+    qhandle_t whiteTextureHandle_ = 0;
+    qhandle_t rawTextureHandle_ = 0;
 
     std::unordered_map<PipelineKind, PipelineDesc, EnumHash> pipelines_;
 };


### PR DESCRIPTION
## Summary
- hook Vulkan 2D drawing entry points into the quad batching helper and replace immediate submissions with SubmitQuad
- add batching utilities for special textures and flush on clip/scale/raw updates to mirror GL behavior
- implement font, picture, fill, and raw draw paths using SubmitQuad-generated vertices

## Testing
- ninja -C dev *(fails: build.ninja missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ed54acbbb08328875b98257311883f