### PR TITLE
Add Vulkan pipeline library stubs

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -220,6 +220,7 @@ elif renderer_opt == 'renderer_vk'
   refresh_src = [
     'src/renderer_vk/main.cpp',
     'src/renderer_vk/renderer.cpp',
+    'src/renderer_vk/pipeline.cpp',
     'src/renderer_vk/resources.cpp',
     'src/renderer_vk/device.cpp',
     'src/renderer_vk/frame.cpp',

--- a/src/renderer_vk/device.cpp
+++ b/src/renderer_vk/device.cpp
@@ -1,6 +1,7 @@
 #include "renderer.h"
 
 #include "renderer/common.h"
+#include "pipeline.h"
 
 #include <algorithm>
 #include <array>
@@ -713,6 +714,13 @@ bool VulkanRenderer::createDeviceResources() {
         return false;
     }
 
+    if (!pipelineLibrary_) {
+        pipelineLibrary_ = std::make_unique<PipelineLibrary>(*this);
+    }
+    if (pipelineLibrary_ && !pipelineLibrary_->initialize()) {
+        return false;
+    }
+
     if (!createSyncObjects()) {
         destroySwapchainResources();
         return false;
@@ -818,6 +826,10 @@ void VulkanRenderer::destroyDeviceResources() {
     destroySwapchainResources();
     destroyAllImageResources();
     destroyModelDescriptorResources();
+    if (pipelineLibrary_) {
+        pipelineLibrary_->shutdown();
+        pipelineLibrary_.reset();
+    }
     destroyDescriptorPool();
     destroyTextureDescriptorSetLayout();
     destroyCommandPool();

--- a/src/renderer_vk/frame.cpp
+++ b/src/renderer_vk/frame.cpp
@@ -308,6 +308,9 @@ const VulkanRenderer::PipelineDesc &VulkanRenderer::ensurePipeline(const Pipelin
     if (inserted) {
         frameStats_.pipelinesBound += 1;
     }
+    if (pipelineLibrary_) {
+        pipelineLibrary_->requestPipeline(key);
+    }
     return it->second;
 }
 VulkanRenderer::PipelineKind VulkanRenderer::selectPipelineForEntity(const entity_t &ent) const {
@@ -838,6 +841,14 @@ void VulkanRenderer::submit2DDraw(const draw2d::Submission &submission) {
     }
 
     VkCommandBuffer commandBuffer = frame.commandBuffer;
+
+    if (pipelineLibrary_) {
+        PipelineKey pipelineKey = buildPipelineKey(PipelineKind::Draw2D);
+        VkPipeline pipelineHandle = pipelineLibrary_->requestPipeline(pipelineKey);
+        if (pipelineHandle != VK_NULL_HANDLE) {
+            vkCmdBindPipeline(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipelineHandle);
+        }
+    }
 
     Draw2DBatch batch{};
     batch.vertexCount = submission.vertexCount;

--- a/src/renderer_vk/pipeline.cpp
+++ b/src/renderer_vk/pipeline.cpp
@@ -1,0 +1,265 @@
+#include "pipeline.h"
+
+#include "renderer.h"
+
+#include "renderer/common.h"
+
+#include "common/files.h"
+
+namespace refresh::vk {
+
+namespace {
+
+constexpr std::string_view shaderStageSuffix(VkShaderStageFlagBits stage) {
+    switch (stage) {
+    case VK_SHADER_STAGE_VERTEX_BIT:
+        return ".vert.spv";
+    case VK_SHADER_STAGE_FRAGMENT_BIT:
+        return ".frag.spv";
+    default:
+        return ".spv";
+    }
+}
+
+} // namespace
+
+PipelineLibrary::PipelineLibrary(VulkanRenderer &renderer)
+    : renderer_{renderer} {}
+
+PipelineLibrary::~PipelineLibrary() {
+    shutdown();
+}
+
+bool PipelineLibrary::initialize() {
+    pipelines_.clear();
+    return true;
+}
+
+void PipelineLibrary::shutdown() {
+    for (auto &[key, pipeline] : pipelines_) {
+        destroyPipelineObject(pipeline);
+    }
+    pipelines_.clear();
+}
+
+VkPipeline PipelineLibrary::requestPipeline(const VulkanRenderer::PipelineKey &key) {
+    if (auto it = pipelines_.find(key); it != pipelines_.end()) {
+        return it->second.handle;
+    }
+
+    PipelineObject object{};
+    object.desc = renderer_.makePipeline(key);
+
+    if (!createGraphicsPipeline(object)) {
+        destroyPipelineObject(object);
+        pipelines_.emplace(key, PipelineObject{});
+        return VK_NULL_HANDLE;
+    }
+
+    auto [it, inserted] = pipelines_.emplace(key, std::move(object));
+    if (!inserted) {
+        destroyPipelineObject(it->second);
+        it->second = std::move(object);
+    }
+
+    return it->second.handle;
+}
+
+PipelineLibrary::ShaderModule PipelineLibrary::loadShaderModule(std::string_view logicalName,
+                                                                VkShaderStageFlagBits stage) {
+    ShaderModule module{};
+
+    std::string filename;
+    filename.reserve(logicalName.size() + 16);
+    filename.append("vk/");
+    filename.append(logicalName);
+    filename.append(shaderStageSuffix(stage));
+
+    void *rawData = nullptr;
+    int fileLength = FS_LoadFile(filename.c_str(), &rawData);
+    if (fileLength <= 0 || !rawData) {
+        std::string altName{logicalName};
+        altName.append(shaderStageSuffix(stage));
+        fileLength = FS_LoadFile(altName.c_str(), &rawData);
+        if (fileLength <= 0 || !rawData) {
+            Com_Printf("refresh-vk: unable to load shader module %s.\n", filename.c_str());
+            return module;
+        }
+        filename = std::move(altName);
+    }
+
+    uint8_t *fileData = static_cast<uint8_t *>(rawData);
+    if (fileLength <= 0 || !fileData) {
+        Com_Printf("refresh-vk: failed to read shader module %s.\n", filename.c_str());
+        return module;
+    }
+
+    VkShaderModuleCreateInfo createInfo{};
+    createInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+    createInfo.codeSize = static_cast<size_t>(fileLength);
+    createInfo.pCode = reinterpret_cast<const uint32_t *>(fileData);
+
+    VkDevice device = renderer_.device();
+    if (device == VK_NULL_HANDLE) {
+        FS_FreeFile(fileData);
+        return module;
+    }
+
+    VkResult result = vkCreateShaderModule(device, &createInfo, nullptr, &module.handle);
+    if (result != VK_SUCCESS || module.handle == VK_NULL_HANDLE) {
+        Com_Printf("refresh-vk: failed to create shader module %s (VkResult %d).\n",
+                   filename.c_str(),
+                   static_cast<int>(result));
+        module.handle = VK_NULL_HANDLE;
+    }
+
+    module.name = filename;
+    FS_FreeFile(rawData);
+    return module;
+}
+
+void PipelineLibrary::destroyShaderModule(ShaderModule &module) const {
+    if (module.handle == VK_NULL_HANDLE) {
+        return;
+    }
+    VkDevice device = renderer_.device();
+    if (device != VK_NULL_HANDLE) {
+        vkDestroyShaderModule(device, module.handle, nullptr);
+    }
+    module.handle = VK_NULL_HANDLE;
+    module.name.clear();
+}
+
+void PipelineLibrary::destroyPipelineObject(PipelineObject &object) {
+    VkDevice device = renderer_.device();
+    if (device != VK_NULL_HANDLE && object.handle != VK_NULL_HANDLE) {
+        vkDestroyPipeline(device, object.handle, nullptr);
+        object.handle = VK_NULL_HANDLE;
+    }
+    destroyShaderModule(object.vertex);
+    destroyShaderModule(object.fragment);
+}
+
+bool PipelineLibrary::createGraphicsPipeline(PipelineObject &object) {
+    VkDevice device = renderer_.device();
+    VkRenderPass renderPass = renderer_.renderPass();
+    VkPipelineLayout layout = renderer_.pipelineLayoutFor(object.desc.key.kind);
+    if (device == VK_NULL_HANDLE || renderPass == VK_NULL_HANDLE || layout == VK_NULL_HANDLE) {
+        return false;
+    }
+
+    object.vertex = loadShaderModule(object.desc.debugName, VK_SHADER_STAGE_VERTEX_BIT);
+    object.fragment = loadShaderModule(object.desc.debugName, VK_SHADER_STAGE_FRAGMENT_BIT);
+    if (object.vertex.handle == VK_NULL_HANDLE || object.fragment.handle == VK_NULL_HANDLE) {
+        return false;
+    }
+
+    VkPipelineShaderStageCreateInfo stages[2]{};
+    stages[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    stages[0].stage = VK_SHADER_STAGE_VERTEX_BIT;
+    stages[0].module = object.vertex.handle;
+    stages[0].pName = "main";
+
+    stages[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    stages[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
+    stages[1].module = object.fragment.handle;
+    stages[1].pName = "main";
+
+    VkPipelineVertexInputStateCreateInfo vertexInput{};
+    vertexInput.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
+
+    VkPipelineInputAssemblyStateCreateInfo inputAssembly{};
+    inputAssembly.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
+    inputAssembly.topology = object.desc.topology;
+    inputAssembly.primitiveRestartEnable = VK_FALSE;
+
+    VkPipelineViewportStateCreateInfo viewportState{};
+    viewportState.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
+    viewportState.viewportCount = 1;
+    viewportState.scissorCount = 1;
+
+    VkPipelineRasterizationStateCreateInfo rasterizer{};
+    rasterizer.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
+    rasterizer.polygonMode = VK_POLYGON_MODE_FILL;
+    rasterizer.cullMode = VK_CULL_MODE_BACK_BIT;
+    rasterizer.frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+    rasterizer.lineWidth = 1.0f;
+
+    VkPipelineMultisampleStateCreateInfo multisample{};
+    multisample.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
+    multisample.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+
+    VkPipelineDepthStencilStateCreateInfo depthStencil{};
+    depthStencil.sType = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
+    depthStencil.depthTestEnable = object.desc.depthTest ? VK_TRUE : VK_FALSE;
+    depthStencil.depthWriteEnable = object.desc.depthWrite ? VK_TRUE : VK_FALSE;
+    depthStencil.depthCompareOp = VK_COMPARE_OP_LESS_OR_EQUAL;
+
+    VkPipelineColorBlendAttachmentState colorBlendAttachment{};
+    colorBlendAttachment.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
+                                         VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+    switch (object.desc.blend) {
+    case VulkanRenderer::PipelineDesc::BlendMode::Alpha:
+        colorBlendAttachment.blendEnable = VK_TRUE;
+        colorBlendAttachment.srcColorBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA;
+        colorBlendAttachment.dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+        colorBlendAttachment.colorBlendOp = VK_BLEND_OP_ADD;
+        colorBlendAttachment.srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
+        colorBlendAttachment.dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+        colorBlendAttachment.alphaBlendOp = VK_BLEND_OP_ADD;
+        break;
+    case VulkanRenderer::PipelineDesc::BlendMode::Additive:
+        colorBlendAttachment.blendEnable = VK_TRUE;
+        colorBlendAttachment.srcColorBlendFactor = VK_BLEND_FACTOR_ONE;
+        colorBlendAttachment.dstColorBlendFactor = VK_BLEND_FACTOR_ONE;
+        colorBlendAttachment.colorBlendOp = VK_BLEND_OP_ADD;
+        colorBlendAttachment.srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
+        colorBlendAttachment.dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
+        colorBlendAttachment.alphaBlendOp = VK_BLEND_OP_ADD;
+        break;
+    default:
+        colorBlendAttachment.blendEnable = VK_FALSE;
+        break;
+    }
+
+    VkPipelineColorBlendStateCreateInfo colorBlend{};
+    colorBlend.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
+    colorBlend.attachmentCount = 1;
+    colorBlend.pAttachments = &colorBlendAttachment;
+
+    VkDynamicState dynamics[] = { VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR };
+    VkPipelineDynamicStateCreateInfo dynamicState{};
+    dynamicState.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
+    dynamicState.dynamicStateCount = 2;
+    dynamicState.pDynamicStates = dynamics;
+
+    VkGraphicsPipelineCreateInfo pipelineInfo{};
+    pipelineInfo.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
+    pipelineInfo.stageCount = 2;
+    pipelineInfo.pStages = stages;
+    pipelineInfo.pVertexInputState = &vertexInput;
+    pipelineInfo.pInputAssemblyState = &inputAssembly;
+    pipelineInfo.pViewportState = &viewportState;
+    pipelineInfo.pRasterizationState = &rasterizer;
+    pipelineInfo.pMultisampleState = &multisample;
+    pipelineInfo.pDepthStencilState = &depthStencil;
+    pipelineInfo.pColorBlendState = &colorBlend;
+    pipelineInfo.pDynamicState = &dynamicState;
+    pipelineInfo.layout = layout;
+    pipelineInfo.renderPass = renderPass;
+    pipelineInfo.subpass = 0;
+
+    VkResult result = vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &object.handle);
+    if (result != VK_SUCCESS || object.handle == VK_NULL_HANDLE) {
+        Com_Printf("refresh-vk: failed to create pipeline %s (VkResult %d).\n",
+                   object.desc.debugName.c_str(),
+                   static_cast<int>(result));
+        object.handle = VK_NULL_HANDLE;
+        return false;
+    }
+
+    return true;
+}
+
+} // namespace refresh::vk
+

--- a/src/renderer_vk/pipeline.h
+++ b/src/renderer_vk/pipeline.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+#include <vulkan/vulkan_core.h>
+
+#include "renderer.h"
+
+namespace refresh::vk {
+
+class PipelineLibrary {
+public:
+    explicit PipelineLibrary(VulkanRenderer &renderer);
+    PipelineLibrary(const PipelineLibrary &) = delete;
+    PipelineLibrary &operator=(const PipelineLibrary &) = delete;
+    ~PipelineLibrary();
+
+    bool initialize();
+    void shutdown();
+
+    VkPipeline requestPipeline(const VulkanRenderer::PipelineKey &key);
+
+private:
+    struct ShaderModule {
+        VkShaderModule handle = VK_NULL_HANDLE;
+        std::string name;
+    };
+
+    struct PipelineObject {
+        VulkanRenderer::PipelineDesc desc;
+        ShaderModule vertex;
+        ShaderModule fragment;
+        VkPipeline handle = VK_NULL_HANDLE;
+    };
+
+    using PipelineMap = std::unordered_map<VulkanRenderer::PipelineKey, PipelineObject, VulkanRenderer::PipelineKeyHash>;
+
+    ShaderModule loadShaderModule(std::string_view logicalName, VkShaderStageFlagBits stage);
+    void destroyShaderModule(ShaderModule &module) const;
+    void destroyPipelineObject(PipelineObject &object);
+    bool createGraphicsPipeline(PipelineObject &object);
+
+    VulkanRenderer &renderer_;
+    PipelineMap pipelines_;
+};
+
+} // namespace refresh::vk
+

--- a/src/renderer_vk/renderer.cpp
+++ b/src/renderer_vk/renderer.cpp
@@ -7,4 +7,11 @@ VulkanRenderer::VulkanRenderer()
 
 VulkanRenderer::~VulkanRenderer() = default;
 
+VkPipelineLayout VulkanRenderer::pipelineLayoutFor(PipelineKind kind) const {
+    switch (kind) {
+    default:
+        return modelPipelineLayout_;
+    }
+}
+
 } // namespace refresh::vk

--- a/src/renderer_vk/renderer.h
+++ b/src/renderer_vk/renderer.h
@@ -3,6 +3,7 @@
 #include <array>
 #include <atomic>
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -22,6 +23,8 @@ namespace refresh::vk {
 namespace draw2d {
     struct Submission;
 }
+
+class PipelineLibrary;
 
 class VulkanRenderer {
 public:
@@ -80,7 +83,12 @@ public:
     void destroyPlatformSurface(VkInstance instance, const VkAllocationCallbacks *allocator);
     VkSurfaceKHR platformSurface() const;
 
+    VkDevice device() const { return device_; }
+    VkRenderPass renderPass() const { return renderPass_; }
+    VkPipelineLayout pipelineLayoutFor(PipelineKind kind) const;
+
 private:
+    friend class PipelineLibrary;
     static constexpr size_t kKFontGlyphCount = static_cast<size_t>(KFONT_ASCII_MAX - KFONT_ASCII_MIN + 1);
 
     enum FogBits : uint32_t {
@@ -528,6 +536,7 @@ private:
     std::vector<Draw2DBatch> frame2DBatches_{};
 
     std::unordered_map<PipelineKey, PipelineDesc, PipelineKeyHash> pipelines_;
+    std::unique_ptr<PipelineLibrary> pipelineLibrary_;
 
     struct PlatformHooks {
         vid_vk_get_instance_extensions_fn getInstanceExtensions = nullptr;


### PR DESCRIPTION
## Summary
- add a pipeline library that loads shader modules and creates graphics pipelines on demand
- wire the Vulkan renderer to own the pipeline library and initialize it during device setup
- bind the draw2d pipeline and request pipeline creation when recording draw calls

## Testing
- ninja -C build *(fails: build directory not generated in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ee76a181a48328b53f23d9a3c287c8