### PR TITLE
Fix size buffer initialization pointer cast

### DIFF
--- a/src/common/sizebuf.cpp
+++ b/src/common/sizebuf.cpp
@@ -25,7 +25,7 @@ void SZ_Init(sizebuf_t *buf, void *data, size_t size, const char *tag)
 {
     Q_assert(size <= INT32_MAX);
     memset(buf, 0, sizeof(*buf));
-    buf->data = data;
+    buf->data = static_cast<byte *>(data);
     buf->maxsize = size;
     buf->tag = tag;
 }


### PR DESCRIPTION
## Summary
- cast the size buffer initialization data pointer to `byte*` to avoid implicit `void*` conversion

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f405258f0c8328a0ef3fce14c98b8b