### PR TITLE
Fix zlib pointer casts for MSVC compatibility

### DIFF
--- a/src/server/mvd/client.cpp
+++ b/src/server/mvd/client.cpp
@@ -1379,18 +1379,18 @@ static int inflate_stream(fifo_t *dst, fifo_t *src, z_streamp z)
     int     ret = Z_BUF_ERROR;
 
     do {
-        data = FIFO_Peek(src, &avail_in);
+        data = static_cast<byte *>(FIFO_Peek(src, &avail_in));
         if (!avail_in) {
             break;
         }
-        z->next_in = data;
+        z->next_in = reinterpret_cast<Bytef *>(data);
         z->avail_in = (uInt)avail_in;
 
-        data = FIFO_Reserve(dst, &avail_out);
+        data = static_cast<byte *>(FIFO_Reserve(dst, &avail_out));
         if (!avail_out) {
             break;
         }
-        z->next_out = data;
+        z->next_out = reinterpret_cast<Bytef *>(data);
         z->avail_out = (uInt)avail_out;
 
         ret = inflate(z, Z_SYNC_FLUSH);


### PR DESCRIPTION
## Summary
- add explicit byte* casts around FIFO buffer access in the server and client MVD code paths
- cast void* buffers to Bytef* before assigning to zlib stream pointers to satisfy MSVC

## Testing
- not run (MSVC build required)


------
https://chatgpt.com/codex/tasks/task_e_68f405285d748328b68f3131b5bd21a7