### PR TITLE
Adjust FS_ListFiles pointer usage in server code

### DIFF
--- a/src/server/commands.cpp
+++ b/src/server/commands.cpp
@@ -486,7 +486,7 @@ static void SV_Map_f(void)
 static void SV_Map_c(genctx_t *ctx, int argnum)
 {
     const char *path;
-    void **list;
+    char **list;
     int count;
 
     if (argnum != 1)
@@ -500,7 +500,7 @@ static void SV_Map_c(genctx_t *ctx, int argnum)
     if (!*path)
         return;
 
-    list = FS_ListFiles(path, ".bsp.override", FS_SEARCH_RECURSIVE, &count);
+    list = reinterpret_cast<char **>(FS_ListFiles(path, ".bsp.override", FS_SEARCH_RECURSIVE, &count));
     if (!list)
         return;
 

--- a/src/server/save.cpp
+++ b/src/server/save.cpp
@@ -225,22 +225,24 @@ static int remove_file(const char *dir, const char *name)
     return remove(path);
 }
 
-static void **list_save_dir(const char *dir, int *count)
+static char **list_save_dir(const char *dir, int *count)
 {
-    return FS_ListFiles(va("save/%s", dir), ".ssv;.sav;.sv2",
-        SAVE_LOOKUP_FLAGS | FS_SEARCH_RECURSIVE, count);
+    return reinterpret_cast<char **>(FS_ListFiles(va("save/%s", dir), ".ssv;.sav;.sv2",
+        SAVE_LOOKUP_FLAGS | FS_SEARCH_RECURSIVE, count));
 }
 
 static int wipe_save_dir(const char *dir)
 {
-    void **list;
+    char **list;
     int i, count, ret = 0;
 
     if ((list = list_save_dir(dir, &count)) == NULL)
         return 0;
 
-    for (i = 0; i < count; i++)
-        ret |= remove_file(dir, list[i]);
+    for (i = 0; i < count; i++) {
+        const char *name = list[i];
+        ret |= remove_file(dir, name);
+    }
 
     FS_FreeList(list);
     return ret;
@@ -248,14 +250,16 @@ static int wipe_save_dir(const char *dir)
 
 static int copy_save_dir(const char *src, const char *dst)
 {
-    void **list;
+    char **list;
     int i, count, ret = 0;
 
     if ((list = list_save_dir(src, &count)) == NULL)
         return -1;
 
-    for (i = 0; i < count; i++)
-        ret |= copy_file(src, dst, list[i]);
+    for (i = 0; i < count; i++) {
+        const char *name = list[i];
+        ret |= copy_file(src, dst, name);
+    }
 
     FS_FreeList(list);
     return ret;


### PR DESCRIPTION
## Summary
- cast the save directory listing helper to work with `char **` results from `FS_ListFiles`
- treat save directory entries as `const char *` when removing or copying files
- update the map completion logic to cast the `FS_ListFiles` results once when building overrides

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f2c7598cc08328bb6d10875314c973