### PR TITLE
Expose shared Vulkan renderer toggles after split

### DIFF
--- a/src/renderer_vk/frame.cpp
+++ b/src/renderer_vk/frame.cpp
@@ -92,13 +92,6 @@ std::string describeFogBits(refresh::vk::VulkanRenderer::FogBits bits) {
     return description;
 }
 
-cvar_t *vk_fog = nullptr;
-cvar_t *vk_bloom = nullptr;
-cvar_t *vk_polyblend = nullptr;
-cvar_t *vk_waterwarp = nullptr;
-cvar_t *vk_dynamic = nullptr;
-cvar_t *vk_perPixelLighting = nullptr;
-
 bool legacyToggleValue(const char *name, bool defaultValue) {
     if (!name || !*name) {
         return defaultValue;
@@ -108,6 +101,15 @@ bool legacyToggleValue(const char *name, bool defaultValue) {
     }
     return defaultValue;
 }
+
+} // namespace
+
+cvar_t *vk_fog = nullptr;
+cvar_t *vk_bloom = nullptr;
+cvar_t *vk_polyblend = nullptr;
+cvar_t *vk_waterwarp = nullptr;
+cvar_t *vk_dynamic = nullptr;
+cvar_t *vk_perPixelLighting = nullptr;
 
 bool resolveToggle(cvar_t *primary, const char *legacyName, bool defaultValue) {
     bool fallback = legacyToggleValue(legacyName, defaultValue);
@@ -120,8 +122,6 @@ bool resolveToggle(cvar_t *primary, const char *legacyName, bool defaultValue) {
     }
     return value > 0;
 }
-
-} // namespace
 
 model_t *MOD_Find(const char *name);
 

--- a/src/renderer_vk/renderer.h
+++ b/src/renderer_vk/renderer.h
@@ -19,6 +19,15 @@
 
 namespace refresh::vk {
 
+extern cvar_t *vk_fog;
+extern cvar_t *vk_bloom;
+extern cvar_t *vk_polyblend;
+extern cvar_t *vk_waterwarp;
+extern cvar_t *vk_dynamic;
+extern cvar_t *vk_perPixelLighting;
+
+bool resolveToggle(cvar_t *primary, const char *legacyName, bool defaultValue);
+
 namespace draw2d {
     struct Submission;
 }


### PR DESCRIPTION
## Summary
- expose the shared Vulkan renderer cvars so all translation units share the same definitions
- publish the resolveToggle helper alongside the shared cvars for modules that consult legacy switches

## Testing
- not run (environment lacks build tooling)

------
https://chatgpt.com/codex/tasks/task_e_68ee2cd920b48328abaae9762dd16005