### PR TITLE
Add C linkage guards to zone header

### DIFF
--- a/inc/common/zone.h
+++ b/inc/common/zone.h
@@ -67,6 +67,10 @@ typedef enum {
     TAG_MAX
 } memtag_t;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void    Z_Init(void);
 void    Z_Free(void *ptr);
 void    Z_Freep(void *ptr);
@@ -88,3 +92,7 @@ void    Z_Stats_f(void);
 
 // may return pointer to static memory
 char    *Z_CvarCopyString(const char *in);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
## Summary
- wrap the zone allocator API declarations with C linkage guards so C++ translation units use unmangled symbols
- rely on existing inclusion of the updated header from the C++ implementation to propagate the linkage specification

## Testing
- meson setup build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f2c17f7f1483288a02b82051cb0a8c