### PR TITLE
Fix missing dependencies in utils header

### DIFF
--- a/inc/common/utils.h
+++ b/inc/common/utils.h
@@ -18,6 +18,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
+#include <climits>
+#include <cstddef>
+#include <cstdint>
+#include <ctime>
+
+#include "shared/shared.h"
+
 #if USE_CLIENT
 extern const char com_env_suf[6][3];
 #endif


### PR DESCRIPTION
## Summary
- include the standard library headers needed by common/utils.h for size, time, and integer utilities
- include shared/shared.h so the header can use shared macros and declarations directly

## Testing
- g++ -std=c++17 -Iinc -DUSE_LITTLE_ENDIAN=1 -c /tmp/test_utils.cpp -o /tmp/test_utils.o


------
https://chatgpt.com/codex/tasks/task_e_68f2c87e6d3083289c9cf869b6460336