### PR TITLE
Fix const correctness in Q_strnlen memchr pointer

### DIFF
--- a/src/shared/shared.cpp
+++ b/src/shared/shared.cpp
@@ -1015,7 +1015,7 @@ void *Q_memccpy(void *dst, const void *src, int c, size_t size)
 #ifndef HAVE_STRNLEN
 size_t Q_strnlen(const char *s, size_t maxlen)
 {
-    char *p = memchr(s, 0, maxlen);
+    const char *p = static_cast<const char *>(memchr(s, 0, maxlen));
     return p ? p - s : maxlen;
 }
 #endif


### PR DESCRIPTION
## Summary
- update Q_strnlen to store the memchr result in a const-qualified pointer to satisfy MSVC

## Testing
- not run (MSVC unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f34a995f6c8328a8dac5a9a9ea69ab