### PR TITLE
Add C++17-compatible proc address casting

### DIFF
--- a/inc/client/proc_address.h
+++ b/inc/client/proc_address.h
@@ -1,6 +1,9 @@
 #pragma once
 
-#include <bit>
+#if defined(__cpp_lib_bit_cast)
+#    include <bit>
+#endif
+#include <cstring>
 #include <type_traits>
 
 #include "system/system.h"
@@ -16,7 +19,13 @@ template <typename Func>
     }
 
     static_assert(sizeof(Func) == sizeof(address), "Function pointer size mismatch");
+#if defined(__cpp_lib_bit_cast)
     return std::bit_cast<Func>(address);
+#else
+    Func ptr;
+    std::memcpy(&ptr, &address, sizeof ptr);
+    return ptr;
+#endif
 }
 
 // Helper to retrieve typed function pointers from dynamic libraries.


### PR DESCRIPTION
## Summary
- guard the `<bit>` include behind a `__cpp_lib_bit_cast` feature test
- fall back to a `memcpy`-based cast when `std::bit_cast` is unavailable

## Testing
- g++ -std=c++17 -Iinc -c /tmp/test_proc_address.cpp

------
https://chatgpt.com/codex/tasks/task_e_68f40b670a7c832889cf2f16b318bce0