### PR TITLE
Refine MVD enum usage and helpers

### DIFF
--- a/src/server/mvd.cpp
+++ b/src/server/mvd.cpp
@@ -1641,7 +1641,7 @@ static bool parse_message(gtv_client_t *client)
 {
     uint32_t magic;
     uint16_t msglen;
-    int cmd;
+    gtv_clientop_t cmd;
 
     if (client->state <= cs_zombie) {
         return false;
@@ -1687,7 +1687,7 @@ static bool parse_message(gtv_client_t *client)
 
     client->msglen = 0;
 
-    cmd = MSG_ReadByte();
+    cmd = static_cast<gtv_clientop_t>(MSG_ReadByte());
     switch (cmd) {
     case GTC_HELLO:
         parse_hello(client);
@@ -1705,7 +1705,7 @@ static bool parse_message(gtv_client_t *client)
         parse_stringcmd(client);
         break;
     default:
-        drop_client(client, "unknown command byte");
+        drop_client(client, va("unknown command byte %d", static_cast<int>(cmd)));
         return false;
     }
 

--- a/src/server/mvd/client.h
+++ b/src/server/mvd/client.h
@@ -20,6 +20,43 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "../server.h"
 #include <setjmp.h>
+#include <type_traits>
+
+template <typename Enum>
+constexpr auto enum_value(Enum value) noexcept
+{
+    return static_cast<std::underlying_type_t<Enum>>(value);
+}
+
+template <typename Enum>
+constexpr Enum enum_from_value(std::underlying_type_t<Enum> value) noexcept
+{
+    return static_cast<Enum>(value);
+}
+
+template <typename Enum>
+constexpr void enum_or_assign(Enum &lhs, Enum rhs) noexcept
+{
+    lhs = enum_from_value<Enum>(enum_value(lhs) | enum_value(rhs));
+}
+
+template <typename Enum>
+constexpr void enum_or_assign(Enum &lhs, std::underlying_type_t<Enum> rhs) noexcept
+{
+    lhs = enum_from_value<Enum>(enum_value(lhs) | rhs);
+}
+
+template <typename Enum>
+constexpr void enum_and_assign(Enum &lhs, std::underlying_type_t<Enum> rhs) noexcept
+{
+    lhs = enum_from_value<Enum>(enum_value(lhs) & rhs);
+}
+
+template <typename Enum>
+constexpr bool enum_has(Enum value, Enum flag) noexcept
+{
+    return (enum_value(value) & enum_value(flag)) != 0;
+}
 
 #define MVD_Malloc(size)    Z_TagMalloc(size, TAG_MVD)
 #define MVD_Mallocz(size)   Z_TagMallocz(size, TAG_MVD)
@@ -162,7 +199,7 @@ typedef struct mvd_s {
     cm_t            cm;
     vec3_t          spawnOrigin;
     vec3_t          spawnAngles;
-    int             pm_type;
+    pmtype_t        pm_type;
     size_t          dcs[BC_COUNT(MAX_CONFIGSTRINGS)];
     configstring_t  baseconfigstrings[MAX_CONFIGSTRINGS];
     configstring_t  configstrings[MAX_CONFIGSTRINGS];

--- a/src/server/mvd/game.cpp
+++ b/src/server/mvd/game.cpp
@@ -353,7 +353,7 @@ static void MVD_SetDefaultLayout(mvd_client_t *client)
         type = LAYOUT_CHANNELS;
     } else if (mvd->intermission) {
         type = LAYOUT_SCORES;
-    } else if (client->target && !(mvd->flags & MVF_SINGLEPOV)) {
+    } else if (client->target && !enum_has(mvd->flags, MVF_SINGLEPOV)) {
         type = LAYOUT_FOLLOW;
     } else {
         type = LAYOUT_NONE;
@@ -797,12 +797,13 @@ static void MVD_SetServerState(client_t *cl, mvd_t *mvd)
     cl->spawncount = mvd->servercount;
     cl->maxclients = mvd->maxclients;
 
-    cl->esFlags &= ~ES_MASK;
-    cl->psFlags &= ~PS_MASK;
-    cl->esFlags |= mvd->esFlags & ES_MASK;
-    cl->psFlags |= mvd->psFlags & PS_MASK;
+    enum_and_assign(cl->esFlags, ~ES_MASK);
+    enum_and_assign(cl->psFlags, ~PS_MASK);
+    enum_or_assign(cl->esFlags, enum_value(mvd->esFlags) & ES_MASK);
+    enum_or_assign(cl->psFlags, enum_value(mvd->psFlags) & PS_MASK);
 
-    cl->esFlags |= MSG_ES_SHORTANGLES | MSG_ES_EXTENSIONS;
+    enum_or_assign(cl->esFlags, MSG_ES_SHORTANGLES);
+    enum_or_assign(cl->esFlags, MSG_ES_EXTENSIONS);
 }
 
 void MVD_SwitchChannel(mvd_client_t *client, mvd_t *mvd)
@@ -1949,7 +1950,7 @@ static void MVD_GameClientBegin(edict_t *ent)
                                 "[MVD] %s entered the channel\n", client->cl->name);
         }
         target = MVD_MostFollowed(mvd);
-    } else if (mvd->flags & MVF_SINGLEPOV) {
+    } else if (enum_has(mvd->flags, MVF_SINGLEPOV)) {
         target = MVD_MostFollowed(mvd);
     } else {
         target = client->oldtarget;
@@ -2215,7 +2216,7 @@ static void MVD_IntermissionStop(mvd_t *mvd)
             continue;
         }
         if (client->layout_type == LAYOUT_SCORES) {
-            client->layout_type = 0;
+            client->layout_type = LAYOUT_NONE;
         }
         target = client->oldtarget;
         if (target && target->inuse) {


### PR DESCRIPTION
## Summary
- add reusable enum utility helpers for MVD code and store pm_type as pmtype_t
- update MVD parsing and game logic to cast message reads to enums and replace implicit zero values
- tighten GTV/MVD client handling to use the enum helpers and improve diagnostics for unknown commands

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68f40528727c832887d0747cdab1a507