### PR TITLE
Handle offscreen target bind failure

### DIFF
--- a/src/renderer_vk/device.cpp
+++ b/src/renderer_vk/device.cpp
@@ -1049,7 +1049,12 @@ bool VulkanRenderer::createOffscreenTarget(OffscreenTarget &target, VkExtent2D e
         return false;
     }
 
-    vkBindImageMemory(device_, target.image, target.memory, 0);
+    VkResult bindResult = vkBindImageMemory(device_, target.image, target.memory, 0);
+    if (bindResult != VK_SUCCESS) {
+        Com_Printf("refresh-vk: failed to bind offscreen image memory (VkResult %d).\n", static_cast<int>(bindResult));
+        destroyOffscreenTarget(target);
+        return false;
+    }
 
     VkImageViewCreateInfo viewInfo{};
     viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;


### PR DESCRIPTION
## Summary
- capture the VkResult when binding offscreen image memory and log failures
- clean up partially created offscreen targets and propagate failure to the caller
- confirmed existing offscreen target call sites already handle a false return by tearing down post-process resources

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eeafde36508328acafc0d8c273440b