### PR TITLE
Fix post-process render pass layout dependency

### DIFF
--- a/src/renderer_vk/device.cpp
+++ b/src/renderer_vk/device.cpp
@@ -1129,7 +1129,7 @@ bool VulkanRenderer::createPostProcessResources() {
     attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
     attachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
     attachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-    attachment.initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    attachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     attachment.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
     VkAttachmentReference colorRef{};
@@ -1144,7 +1144,7 @@ bool VulkanRenderer::createPostProcessResources() {
     VkSubpassDependency dependency{};
     dependency.srcSubpass = VK_SUBPASS_EXTERNAL;
     dependency.dstSubpass = 0;
-    dependency.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    dependency.srcStageMask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
     dependency.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
     dependency.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
 


### PR DESCRIPTION
## Summary
- set the post-process color attachment to start from VK_IMAGE_LAYOUT_UNDEFINED
- adjust the external dependency to transition from top-of-pipe to color attachment output

## Testing
- meson setup builddir *(fails: `meson` not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eeafd91f488328a373f15349cd6fc8