### PR TITLE
Fix SDL context handling for SDL backend

### DIFF
--- a/src/unix/video/sdl.cpp
+++ b/src/unix/video/sdl.cpp
@@ -39,7 +39,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 static struct {
     SDL_Window      *window;
-    SDL_GLContext   *context;
+    SDL_GLContext   context;
     vidFlags_t      flags;
 
     int             width;


### PR DESCRIPTION
## Summary
- store the SDL OpenGL context handle directly instead of as a pointer

## Testing
- `meson setup builddir` *(fails: meson executable not available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f2c1c9b0848328b587e92a2dd2c02f