### PR TITLE
Implement Vulkan world render command flow

### DIFF
--- a/src/renderer_vk/frame.cpp
+++ b/src/renderer_vk/frame.cpp
@@ -160,6 +160,9 @@ void VulkanRenderer::clearFrameTransientQueues() {
     frameQueues_.clear();
     framePrimitives_.clear();
     effectStreams_.clear();
+    for (auto &bucket : worldSurfaceBuckets_) {
+        bucket.clear();
+    }
 }
 void VulkanRenderer::resetFrameStatistics() {
     frameStats_.reset();
@@ -2115,7 +2118,186 @@ void VulkanRenderer::beginWorldPass() {
     frameState_.worldRendered = false;
 }
 void VulkanRenderer::renderWorld() {
-    frameState_.worldRendered = true;
+    frameState_.worldRendered = false;
+
+    if (!frameState_.inWorldPass) {
+        return;
+    }
+
+    if (inFlightFrames_.empty() || currentFrameIndex_ >= inFlightFrames_.size()) {
+        return;
+    }
+
+    InFlightFrame &frame = inFlightFrames_[currentFrameIndex_];
+    VkCommandBuffer commandBuffer = frame.commandBuffer;
+    if (commandBuffer == VK_NULL_HANDLE) {
+        return;
+    }
+
+    if (worldVertexBuffer_.buffer == VK_NULL_HANDLE || worldVertexBuffer_.size == 0) {
+        return;
+    }
+
+    bool hasDrawData = false;
+    for (const auto &bucket : worldSurfaceBuckets_) {
+        for (const WorldDrawCommand &draw : bucket) {
+            if (draw.indexCount > 0 || draw.vertexCount > 0) {
+                hasDrawData = true;
+                break;
+            }
+        }
+        if (hasDrawData) {
+            break;
+        }
+    }
+
+    if (!hasDrawData) {
+        return;
+    }
+
+    PipelineKey pipelineKey = buildPipelineKey(PipelineKind::InlineBsp);
+    const PipelineDesc &pipeline = ensurePipeline(pipelineKey);
+
+    VkPipeline pipelineHandle = VK_NULL_HANDLE;
+    if (pipelineLibrary_) {
+        pipelineHandle = pipelineLibrary_->requestPipeline(pipelineKey);
+    }
+    if (pipelineHandle == VK_NULL_HANDLE) {
+        return;
+    }
+
+    vkCmdBindPipeline(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipelineHandle);
+
+    std::string pipelineEntry{"bind.pipeline."};
+    pipelineEntry.append(pipeline.debugName);
+    commandLog_.push_back(std::move(pipelineEntry));
+
+    VkBuffer vertexBuffers[] = { worldVertexBuffer_.buffer };
+    VkDeviceSize vertexOffsets[] = { worldVertexBuffer_.offset };
+    vkCmdBindVertexBuffers(commandBuffer, 0, 1, vertexBuffers, vertexOffsets);
+
+    const bool hasIndexBuffer = worldIndexBuffer_.buffer != VK_NULL_HANDLE && worldIndexBuffer_.size > 0;
+    if (hasIndexBuffer) {
+        vkCmdBindIndexBuffer(commandBuffer, worldIndexBuffer_.buffer, worldIndexBuffer_.offset, worldIndexType_);
+    }
+
+    EntityPushConstants constants{};
+    constants.modelMatrix = {
+        1.0f, 0.0f, 0.0f, 0.0f,
+        0.0f, 1.0f, 0.0f, 0.0f,
+        0.0f, 0.0f, 1.0f, 0.0f,
+        0.0f, 0.0f, 0.0f, 1.0f,
+    };
+    constants.color = { 1.0f, 1.0f, 1.0f, 1.0f };
+    constants.lighting.fill(0.0f);
+    if (frameState_.hasLightstyles) {
+        size_t count = std::min(constants.lighting.size(), frameState_.lightstyles.size());
+        for (size_t i = 0; i < count; ++i) {
+            constants.lighting[i] = frameState_.lightstyles[i].white;
+        }
+    }
+    constants.misc = { 0.0f, 0.0f, 0.0f, 0.0f };
+    constants.indices = {
+        static_cast<uint32_t>(frameState_.fogBits),
+        static_cast<uint32_t>(frameState_.fogBitsSky),
+        static_cast<uint32_t>(std::max(frameState_.dynamicLightCount, 0)),
+        frameState_.dynamicLightsUploaded ? 1u : 0u,
+    };
+
+    if (modelPipelineLayout_ != VK_NULL_HANDLE) {
+        vkCmdPushConstants(commandBuffer,
+                           modelPipelineLayout_,
+                           VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT,
+                           0,
+                           sizeof(EntityPushConstants),
+                           &constants);
+    }
+
+    auto drawBucket = [&](const std::vector<WorldDrawCommand> &bucket, std::string_view label) {
+        size_t submitted = 0;
+
+        for (const WorldDrawCommand &draw : bucket) {
+            if (draw.indexCount == 0 && draw.vertexCount == 0) {
+                continue;
+            }
+
+            if (draw.geometry.set != VK_NULL_HANDLE && modelPipelineLayout_ != VK_NULL_HANDLE) {
+                vkCmdBindDescriptorSets(commandBuffer,
+                                        VK_PIPELINE_BIND_POINT_GRAPHICS,
+                                        modelPipelineLayout_,
+                                        0,
+                                        1,
+                                        &draw.geometry.set,
+                                        0,
+                                        nullptr);
+            }
+
+            if (draw.diffuse != VK_NULL_HANDLE && modelPipelineLayout_ != VK_NULL_HANDLE) {
+                vkCmdBindDescriptorSets(commandBuffer,
+                                        VK_PIPELINE_BIND_POINT_GRAPHICS,
+                                        modelPipelineLayout_,
+                                        1,
+                                        1,
+                                        &draw.diffuse,
+                                        0,
+                                        nullptr);
+            }
+
+            if (draw.lightmap != VK_NULL_HANDLE && modelPipelineLayout_ != VK_NULL_HANDLE) {
+                vkCmdBindDescriptorSets(commandBuffer,
+                                        VK_PIPELINE_BIND_POINT_GRAPHICS,
+                                        modelPipelineLayout_,
+                                        2,
+                                        1,
+                                        &draw.lightmap,
+                                        0,
+                                        nullptr);
+            }
+
+            if (draw.dynamicLights != VK_NULL_HANDLE && modelPipelineLayout_ != VK_NULL_HANDLE) {
+                vkCmdBindDescriptorSets(commandBuffer,
+                                        VK_PIPELINE_BIND_POINT_GRAPHICS,
+                                        modelPipelineLayout_,
+                                        3,
+                                        1,
+                                        &draw.dynamicLights,
+                                        0,
+                                        nullptr);
+            }
+
+            if (draw.indexCount > 0 && hasIndexBuffer) {
+                vkCmdDrawIndexed(commandBuffer,
+                                 draw.indexCount,
+                                 1,
+                                 draw.firstIndex,
+                                 draw.vertexOffset,
+                                 0);
+                ++submitted;
+            } else if (draw.vertexCount > 0 && draw.vertexOffset >= 0) {
+                vkCmdDraw(commandBuffer,
+                          draw.vertexCount,
+                          1,
+                          static_cast<uint32_t>(draw.vertexOffset),
+                          0);
+                ++submitted;
+            }
+        }
+
+        if (submitted > 0) {
+            recordDrawCall(pipeline, label, submitted);
+        }
+
+        return submitted;
+    };
+
+    size_t totalDraws = 0;
+    totalDraws += drawBucket(worldSurfaceBuckets_[0], "world.opaque");
+    totalDraws += drawBucket(worldSurfaceBuckets_[1], "world.alpha");
+    totalDraws += drawBucket(worldSurfaceBuckets_[2], "world.sky");
+
+    if (totalDraws > 0) {
+        frameState_.worldRendered = true;
+    }
 }
 void VulkanRenderer::endWorldPass() {
     frameState_.inWorldPass = false;

--- a/src/renderer_vk/renderer.h
+++ b/src/renderer_vk/renderer.h
@@ -364,6 +364,17 @@ private:
         VkExtent2D extent{ 0u, 0u };
     };
 
+    struct WorldDrawCommand {
+        ModelRecord::DescriptorReference geometry{};
+        VkDescriptorSet diffuse = VK_NULL_HANDLE;
+        VkDescriptorSet lightmap = VK_NULL_HANDLE;
+        VkDescriptorSet dynamicLights = VK_NULL_HANDLE;
+        uint32_t firstIndex = 0;
+        uint32_t indexCount = 0;
+        int32_t vertexOffset = 0;
+        uint32_t vertexCount = 0;
+    };
+
     struct Draw2DBatch {
         ModelRecord::BufferAllocationInfo vertex;
         ModelRecord::BufferAllocationInfo index;
@@ -513,6 +524,11 @@ private:
 
     SkyDefinition sky_{};
     std::string currentMap_;
+
+    ModelRecord::BufferAllocationInfo worldVertexBuffer_{};
+    ModelRecord::BufferAllocationInfo worldIndexBuffer_{};
+    VkIndexType worldIndexType_ = VK_INDEX_TYPE_UINT16;
+    std::array<std::vector<WorldDrawCommand>, 3> worldSurfaceBuckets_{};
 
     struct VideoGeometry {
         int width = SCREEN_WIDTH;


### PR DESCRIPTION
## Summary
- add cached world draw command structures and state tracking to the Vulkan renderer
- reset world surface buckets each frame to avoid stale draw commands
- implement renderWorld to bind inline BSP resources, issue draw calls, and log statistics only when geometry is submitted

## Testing
- not run (build configuration not available)


------
https://chatgpt.com/codex/tasks/task_e_68eea6fe2ab88328826cb383c7911bf9