### PR TITLE
Fix endian macro conditional checks

### DIFF
--- a/inc/shared/shared.h
+++ b/inc/shared/shared.h
@@ -809,7 +809,7 @@ static inline int32_t SignExtend(uint32_t v, int bits)
     return (int32_t)(v << (32 - bits)) >> (32 - bits);
 }
 
-#if defined(USE_LITTLE_ENDIAN)
+#if USE_LITTLE_ENDIAN
 #define BigShort(x)     ShortSwap(x)
 #define BigLong(x)      LongSwap(x)
 #define BigFloat(x)     FloatSwap(x)
@@ -818,7 +818,7 @@ static inline int32_t SignExtend(uint32_t v, int bits)
 #define LittleFloat(x)  ((float)(x))
 #define MakeRawLong(b1,b2,b3,b4) MakeLittleLong(b1,b2,b3,b4)
 #define MakeRawShort(b1,b2) (((b2)<<8)|(b1))
-#elif defined(USE_BIG_ENDIAN)
+#elif USE_BIG_ENDIAN
 #define BigShort(x)     ((uint16_t)(x))
 #define BigLong(x)      ((uint32_t)(x))
 #define BigFloat(x)     ((float)(x))


### PR DESCRIPTION
## Summary
- restore value-based checks for USE_LITTLE_ENDIAN and USE_BIG_ENDIAN so zero-valued macros do not trigger the wrong branch

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f3454160a0832882fc9c6eee944fbc