### PR TITLE
Fix font image lookup for Vulkan renderer

### DIFF
--- a/src/refresh-vk/renderer.cpp
+++ b/src/refresh-vk/renderer.cpp
@@ -3951,7 +3951,7 @@ void VulkanRenderer::loadKFont(kfont_t *font, const char *filename) {
         return;
     }
 
-    const image_t *image = IMG_ForHandle(record.texture);
+    const ImageRecord *image = findImageRecord(record.texture);
     if (!image || image->width <= 0 || image->height <= 0) {
         assignFallback();
         return;


### PR DESCRIPTION
## Summary
- load font dimensions from the Vulkan renderer's image records instead of the global image table

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ed97453df48328926f25b303b1b64c