### PR TITLE
Expose zone C API symbols to C++

### DIFF
--- a/inc/common/zone.h
+++ b/inc/common/zone.h
@@ -145,4 +145,13 @@ static inline z_allocation Z_TagMallocz_allocation(size_t size, memtag_t tag) no
 #define Z_TagMalloc(size, tag) (Z_TagMalloc_allocation((size), (tag)))
 #define Z_TagMallocz(size, tag) (Z_TagMallocz_allocation((size), (tag)))
 
+using zone_c_api::Z_CvarCopyString;
+using zone_c_api::Z_Free;
+using zone_c_api::Z_FreeTags;
+using zone_c_api::Z_Freep;
+using zone_c_api::Z_Init;
+using zone_c_api::Z_LeakTest;
+using zone_c_api::Z_Stats_f;
+using zone_c_api::Z_TagCopyString;
+
 #endif // __cplusplus


### PR DESCRIPTION
## Summary
- add C++ using declarations so zone API symbols remain accessible without namespace qualifiers

## Testing
- meson setup build *(fails: meson not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f4052593548328b96bbcd19ac73689