### PR TITLE
Wrap GetGameAPI in extern C

### DIFF
--- a/src/game/g_main.cpp
+++ b/src/game/g_main.cpp
@@ -196,6 +196,7 @@ Returns a pointer to the structure with all entry points
 and global variables
 =================
 */
+extern "C" {
 q_exported game3_export_t *GetGameAPI(game3_import_t *import)
 {
     gi = *import;
@@ -224,6 +225,7 @@ q_exported game3_export_t *GetGameAPI(game3_import_t *import)
     globals.edict_size = sizeof(edict_t);
 
     return &globals;
+}
 }
 
 #ifndef GAME_HARD_LINKED


### PR DESCRIPTION
## Summary
- wrap the game module's `GetGameAPI` export in an `extern "C"` block so the server can resolve the symbol

## Testing
- meson setup builddir *(fails: `meson` is not installed in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f2c1e621a48328bedb6e40a8c8c813