### PR TITLE
Fix PRI format macro usage in format strings

### DIFF
--- a/src/client/demo.cpp
+++ b/src/client/demo.cpp
@@ -1231,7 +1231,7 @@ static void CL_Seek_f(void)
     // save previous server frame number
     prev = cl.frame.number;
 
-    Com_DPrintf("[%d] seeking to %"PRId64"\n", cls.demo.frames_read, dest);
+    Com_DPrintf("[%d] seeking to %" PRId64 "\n", cls.demo.frames_read, dest);
 
     // seek to the previous most recent snapshot
     if (back_seek || cls.demo.last_snapshot > cls.demo.frames_read) {

--- a/src/common/files.cpp
+++ b/src/common/files.cpp
@@ -959,7 +959,7 @@ static int64_t open_file_write(file_t *file, const char *name)
         goto fail;
     }
 
-    FS_DPrintf("%s: %s: %"PRId64" bytes\n", __func__, fullpath.data(), pos);
+    FS_DPrintf("%s: %s: %" PRId64 " bytes\n", __func__, fullpath.data(), pos);
     return pos;
 
 fail:
@@ -1249,7 +1249,7 @@ static int64_t open_from_pack(file_t *file, pack_t *pack, packfile_t *entry)
         fs_non_uniq_open = true;
     }
 
-    FS_DPrintf("%s: %s/%s: %"PRId64" bytes\n",
+    FS_DPrintf("%s: %s/%s: %" PRId64 " bytes\n",
                __func__, pack->filename, pack->names + entry->nameofs, file->length);
 
     return file->length;
@@ -1355,7 +1355,7 @@ static int64_t open_from_disk(file_t *file, const char *fullpath)
     }
 #endif
 
-    FS_DPrintf("%s: %s: %"PRId64" bytes\n", __func__, fullpath, file->length);
+    FS_DPrintf("%s: %s: %" PRId64 " bytes\n", __func__, fullpath, file->length);
     return file->length;
 
 fail:
@@ -2599,7 +2599,7 @@ static pack_t *load_zip_file(const char *packfile)
 // non-zero for sfx?
     extra_bytes = header_pos - central_end;
     if (extra_bytes) {
-        Com_WPrintf("%s has %"PRId64" extra bytes at the beginning\n", packfile, extra_bytes);
+        Com_WPrintf("%s has %" PRId64 " extra bytes at the beginning\n", packfile, extra_bytes);
     }
 
     if (os_fseek(fp, central_ofs + extra_bytes, SEEK_SET)) {
@@ -3299,7 +3299,7 @@ recheck:
                 }
                 if (!FS_pathcmp(pak->names + entry->nameofs, normalized.data())) {
                     // found it!
-                    Com_Printf("%s/%s (%"PRId64" bytes)\n", pak->filename,
+                    Com_Printf("%s/%s (%" PRId64 " bytes)\n", pak->filename,
                                normalized.data(), entry->filelen);
                     if (!report_all) {
                         return;
@@ -3345,7 +3345,7 @@ recheck:
 #endif
 
             if (ret == Q_ERR_SUCCESS) {
-                Com_Printf("%s (%"PRId64" bytes)\n", fullpath.data(), info.size);
+                Com_Printf("%s (%" PRId64 " bytes)\n", fullpath.data(), info.size);
                 if (!report_all) {
                     return;
                 }

--- a/src/common/net/net.cpp
+++ b/src/common/net/net.cpp
@@ -508,19 +508,19 @@ static void NET_Stats_f(void)
 
     Com_FormatTime(buffer, sizeof(buffer), diff);
     Com_Printf("Network uptime: %s\n", buffer);
-    Com_Printf("Bytes sent: %"PRIu64" (%"PRIu64" bytes/sec)\n",
+    Com_Printf("Bytes sent: %" PRIu64 " (%" PRIu64 " bytes/sec)\n",
                net_bytes_sent, net_bytes_sent / diff);
-    Com_Printf("Bytes rcvd: %"PRIu64" (%"PRIu64" bytes/sec)\n",
+    Com_Printf("Bytes rcvd: %" PRIu64 " (%" PRIu64 " bytes/sec)\n",
                net_bytes_rcvd, net_bytes_rcvd / diff);
-    Com_Printf("Packets sent: %"PRIu64" (%"PRIu64" packets/sec)\n",
+    Com_Printf("Packets sent: %" PRIu64 " (%" PRIu64 " packets/sec)\n",
                net_packets_sent, net_packets_sent / diff);
-    Com_Printf("Packets rcvd: %"PRIu64" (%"PRIu64" packets/sec)\n",
+    Com_Printf("Packets rcvd: %" PRIu64 " (%" PRIu64 " packets/sec)\n",
                net_packets_rcvd, net_packets_rcvd / diff);
 #if USE_ICMP
-    Com_Printf("Total errors: %"PRIu64"/%"PRIu64"/%"PRIu64" (send/recv/icmp)\n",
+    Com_Printf("Total errors: %" PRIu64 "/%" PRIu64 "/%" PRIu64 " (send/recv/icmp)\n",
                net_send_errors, net_recv_errors, net_icmp_errors);
 #else
-    Com_Printf("Total errors: %"PRIu64"/%"PRIu64" (send/recv)\n",
+    Com_Printf("Total errors: %" PRIu64 "/%" PRIu64 " (send/recv)\n",
                net_send_errors, net_recv_errors);
 #endif
     Com_Printf("Current upload rate: %zu bytes/sec\n", net_rate_up);

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -544,16 +544,16 @@ size_t Com_FormatSize(char *dest, size_t destsize, int64_t bytes)
         return Q_scnprintf(dest, destsize, "%.1fG", bytes * 1e-9);
     }
     if (bytes >= 10000000) {
-        return Q_scnprintf(dest, destsize, "%"PRId64 "M", bytes / 1000000);
+        return Q_scnprintf(dest, destsize, "%" PRId64 "M", bytes / 1000000);
     }
     if (bytes >= 1000000) {
         return Q_scnprintf(dest, destsize, "%.1fM", bytes * 1e-6);
     }
     if (bytes >= 1000) {
-        return Q_scnprintf(dest, destsize, "%"PRId64 "K", bytes / 1000);
+        return Q_scnprintf(dest, destsize, "%" PRId64 "K", bytes / 1000);
     }
     if (bytes >= 0) {
-        return Q_scnprintf(dest, destsize, "%"PRId64, bytes);
+        return Q_scnprintf(dest, destsize, "%" PRId64, bytes);
     }
     return Q_scnprintf(dest, destsize, "???");
 }
@@ -564,16 +564,16 @@ size_t Com_FormatSizeLong(char *dest, size_t destsize, int64_t bytes)
         return Q_scnprintf(dest, destsize, "%.1f GB", bytes * 1e-9);
     }
     if (bytes >= 10000000) {
-        return Q_scnprintf(dest, destsize, "%"PRId64 " MB", bytes / 1000000);
+        return Q_scnprintf(dest, destsize, "%" PRId64 " MB", bytes / 1000000);
     }
     if (bytes >= 1000000) {
         return Q_scnprintf(dest, destsize, "%.1f MB", bytes * 1e-6);
     }
     if (bytes >= 1000) {
-        return Q_scnprintf(dest, destsize, "%"PRId64 " kB", bytes / 1000);
+        return Q_scnprintf(dest, destsize, "%" PRId64 " kB", bytes / 1000);
     }
     if (bytes >= 0) {
-        return Q_scnprintf(dest, destsize, "%"PRId64 " byte%s",
+        return Q_scnprintf(dest, destsize, "%" PRId64 " byte%s",
                            bytes, bytes == 1 ? "" : "s");
     }
     return Q_scnprintf(dest, destsize, "unknown size");

--- a/src/server/mvd/client.cpp
+++ b/src/server/mvd/client.cpp
@@ -2327,7 +2327,7 @@ static void MVD_Seek_f(void)
     // clear dirty configstrings
     memset(mvd->dcs, 0, sizeof(mvd->dcs));
 
-    Com_DPrintf("[%d] seeking to %"PRId64"\n", mvd->framenum, dest);
+    Com_DPrintf("[%d] seeking to %" PRId64 "\n", mvd->framenum, dest);
 
     // seek to the previous most recent snapshot
     if (back_seek || mvd->last_snapshot > mvd->framenum) {


### PR DESCRIPTION
## Summary
- update format strings that embed PRI* macros to use adjacent string literals
- ensure size formatting helpers and logging calls use portable constructions recognized by MSVC

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f2cef3ced88328b57696d4df605224