### PR TITLE
Address Codex review feedback: preserve palette particle alpha

### DIFF
--- a/src/refresh-vk/renderer.cpp
+++ b/src/refresh-vk/renderer.cpp
@@ -938,6 +938,7 @@ void VulkanRenderer::buildEffectBuffers(const refdef_t &fd) {
             billboard.alpha = particle.alpha;
             if (particle.color != -1) {
                 billboard.color.u32 = d_8to24table[particle.color & 0xff];
+                billboard.color.a = 255;
             } else {
                 billboard.color = particle.rgba;
             }


### PR DESCRIPTION
## Summary
- set the alpha channel when loading palette-based particle colours so per-particle opacity works

## Testing
- Not run (not supported in environment)


------
https://chatgpt.com/codex/tasks/task_e_68ed9744add0832884a1c09ebedb956f