### PR TITLE
Improve endian detection fallback

### DIFF
--- a/inc/common/intreadwrite.h
+++ b/inc/common/intreadwrite.h
@@ -56,7 +56,7 @@ struct unaligned64 { uint64_t u; } __attribute__((packed, may_alias));
 
 #endif
 
-#if USE_LITTLE_ENDIAN
+#if defined(USE_LITTLE_ENDIAN)
 // We only optimize for little-endian arches here.
 
 #ifdef RN16

--- a/src/client/sound/mem.cpp
+++ b/src/client/sound/mem.cpp
@@ -456,7 +456,7 @@ static void ConvertSamples(void)
         return;
     }
 
-#if USE_BIG_ENDIAN
+#if defined(USE_BIG_ENDIAN)
     if (s_info.width == 2) {
         for (int i = 0; i < count; i++)
             data[i] = LittleShort(data[i]);

--- a/src/refresh/models.cpp
+++ b/src/refresh/models.cpp
@@ -199,7 +199,7 @@ void MOD_FreeAll(void)
 static void LittleBlock(void *out, const void *in, size_t size)
 {
     memcpy(out, in, size);
-#if USE_BIG_ENDIAN
+#if defined(USE_BIG_ENDIAN)
     for (int i = 0; i < size / 4; i++)
         ((uint32_t *)out)[i] = LittleLong(((uint32_t *)out)[i]);
 #endif


### PR DESCRIPTION
## Summary
- add a detection block in `shared.h` that prefers `std::endian` when available and falls back to compiler byte-order macros
- remove the unconditional byte-order error path and gate endian-specific helpers on the presence of the configured macros
- adjust call sites to test for the macros via `defined()` so builds without explicit values still compile cleanly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f2c87c6ea08328876be01ae29a25a9