### PR TITLE
Adjust classic client code for MSVC compatibility

### DIFF
--- a/src/client/cgame_classic.cpp
+++ b/src/client/cgame_classic.cpp
@@ -136,8 +136,8 @@ DrawStringMulti
 */
 static void CG_DrawStringMulti(int x, int y, int flags, size_t maxlen, const char *s, color_t color)
 {
-    char    *p;
-    size_t  len;
+    const char  *p;
+    size_t       len;
 
     while (*s) {
         p = strchr(s, '\n');
@@ -520,8 +520,8 @@ static void SCR_DrawHealthBar(vrect_t hud_vrect, int x, int y, int value)
     if (!value)
         return;
 
-    const rgba_t rgba_fg = {.r = 239, .g = 0, .b = 0, .a = 255};    // index 240
-    const rgba_t rgba_bg = {.r = 63, .g = 63, .b = 63, .a = 255};   // index 4
+    const rgba_t rgba_fg = ColorRGBA(239, 0, 0, 255);    // index 240
+    const rgba_t rgba_bg = ColorRGBA(63, 63, 63, 255);    // index 4
 
     int bar_width = hud_vrect.width / 3;
     float percent = (value - 1) / 254.0f;


### PR DESCRIPTION
## Summary
- update the pointer returned from `strchr` to use a `const char*` in the classic HUD text renderer
- replace C++ designated initializers for HUD colors with `ColorRGBA` helpers so MSVC can build the client

## Testing
- `meson setup builddir` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f4054091088328bae28bc227c2c587