### PR TITLE
Add Vulkan platform surface hooks

### DIFF
--- a/inc/client/video.h
+++ b/inc/client/video.h
@@ -18,6 +18,30 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifndef VK_VERSION_1_0
+typedef struct VkInstance_T *VkInstance;
+typedef struct VkSurfaceKHR_T *VkSurfaceKHR;
+typedef struct VkAllocationCallbacks VkAllocationCallbacks;
+typedef enum VkResult VkResult;
+#endif
+
+typedef const char *const *(*vid_vk_get_instance_extensions_fn)(uint32_t *count);
+typedef VkResult (*vid_vk_create_surface_fn)(VkInstance instance,
+                                             const VkAllocationCallbacks *allocator,
+                                             VkSurfaceKHR *surface);
+typedef void (*vid_vk_destroy_surface_fn)(VkInstance instance,
+                                          VkSurfaceKHR surface,
+                                          const VkAllocationCallbacks *allocator);
+
+typedef struct {
+    vid_vk_get_instance_extensions_fn get_instance_extensions;
+    vid_vk_create_surface_fn create_surface;
+    vid_vk_destroy_surface_fn destroy_surface;
+} vid_vk_platform_t;
+
 typedef struct {
     const char *name;
 
@@ -45,6 +69,8 @@ typedef struct {
     void (*grab_mouse)(bool grab);
     void (*warp_mouse)(int x, int y);
     bool (*get_mouse_motion)(int *dx, int *dy);
+
+    vid_vk_platform_t vk;
 } vid_driver_t;
 
 extern cvar_t       *vid_geometry;

--- a/src/refresh-vk/renderer.h
+++ b/src/refresh-vk/renderer.h
@@ -75,6 +75,11 @@ public:
     void loadKFont(kfont_t *font, const char *filename);
     const kfont_char_t *lookupKFontChar(const kfont_t *kfont, uint32_t codepoint) const;
 
+    const std::vector<std::string> &platformInstanceExtensions() const;
+    bool createPlatformSurface(VkInstance instance, const VkAllocationCallbacks *allocator);
+    void destroyPlatformSurface(VkInstance instance, const VkAllocationCallbacks *allocator);
+    VkSurfaceKHR platformSurface() const;
+
 private:
     static constexpr size_t kKFontGlyphCount = static_cast<size_t>(KFONT_ASCII_MAX - KFONT_ASCII_MIN + 1);
 
@@ -300,6 +305,9 @@ private:
     qhandle_t ensureWhiteTexture();
     qhandle_t ensureRawTexture();
 
+    void initializePlatformHooks();
+    void collectPlatformInstanceExtensions();
+
     std::atomic<qhandle_t> handleCounter_;
     bool initialized_ = false;
     bool frameActive_ = false;
@@ -347,6 +355,17 @@ private:
     qhandle_t rawTextureHandle_ = 0;
 
     std::unordered_map<PipelineKind, PipelineDesc, EnumHash> pipelines_;
+
+    struct PlatformHooks {
+        vid_vk_get_instance_extensions_fn getInstanceExtensions = nullptr;
+        vid_vk_create_surface_fn createSurface = nullptr;
+        vid_vk_destroy_surface_fn destroySurface = nullptr;
+    };
+
+    PlatformHooks platformHooks_{};
+    std::vector<std::string> platformInstanceExtensions_;
+    VkInstance platformInstance_ = VK_NULL_HANDLE;
+    VkSurfaceKHR platformSurface_ = VK_NULL_HANDLE;
 };
 
 } // namespace refresh::vk


### PR DESCRIPTION
## Summary
- extend the video driver interface with Vulkan surface callbacks and extension queries
- teach the Vulkan renderer to collect platform extensions and manage surface creation/destroy helpers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ed87280d4483288dc1a0219a5721fd