### PR TITLE
Ensure persistent bloom draw buffer array

### DIFF
--- a/src/refresh/shader.cpp
+++ b/src/refresh/shader.cpp
@@ -966,11 +966,12 @@ static void shader_state_bits(glStateBits_t bits)
     }
 
     if (diff & GLS_BLOOM_GENERATE && glr.framebuffer_bound) {
-        int n = (bits & GLS_BLOOM_GENERATE) ? 2 : 1;
-        qglDrawBuffers(n, (const GLenum []) {
+        static constexpr GLenum bloom_targets[] = {
             GL_COLOR_ATTACHMENT0,
-            GL_COLOR_ATTACHMENT1
-        });
+            GL_COLOR_ATTACHMENT1,
+        };
+        int n = (bits & GLS_BLOOM_GENERATE) ? 2 : 1;
+        qglDrawBuffers(n, bloom_targets);
     }
 }
 


### PR DESCRIPTION
## Summary
- replace the temporary GLenum initializer list used for qglDrawBuffers with a persistent static array
- continue to select the number of draw buffers dynamically while passing a stable pointer

## Testing
- meson setup build *(fails: `meson` not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f2c1a922f08328aa1f3bfbcb9891aa