### PR TITLE
Fix com_hexchars declaration size

### DIFF
--- a/inc/common/utils.h
+++ b/inc/common/utils.h
@@ -86,7 +86,7 @@ color_index_t Com_ParseColor(const char *s);
 unsigned Com_ParseExtensionString(const char *s, const char *const extnames[]);
 #endif
 
-extern const char com_hexchars[16];
+extern const char com_hexchars[];
 
 size_t Com_EscapeString(char *dst, const char *src, size_t size);
 

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -595,7 +595,11 @@ static int escape_char(int c)
     return 0;
 }
 
-const char com_hexchars[] = "0123456789ABCDEF";
+const char com_hexchars[] = {
+    '0', '1', '2', '3', '4', '5', '6', '7',
+    '8', '9', 'A', 'B', 'C', 'D', 'E', 'F',
+    '\0'
+};
 
 size_t Com_EscapeString(char *dst, const char *src, size_t size)
 {


### PR DESCRIPTION
## Summary
- adjust the com_hexchars declaration to use an unsized array so its storage matches the definition
- rewrite the com_hexchars definition with an explicit null-terminated initializer to align with the declaration and satisfy MSVC

## Testing
- meson compile *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f34a83f734832884e8860340f2cc4c