### PR TITLE
Fix function pointer initializers in Game3 proxy

### DIFF
--- a/src/server/game3_proxy/game3_proxy.cpp
+++ b/src/server/game3_proxy/game3_proxy.cpp
@@ -1081,8 +1081,9 @@ game_export_t *GetGame3Proxy(game_import_t *import, void *game3_entry, void *gam
     game_import = *import;
 
     game3_import_t import3;
-    game3_export_t *(*entry)(game3_import_t *) = game3_entry;
-    const game3_export_ex_t *(*entry_ex)(const game3_import_ex_t *) = game3_ex_entry;
+    game3_export_t *(*entry)(game3_import_t *) = reinterpret_cast<game3_export_t *(*)(game3_import_t *)>(game3_entry);
+    const game3_export_ex_t *(*entry_ex)(const game3_import_ex_t *) =
+        reinterpret_cast<const game3_export_ex_t *(*)(const game3_import_ex_t *)>(game3_ex_entry);
 
     import3.multicast = wrap_multicast;
     import3.unicast = wrap_unicast;


### PR DESCRIPTION
## Summary
- use `reinterpret_cast` when initializing the Game3 entry function pointers so the void* handles become typed

## Testing
- meson setup build *(fails: `meson` not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f2c755b80083288020ee87ffb07a1a