### PR TITLE
Ensure zone API wrappers are available in C++

### DIFF
--- a/inc/common/zone.h
+++ b/inc/common/zone.h
@@ -145,13 +145,44 @@ static inline z_allocation Z_TagMallocz_allocation(size_t size, memtag_t tag) no
 #define Z_TagMalloc(size, tag) (Z_TagMalloc_allocation((size), (tag)))
 #define Z_TagMallocz(size, tag) (Z_TagMallocz_allocation((size), (tag)))
 
-using zone_c_api::Z_CvarCopyString;
-using zone_c_api::Z_Free;
-using zone_c_api::Z_FreeTags;
-using zone_c_api::Z_Freep;
-using zone_c_api::Z_Init;
-using zone_c_api::Z_LeakTest;
-using zone_c_api::Z_Stats_f;
-using zone_c_api::Z_TagCopyString;
+static inline void Z_Init(void) noexcept
+{
+    zone_c_api::Z_Init();
+}
+
+static inline void Z_Free(void *ptr) noexcept
+{
+    zone_c_api::Z_Free(ptr);
+}
+
+static inline void Z_Freep(void *ptr) noexcept
+{
+    zone_c_api::Z_Freep(ptr);
+}
+
+static inline void Z_FreeTags(memtag_t tag) noexcept
+{
+    zone_c_api::Z_FreeTags(tag);
+}
+
+static inline void Z_LeakTest(memtag_t tag) noexcept
+{
+    zone_c_api::Z_LeakTest(tag);
+}
+
+static inline void Z_Stats_f(void)
+{
+    zone_c_api::Z_Stats_f();
+}
+
+static inline char *Z_TagCopyString(const char *in, memtag_t tag) noexcept
+{
+    return zone_c_api::Z_TagCopyString(in, tag);
+}
+
+static inline char *Z_CvarCopyString(const char *in) noexcept
+{
+    return zone_c_api::Z_CvarCopyString(in);
+}
 
 #endif // __cplusplus


### PR DESCRIPTION
## Summary
- replace the `using zone_c_api::...` declarations in `zone.h` with inline wrappers so the Z_* APIs remain usable when compiling as C++
- verified that translation units including `shared/shared.h` already include `common/zone.h` through their existing dependencies before invoking Z_* macros

## Testing
- not run (MSVC build environment unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f40b68ca688328aca341ef7ab41996