### PR TITLE
Add Meson build directory setup helper script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 /subprojects/*/
 !/subprojects/packagefiles/
 !/subprojects/rerelease-game/
+/build*
+/builddir/
+/meson-info/
+/meson-logs/
+/meson-private/
 /tags
 /TAGS
 .vs/

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -50,6 +50,17 @@ Setup build directory (arbitrary name can be used instead of `builddir`):
 
     meson setup builddir
 
+If you prefer an automated helper that also prepares a Meson development
+environment shell, you can use the provided script:
+
+    ./dev/setup_meson_env.sh
+
+The script accepts a `-b` flag to choose a different build directory and passes
+any arguments after `--` straight to `meson setup`. By default it will spawn a
+shell inside `meson devenv` so the project can be built and run with the
+correct environment variables already configured. Use `-c "command"` to run a
+specific command inside the environment or `-n` to skip launching the shell.
+
 Review and configure options:
 
     meson configure builddir

--- a/dev/setup_meson_env.sh
+++ b/dev/setup_meson_env.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+#
+# Helper script to create or reconfigure a Meson build directory and optionally
+# start a Meson development environment shell.
+#
+set -eu
+
+usage() {
+  cat <<USAGE
+Usage: $0 [-b builddir] [-c command] [-n] [-- meson-setup-args...]
+
+Options:
+  -b builddir  Location of the Meson build directory (default: builddir)
+  -c command   Command to execute via "sh -c" inside meson devenv
+  -n           Do not start the Meson development environment after setup
+  -h           Show this help message
+
+All arguments after "--" are passed directly to "meson setup".
+If no command is provided, an interactive shell is started inside meson devenv.
+USAGE
+}
+
+builddir="builddir"
+run_devenv=true
+devenv_command=""
+
+while getopts "b:c:nh" opt; do
+  case "${opt}" in
+    b)
+      builddir="${OPTARG}"
+      ;;
+    c)
+      devenv_command="${OPTARG}"
+      ;;
+    n)
+      run_devenv=false
+      ;;
+    h)
+      usage
+      exit 0
+      ;;
+    \?)
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+if [ "${builddir}" = "" ]; then
+  echo "error: build directory path cannot be empty" >&2
+  exit 1
+fi
+
+if [ -d "${builddir}/meson-private" ]; then
+  echo "Reconfiguring existing Meson build directory: ${builddir}"
+  meson setup --reconfigure "${builddir}" "$@"
+else
+  echo "Creating Meson build directory: ${builddir}"
+  meson setup "${builddir}" "$@"
+fi
+
+if ${run_devenv}; then
+  if [ -n "${devenv_command}" ]; then
+    echo "Starting Meson development environment in '${builddir}' (command: ${devenv_command})"
+    meson devenv -C "${builddir}" -- "${SHELL:-/bin/sh}" -c "${devenv_command}"
+  else
+    echo "Starting interactive Meson development environment in '${builddir}'"
+    meson devenv -C "${builddir}"
+  fi
+else
+  cat <<INFO
+Meson build directory '${builddir}' is ready.
+Run 'meson compile -C ${builddir}' to build the project.
+Run 'meson devenv -C ${builddir}' to enter the development environment.
+INFO
+fi


### PR DESCRIPTION
## Summary
- add a helper script for creating/reconfiguring Meson build directories and entering a devenv shell
- document the helper usage in BUILDING.md
- ignore common Meson build output directories

## Testing
- not run (tooling-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68eee3c3edb48328ac335ebde3d588f5