### PR TITLE
Use reinterpret_cast for game entry lookup

### DIFF
--- a/src/server/game.cpp
+++ b/src/server/game.cpp
@@ -1096,7 +1096,7 @@ void SV_InitGameProgs(void)
 
     game_library = GameDll_Load();
     if (game_library)
-        entry = Sys_GetProcAddress(game_library, "GetGameAPI");
+        entry = reinterpret_cast<game_entry_t>(Sys_GetProcAddress(game_library, "GetGameAPI"));
     if (!entry)
         Com_Error(ERR_DROP, "Failed to load game library");
 


### PR DESCRIPTION
## Summary
- ensure the GetGameAPI symbol is cast to the expected game_entry_t type before use

## Testing
- meson setup builddir *(fails: `meson` is not installed in the environment and network access to install it is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68f2c759108483288dd709446ab37914