### PR TITLE
Fix color helpers for C compilation - handle normalized alpha

### DIFF
--- a/inc/shared/shared.h
+++ b/inc/shared/shared.h
@@ -930,7 +930,7 @@ static inline color_t ColorSetAlpha(color_t c, float alpha)
         return ColorSetAlphaByte(c, 0);
     }
 
-    if (alpha < 1.0f) {
+    if (alpha <= 1.0f) {
         float scaled = alpha * 255.0f + 0.5f;
         if (scaled < 0.0f) {
             scaled = 0.0f;


### PR DESCRIPTION
## Summary
- ensure the C ColorSetAlpha helper scales normalized alpha values up to and including 1.0f to the full byte range

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f34759f2bc8328954b21d539eed4f9