### PR TITLE
Consolidate Vulkan frame state resets

### DIFF
--- a/src/refresh-vk/renderer.cpp
+++ b/src/refresh-vk/renderer.cpp
@@ -732,10 +732,13 @@ void VulkanRenderer::resetTransientState() {
     resetFrameState();
 }
 
-void VulkanRenderer::resetFrameState() {
+void VulkanRenderer::clearFrameTransientQueues() {
     frameQueues_.clear();
     framePrimitives_.clear();
     effectStreams_.clear();
+}
+
+void VulkanRenderer::resetFrameStatistics() {
     frameStats_.reset();
 }
 
@@ -4504,6 +4507,9 @@ const kfont_char_t *VulkanRenderer::lookupKFontChar(const kfont_t *kfont, uint32
 }
 
 void VulkanRenderer::resetFrameState() {
+    clearFrameTransientQueues();
+    resetFrameStatistics();
+
     frameState_.refdef = {};
     frameState_.entities.clear();
     frameState_.dlights.clear();

--- a/src/refresh-vk/renderer.h
+++ b/src/refresh-vk/renderer.h
@@ -348,6 +348,8 @@ private:
     qhandle_t registerResource(NameLookup &lookup, std::string_view name);
 
     void resetTransientState();
+    void clearFrameTransientQueues();
+    void resetFrameStatistics();
     void resetFrameState();
     void prepareFrameState(const refdef_t &fd);
     void allocateModelGeometry(ModelRecord &record, const model_t &model);


### PR DESCRIPTION
## Summary
- add helpers to clear transient frame queues and reset per-frame statistics
- consolidate frame state reset logic into a single implementation that clears queues, stats, and frame metadata
- ensure renderer lifecycle paths call the unified reset helper

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ed96dce7008328b5ebcca9a8aea8d5