### PR TITLE
Fix C initializer for q2proto_make_string

### DIFF
--- a/q2proto/inc/q2proto/q2proto_string.h
+++ b/q2proto/inc/q2proto/q2proto_string.h
@@ -42,7 +42,7 @@ typedef struct q2proto_string_s {
 /// Helper: Create a q2proto_string_t from a null-terminated string
 static inline q2proto_string_t q2proto_make_string(const char *s)
 {
-    q2proto_string_t q2p_str{ s, s ? strlen(s) : 0 };
+    q2proto_string_t q2p_str = { s, s ? strlen(s) : 0 };
     return q2p_str;
 }
 


### PR DESCRIPTION
## Summary
- replace the C++-style aggregate initialization in `q2proto_make_string` with a C-compatible initializer

## Testing
- `meson setup build-c --wipe -Dc_std=c11` *(fails: `meson` is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f34a9012a08328b66620fd3e3f67e8