### PR TITLE
Reset world visibility cache on BSP changes

### DIFF
--- a/src/renderer_vk/frame.cpp
+++ b/src/renderer_vk/frame.cpp
@@ -1002,6 +1002,9 @@ void VulkanRenderer::beginRegistration(const char *map) {
         currentMap_.clear();
     }
 
+    currentBsp_ = nullptr;
+    resetWorldVisibilityState();
+
     ++r_registration_sequence;
 }
 qhandle_t VulkanRenderer::registerModel(const char *name) {
@@ -2117,6 +2120,13 @@ void VulkanRenderer::uploadDynamicLights() {
 void VulkanRenderer::updateSkyState() {
     frameState_.skyActive = !sky_.name.empty();
 }
+
+void VulkanRenderer::resetWorldVisibilityState() {
+    worldVisFrame_ = 0u;
+    worldDrawFrame_ = 0u;
+    worldViewCluster1_ = -1;
+    worldViewCluster2_ = -1;
+}
 namespace {
 
 constexpr int kNodeClipped = 0;
@@ -2143,6 +2153,11 @@ void VulkanRenderer::renderWorld() {
     const bsp_t *bsp = cl.bsp;
     if (!bsp || !bsp->nodes) {
         return;
+    }
+
+    if (bsp != currentBsp_) {
+        resetWorldVisibilityState();
+        currentBsp_ = bsp;
     }
 
     markVisibleNodes(bsp);

--- a/src/renderer_vk/renderer.h
+++ b/src/renderer_vk/renderer.h
@@ -456,6 +456,7 @@ private:
     void evaluateFrameSettings();
     void uploadDynamicLights();
     void updateSkyState();
+    void resetWorldVisibilityState();
     void beginWorldPass();
     void renderWorld();
     void endWorldPass();
@@ -542,6 +543,7 @@ private:
     unsigned int worldDrawFrame_ = 0;
     int worldViewCluster1_ = -1;
     int worldViewCluster2_ = -1;
+    const bsp_t *currentBsp_ = nullptr;
 
     SkyDefinition sky_{};
     std::string currentMap_;


### PR DESCRIPTION
## Summary
- reset world visibility counters whenever registration starts or the active BSP pointer changes
- track the currently bound BSP pointer to detect map transitions during world rendering

## Testing
- not run (build directory not configured)

------
https://chatgpt.com/codex/tasks/task_e_68eeabdfca088328ae10e70cb4acf801