### PR TITLE
Use bool for MVD dummy connect flag

### DIFF
--- a/src/server/mvd.cpp
+++ b/src/server/mvd.cpp
@@ -351,7 +351,7 @@ static int dummy_create(void)
     client_t *newcl;
     char userinfo[MAX_INFO_STRING * 2];
     const char *s;
-    qboolean allow;
+    bool allow;
     int number;
 
     // do nothing if already created
@@ -399,7 +399,7 @@ static int dummy_create(void)
     // get the game a chance to reject this connection or modify the userinfo
     sv_client = newcl;
     sv_player = newcl->edict;
-    allow = ge->ClientConnect(newcl->edict, userinfo, "", false);
+    allow = ge->ClientConnect(newcl->edict, userinfo, "", false) != false;
     sv_client = NULL;
     sv_player = NULL;
     if (!allow) {


### PR DESCRIPTION
## Summary
- update the dummy client connection logic to use a C++ bool for the allow flag
- ensure the result of ClientConnect is normalized to bool to avoid implicit conversion issues

## Testing
- not run (MSVC build not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68f40b5f9a30832881be8458dbefbf34