### PR TITLE
Add decal pipeline scaffolding

### DIFF
--- a/src/renderer_vk/frame.cpp
+++ b/src/renderer_vk/frame.cpp
@@ -195,6 +195,13 @@ VulkanRenderer::PipelineDesc VulkanRenderer::makePipeline(const PipelineKey &key
     case PipelineKind::InlineBsp:
         desc.debugName = "inline_bsp";
         break;
+    case PipelineKind::Decal:
+        desc.debugName = "decal";
+        desc.blend = PipelineDesc::BlendMode::Alpha;
+        desc.depthWrite = false;
+        desc.textured = true;
+        desc.usesFog = false;
+        break;
     case PipelineKind::Alias:
         desc.debugName = "alias";
         break;
@@ -289,6 +296,7 @@ VulkanRenderer::PipelineKey VulkanRenderer::buildPipelineKey(PipelineKind kind) 
 
     switch (kind) {
     case PipelineKind::InlineBsp:
+    case PipelineKind::Decal:
         key.fogBits = frameState_.fogBits;
         key.fogSkyBits = frameState_.fogBitsSky;
         key.perPixelLighting = frameState_.perPixelLighting;
@@ -2576,6 +2584,7 @@ void VulkanRenderer::gatherNodeSurfaces(const mnode_t *node, int clipFlags) {
     totalDraws += drawBucket(worldSurfaceBuckets_[0], "world.opaque");
     totalDraws += drawBucket(worldSurfaceBuckets_[1], "world.alpha");
     totalDraws += drawBucket(worldSurfaceBuckets_[2], "world.sky");
+    totalDraws += drawBucket(worldSurfaceBuckets_[3], "world.decal");
 
     if (totalDraws > 0) {
         frameState_.worldRendered = true;

--- a/src/renderer_vk/renderer.h
+++ b/src/renderer_vk/renderer.h
@@ -101,6 +101,7 @@ private:
   
     enum class PipelineKind {
         InlineBsp,
+        Decal,
         Alias,
         Sprite,
         Weapon,
@@ -549,7 +550,7 @@ private:
     ModelRecord::BufferAllocationInfo worldVertexBuffer_{};
     ModelRecord::BufferAllocationInfo worldIndexBuffer_{};
     VkIndexType worldIndexType_ = VK_INDEX_TYPE_UINT16;
-    std::array<std::vector<WorldDrawCommand>, 3> worldSurfaceBuckets_{};
+    std::array<std::vector<WorldDrawCommand>, 4> worldSurfaceBuckets_{};
 
     struct VideoGeometry {
         int width = SCREEN_WIDTH;


### PR DESCRIPTION
## Summary
- add a Decal pipeline kind to the Vulkan renderer enumeration
- configure pipeline descriptors to build the new decal pipeline and reserve a render bucket slot

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eebd0574a083288dbe90ce45c5a8b9