### PR TITLE
Guard Cvar_WriteVariables for non-client builds

### DIFF
--- a/src/common/cvar.cpp
+++ b/src/common/cvar.cpp
@@ -769,7 +769,7 @@ static void Cvar_SetFlag_f(void)
     Cvar_FullSet(Cmd_Argv(1), Cmd_ArgsFrom(2), flags, Cmd_From());
 }
 
-#if USE_CLIENT
+#if defined(USE_CLIENT) && USE_CLIENT
 
 /*
 ============
@@ -797,6 +797,15 @@ void Cvar_WriteVariables(qhandle_t f, int mask, bool modified)
         a = !modified && (var->flags & CVAR_ARCHIVE) ? "a" : "";
         FS_FPrintf(f, "set%s %s \"%s\"\n", a, var->name, s);
     }
+}
+
+#else
+
+void Cvar_WriteVariables(qhandle_t f, int mask, bool modified)
+{
+    (void)f;
+    (void)mask;
+    (void)modified;
 }
 
 #endif


### PR DESCRIPTION
## Summary
- update the Cvar_WriteVariables guard to check whether USE_CLIENT is defined before compiling the client-only implementation
- provide a stub implementation when the client is disabled so non-client builds no longer hit an unmatched #endif on MSVC

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f3504de7388328a7d5e78fedd16771