### PR TITLE
Fix key destination mask conversions

### DIFF
--- a/inc/client/keys.h
+++ b/inc/client/keys.h
@@ -121,6 +121,11 @@ typedef enum {
     KEY_MENU    = BIT(2)
 } keydest_t;
 
+constexpr keydest_t Key_FromMask(int mask)
+{
+    return static_cast<keydest_t>(mask);
+}
+
 typedef bool (*keywaitcb_t)(void *arg, int key);
 
 void    Key_Init(void);

--- a/src/client/console.cpp
+++ b/src/client/console.cpp
@@ -145,7 +145,7 @@ void Con_Close(bool force)
     Con_ClearTyping();
     Con_ClearNotify_f();
 
-    Key_SetDest(cls.key_dest & ~KEY_CONSOLE);
+    Key_SetDest(Key_FromMask(cls.key_dest & ~KEY_CONSOLE));
 
     con.destHeight = con.currentHeight = 0;
     con.mode = CON_POPUP;
@@ -165,7 +165,7 @@ void Con_Popup(bool force)
         con.mode = CON_POPUP;
     }
 
-    Key_SetDest(cls.key_dest | KEY_CONSOLE);
+    Key_SetDest(Key_FromMask(cls.key_dest | KEY_CONSOLE));
     Con_RunConsole();
 }
 
@@ -184,14 +184,14 @@ static void toggle_console(consoleMode_t mode, chatMode_t chat)
     Con_ClearNotify_f();
 
     if (cls.key_dest & KEY_CONSOLE) {
-        Key_SetDest(cls.key_dest & ~KEY_CONSOLE);
+        Key_SetDest(Key_FromMask(cls.key_dest & ~KEY_CONSOLE));
         con.mode = CON_POPUP;
         con.chat = CHAT_NONE;
         return;
     }
 
     // toggling console discards chat message
-    Key_SetDest((cls.key_dest | KEY_CONSOLE) & ~KEY_MESSAGE);
+    Key_SetDest(Key_FromMask((cls.key_dest | KEY_CONSOLE) & ~KEY_MESSAGE));
     con.mode = mode;
     con.chat = chat;
 }
@@ -302,7 +302,7 @@ static void start_message_mode(chatMode_t mode)
 
     con.chat = mode;
     IF_Replace(&con.chatPrompt.inputLine, COM_StripQuotes(Cmd_RawArgs()));
-    Key_SetDest(cls.key_dest | KEY_MESSAGE);
+    Key_SetDest(Key_FromMask(cls.key_dest | KEY_MESSAGE));
 }
 
 static void Con_MessageMode_f(void)
@@ -1333,12 +1333,12 @@ void Key_Message(int key)
         if (cmd) {
             Con_Say(cmd);
         }
-        Key_SetDest(cls.key_dest & ~KEY_MESSAGE);
+        Key_SetDest(Key_FromMask(cls.key_dest & ~KEY_MESSAGE));
         return;
     }
 
     if (key == K_ESCAPE) {
-        Key_SetDest(cls.key_dest & ~KEY_MESSAGE);
+        Key_SetDest(Key_FromMask(cls.key_dest & ~KEY_MESSAGE));
         IF_Clear(&con.chatPrompt.inputLine);
         return;
     }

--- a/src/client/ui/ui.cpp
+++ b/src/client/ui/ui.cpp
@@ -71,7 +71,7 @@ void UI_PushMenu(menuFrameWork_t *menu)
 
     Menu_Init(menu);
 
-    Key_SetDest((Key_GetDest() & ~KEY_CONSOLE) | KEY_MENU);
+    Key_SetDest(Key_FromMask((Key_GetDest() & ~KEY_CONSOLE) | KEY_MENU));
 
     Con_Close(true);
 
@@ -127,7 +127,7 @@ void UI_ForceMenuOff(void)
         }
     }
 
-    Key_SetDest(Key_GetDest() & ~KEY_MENU);
+    Key_SetDest(Key_FromMask(Key_GetDest() & ~KEY_MENU));
     uis.menuDepth = 0;
     uis.activeMenu = NULL;
     uis.mouseTracker = NULL;


### PR DESCRIPTION
## Summary
- add a helper to cast integer bitmasks to `keydest_t`
- use the helper when setting key destinations in the console and UI code to avoid implicit conversions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f40b63e4588328b58e7c25546c7487