### PR TITLE
Sort transparent queues in Vulkan renderer

### DIFF
--- a/src/refresh-vk/renderer.h
+++ b/src/refresh-vk/renderer.h
@@ -372,6 +372,7 @@ private:
     void renderWorld();
     void endWorldPass();
     void classifyEntities(const refdef_t &fd);
+    void sortTransparentQueues(const refdef_t &fd);
     void buildEffectBuffers(const refdef_t &fd);
     void recordDrawCall(const PipelineDesc &pipeline, std::string_view label, size_t count = 0);
     void recordStage(std::string_view label);


### PR DESCRIPTION
## Summary
- respect the gl_drawentities cvar when building Vulkan entity queues
- depth sort alpha-front and alpha-back entity lists to prepare for correct blended rendering
- call the new sort step during frame assembly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ed910e3bcc8328a7a9b2430b607283