### PR TITLE
Adjust zone allocation API for C linkage

### DIFF
--- a/inc/common/zone.h
+++ b/inc/common/zone.h
@@ -83,16 +83,16 @@ extern "C" {
 void    Z_Init(void);
 void    Z_Free(void *ptr);
 void    Z_Freep(void *ptr);
-z_pointer   Z_Realloc(void *ptr, size_t size);
-z_pointer   Z_ReallocArray(void *ptr, size_t nmemb, size_t size, memtag_t tag);
+void   *Z_Realloc(void *ptr, size_t size);
+void   *Z_ReallocArray(void *ptr, size_t nmemb, size_t size, memtag_t tag);
 q_zone_allocator
-z_pointer   Z_Malloc(size_t size);
+void   *Z_Malloc(size_t size);
 q_zone_allocator
-z_pointer   Z_Mallocz(size_t size);
+void   *Z_Mallocz(size_t size);
 q_zone_allocator
-z_pointer   Z_TagMalloc(size_t size, memtag_t tag);
+void   *Z_TagMalloc(size_t size, memtag_t tag);
 q_zone_allocator
-z_pointer   Z_TagMallocz(size_t size, memtag_t tag);
+void   *Z_TagMallocz(size_t size, memtag_t tag);
 q_malloc
 char    *Z_TagCopyString(const char *in, memtag_t tag);
 #undef q_zone_allocator
@@ -105,4 +105,42 @@ char    *Z_CvarCopyString(const char *in);
 
 #ifdef __cplusplus
 }
+
+static inline z_allocation Z_Realloc_allocation(void *ptr, size_t size) noexcept
+{
+    return z_allocation{::Z_Realloc(ptr, size)};
+}
+
+static inline z_allocation Z_ReallocArray_allocation(void *ptr, size_t nmemb, size_t size, memtag_t tag) noexcept
+{
+    return z_allocation{::Z_ReallocArray(ptr, nmemb, size, tag)};
+}
+
+static inline z_allocation Z_Malloc_allocation(size_t size) noexcept
+{
+    return z_allocation{::Z_Malloc(size)};
+}
+
+static inline z_allocation Z_Mallocz_allocation(size_t size) noexcept
+{
+    return z_allocation{::Z_Mallocz(size)};
+}
+
+static inline z_allocation Z_TagMalloc_allocation(size_t size, memtag_t tag) noexcept
+{
+    return z_allocation{::Z_TagMalloc(size, tag)};
+}
+
+static inline z_allocation Z_TagMallocz_allocation(size_t size, memtag_t tag) noexcept
+{
+    return z_allocation{::Z_TagMallocz(size, tag)};
+}
+
+#define Z_Realloc(ptr, size) (Z_Realloc_allocation((ptr), (size)))
+#define Z_ReallocArray(ptr, nmemb, size, tag) (Z_ReallocArray_allocation((ptr), (nmemb), (size), (tag)))
+#define Z_Malloc(size) (Z_Malloc_allocation((size)))
+#define Z_Mallocz(size) (Z_Mallocz_allocation((size)))
+#define Z_TagMalloc(size, tag) (Z_TagMalloc_allocation((size), (tag)))
+#define Z_TagMallocz(size, tag) (Z_TagMallocz_allocation((size), (tag)))
+
 #endif

--- a/src/common/zone.cpp
+++ b/src/common/zone.cpp
@@ -21,6 +21,15 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "common/common.h"
 #include "common/zone.h"
 
+#ifdef __cplusplus
+#undef Z_Realloc
+#undef Z_ReallocArray
+#undef Z_Malloc
+#undef Z_Mallocz
+#undef Z_TagMalloc
+#undef Z_TagMallocz
+#endif
+
 #if USE_MEMORY_TRACES
 #define MAX_TRACE_SIZE 32
 #include "system/system.h"
@@ -175,7 +184,7 @@ void Z_Freep(void *ptr)
 Z_Realloc
 ========================
 */
-z_pointer Z_Realloc(void *ptr, size_t size)
+void *Z_Realloc(void *ptr, size_t size)
 {
     zhead_t *z;
 
@@ -220,7 +229,7 @@ z_pointer Z_Realloc(void *ptr, size_t size)
     return z + 1;
 }
 
-z_pointer Z_ReallocArray(void *ptr, size_t nmemb, size_t size, memtag_t tag)
+void *Z_ReallocArray(void *ptr, size_t nmemb, size_t size, memtag_t tag)
 {
     Q_assert(!size || nmemb <= INT_MAX / size);
     if (!ptr)
@@ -317,22 +326,22 @@ static void *Z_TagMallocInternal(size_t size, memtag_t tag, bool init)
     return z + 1;
 }
 
-z_pointer Z_TagMalloc(size_t size, memtag_t tag)
+void *Z_TagMalloc(size_t size, memtag_t tag)
 {
     return Z_TagMallocInternal(size, tag, false);
 }
 
-z_pointer Z_TagMallocz(size_t size, memtag_t tag)
+void *Z_TagMallocz(size_t size, memtag_t tag)
 {
     return Z_TagMallocInternal(size, tag, true);
 }
 
-z_pointer Z_Malloc(size_t size)
+void *Z_Malloc(size_t size)
 {
     return Z_TagMalloc(size, TAG_GENERAL);
 }
 
-z_pointer Z_Mallocz(size_t size)
+void *Z_Mallocz(size_t size)
 {
     return Z_TagMallocz(size, TAG_GENERAL);
 }


### PR DESCRIPTION
## Summary
- switch the zone allocation prototypes inside the C linkage block to return raw `void*`
- add C++ inline helpers/macros so callers still receive `z_allocation` wrappers
- update the implementation to match and undefine the helper macros where the functions are defined

## Testing
- not run (MSVC unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68f34a85bb5083289993c552d91e3b77