### PR TITLE
Add typed bitmask helpers for message flags

### DIFF
--- a/inc/common/msg.h
+++ b/inc/common/msg.h
@@ -18,8 +18,58 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
+#include <type_traits>
+
 #include "common/protocol.h"
 #include "common/sizebuf.h"
+
+template <typename Enum>
+constexpr auto enum_value(Enum value) noexcept
+{
+    return static_cast<std::underlying_type_t<Enum>>(value);
+}
+
+template <typename Enum>
+constexpr Enum enum_from_value(std::underlying_type_t<Enum> value) noexcept
+{
+    return static_cast<Enum>(value);
+}
+
+template <typename Enum>
+constexpr Enum enum_bit_or(Enum lhs, Enum rhs) noexcept
+{
+    return enum_from_value<Enum>(enum_value(lhs) | enum_value(rhs));
+}
+
+template <typename Enum>
+constexpr Enum enum_bit_or(Enum lhs, std::underlying_type_t<Enum> rhs) noexcept
+{
+    return enum_from_value<Enum>(enum_value(lhs) | rhs);
+}
+
+template <typename Enum>
+constexpr Enum enum_bit_and(Enum lhs, Enum rhs) noexcept
+{
+    return enum_from_value<Enum>(enum_value(lhs) & enum_value(rhs));
+}
+
+template <typename Enum>
+constexpr Enum enum_bit_and(Enum lhs, std::underlying_type_t<Enum> rhs) noexcept
+{
+    return enum_from_value<Enum>(enum_value(lhs) & rhs);
+}
+
+template <typename Enum>
+constexpr Enum enum_bit_not(Enum value) noexcept
+{
+    return enum_from_value<Enum>(~enum_value(value));
+}
+
+template <typename Enum>
+constexpr bool enum_has(Enum value, Enum flag) noexcept
+{
+    return (enum_value(value) & enum_value(flag)) != 0;
+}
 
 #define MAX_PACKETENTITY_BYTES  70  // 68 bytes worst case + 2 byte eof
 

--- a/src/server/mvd/client.cpp
+++ b/src/server/mvd/client.cpp
@@ -1831,26 +1831,28 @@ void MVD_StreamedStop_f(void)
     Com_Printf("[%s] Stopped recording.\n", mvd->name);
 }
 
-static inline int player_flags(mvd_t *mvd, mvd_player_t *player)
+static inline msgPsFlags_t player_flags(mvd_t *mvd, mvd_player_t *player)
 {
-    auto flags = enum_value(mvd->psFlags);
+    auto flags = mvd->psFlags;
 
-    if (!player->inuse)
-        flags |= enum_value(MSG_PS_REMOVE);
+    if (!player->inuse) {
+        flags = enum_bit_or(flags, MSG_PS_REMOVE);
+    }
 
     return flags;
 }
 
-static inline int entity_flags(mvd_t *mvd, edict_t *ent)
+static inline msgEsFlags_t entity_flags(mvd_t *mvd, edict_t *ent)
 {
-    auto flags = enum_value(mvd->esFlags);
+    auto flags = mvd->esFlags;
 
     if (!ent->inuse) {
-        flags |= enum_value(MSG_ES_REMOVE);
+        flags = enum_bit_or(flags, MSG_ES_REMOVE);
     } else if (ent->s.number <= mvd->maxclients) {
         mvd_player_t *player = &mvd->players[ent->s.number - 1];
-        if (player->inuse && player->ps.pmove.pm_type == PM_NORMAL)
-            flags |= MSG_ES_FIRSTPERSON;
+        if (player->inuse && player->ps.pmove.pm_type == PM_NORMAL) {
+            flags = enum_bit_or(flags, MSG_ES_FIRSTPERSON);
+        }
     }
 
     return flags;

--- a/src/server/mvd/client.h
+++ b/src/server/mvd/client.h
@@ -20,43 +20,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "../server.h"
 #include <setjmp.h>
-#include <type_traits>
-
-template <typename Enum>
-constexpr auto enum_value(Enum value) noexcept
-{
-    return static_cast<std::underlying_type_t<Enum>>(value);
-}
-
-template <typename Enum>
-constexpr Enum enum_from_value(std::underlying_type_t<Enum> value) noexcept
-{
-    return static_cast<Enum>(value);
-}
-
-template <typename Enum>
-constexpr void enum_or_assign(Enum &lhs, Enum rhs) noexcept
-{
-    lhs = enum_from_value<Enum>(enum_value(lhs) | enum_value(rhs));
-}
-
-template <typename Enum>
-constexpr void enum_or_assign(Enum &lhs, std::underlying_type_t<Enum> rhs) noexcept
-{
-    lhs = enum_from_value<Enum>(enum_value(lhs) | rhs);
-}
-
-template <typename Enum>
-constexpr void enum_and_assign(Enum &lhs, std::underlying_type_t<Enum> rhs) noexcept
-{
-    lhs = enum_from_value<Enum>(enum_value(lhs) & rhs);
-}
-
-template <typename Enum>
-constexpr bool enum_has(Enum value, Enum flag) noexcept
-{
-    return (enum_value(value) & enum_value(flag)) != 0;
-}
 
 #define MVD_Malloc(size)    Z_TagMalloc(size, TAG_MVD)
 #define MVD_Mallocz(size)   Z_TagMallocz(size, TAG_MVD)

--- a/src/server/mvd/game.cpp
+++ b/src/server/mvd/game.cpp
@@ -777,8 +777,12 @@ void MVD_BroadcastPrintf(mvd_t *mvd, int level, int mask, const char *fmt, ...)
     SZ_Clear(&msg_write);
 }
 
-#define ES_MASK     (MSG_ES_SHORTANGLES | MSG_ES_EXTENSIONS | MSG_ES_EXTENSIONS_2)
-#define PS_MASK     (MSG_PS_EXTENSIONS | MSG_PS_EXTENSIONS_2 | MSG_PS_MOREBITS)
+static constexpr msgEsFlags_t ES_MASK = enum_bit_or(
+    MSG_ES_SHORTANGLES,
+    enum_bit_or(MSG_ES_EXTENSIONS, MSG_ES_EXTENSIONS_2));
+static constexpr msgPsFlags_t PS_MASK = enum_bit_or(
+    MSG_PS_EXTENSIONS,
+    enum_bit_or(MSG_PS_EXTENSIONS_2, MSG_PS_MOREBITS));
 
 static void MVD_SetServerState(client_t *cl, mvd_t *mvd)
 {
@@ -797,13 +801,13 @@ static void MVD_SetServerState(client_t *cl, mvd_t *mvd)
     cl->spawncount = mvd->servercount;
     cl->maxclients = mvd->maxclients;
 
-    enum_and_assign(cl->esFlags, ~ES_MASK);
-    enum_and_assign(cl->psFlags, ~PS_MASK);
-    enum_or_assign(cl->esFlags, enum_value(mvd->esFlags) & ES_MASK);
-    enum_or_assign(cl->psFlags, enum_value(mvd->psFlags) & PS_MASK);
+    cl->esFlags = enum_bit_and(cl->esFlags, enum_bit_not(ES_MASK));
+    cl->psFlags = enum_bit_and(cl->psFlags, enum_bit_not(PS_MASK));
+    cl->esFlags = enum_bit_or(cl->esFlags, enum_bit_and(mvd->esFlags, ES_MASK));
+    cl->psFlags = enum_bit_or(cl->psFlags, enum_bit_and(mvd->psFlags, PS_MASK));
 
-    enum_or_assign(cl->esFlags, MSG_ES_SHORTANGLES);
-    enum_or_assign(cl->esFlags, MSG_ES_EXTENSIONS);
+    cl->esFlags = enum_bit_or(cl->esFlags, MSG_ES_SHORTANGLES);
+    cl->esFlags = enum_bit_or(cl->esFlags, MSG_ES_EXTENSIONS);
 }
 
 void MVD_SwitchChannel(mvd_client_t *client, mvd_t *mvd)

--- a/src/server/mvd/parse.cpp
+++ b/src/server/mvd/parse.cpp
@@ -727,7 +727,7 @@ static void MVD_ParsePacketPlayers(mvd_t *mvd)
 
         bits = MSG_ReadWord();
         if (bits & PPS_MOREBITS) {
-            if (mvd->psFlags & MSG_PS_MOREBITS)
+            if (enum_has(mvd->psFlags, MSG_PS_MOREBITS))
                 bits |= (uint32_t)MSG_ReadByte() << 16;
             else
                 bits |= PPS_REMOVE; // MOREBITS == REMOVE for old demos
@@ -911,33 +911,33 @@ static void MVD_ParseServerData(mvd_t *mvd, int extrabits)
     }
     mvd->clientNum = MSG_ReadShort();
     mvd->esFlags = MSG_ES_UMASK;
-    enum_or_assign(mvd->esFlags, MSG_ES_BEAMORIGIN);
+    mvd->esFlags = enum_bit_or(mvd->esFlags, MSG_ES_BEAMORIGIN);
     mvd->psFlags = static_cast<msgPsFlags_t>(0);
     mvd->csr = &cs_remap_old;
 
     if (mvd->version == PROTOCOL_VERSION_MVD_RERELEASE) {
-        enum_or_assign(mvd->esFlags, MSG_ES_LONGSOLID);
-        enum_or_assign(mvd->esFlags, MSG_ES_SHORTANGLES);
-        enum_or_assign(mvd->esFlags, MSG_ES_EXTENSIONS);
-        enum_or_assign(mvd->esFlags, MSG_ES_RERELEASE);
-        enum_or_assign(mvd->psFlags, MSG_PS_EXTENSIONS);
-        enum_or_assign(mvd->psFlags, MSG_PS_RERELEASE);
+        mvd->esFlags = enum_bit_or(mvd->esFlags, MSG_ES_LONGSOLID);
+        mvd->esFlags = enum_bit_or(mvd->esFlags, MSG_ES_SHORTANGLES);
+        mvd->esFlags = enum_bit_or(mvd->esFlags, MSG_ES_EXTENSIONS);
+        mvd->esFlags = enum_bit_or(mvd->esFlags, MSG_ES_RERELEASE);
+        mvd->psFlags = enum_bit_or(mvd->psFlags, MSG_PS_EXTENSIONS);
+        mvd->psFlags = enum_bit_or(mvd->psFlags, MSG_PS_RERELEASE);
         mvd->csr = &cs_remap_rerelease;
     } else if (mvd->version >= PROTOCOL_VERSION_MVD_EXTENDED_LIMITS && enum_has(mvd->flags, MVF_EXTLIMITS)) {
-        enum_or_assign(mvd->esFlags, MSG_ES_LONGSOLID);
-        enum_or_assign(mvd->esFlags, MSG_ES_SHORTANGLES);
-        enum_or_assign(mvd->esFlags, MSG_ES_EXTENSIONS);
-        enum_or_assign(mvd->psFlags, MSG_PS_EXTENSIONS);
+        mvd->esFlags = enum_bit_or(mvd->esFlags, MSG_ES_LONGSOLID);
+        mvd->esFlags = enum_bit_or(mvd->esFlags, MSG_ES_SHORTANGLES);
+        mvd->esFlags = enum_bit_or(mvd->esFlags, MSG_ES_EXTENSIONS);
+        mvd->psFlags = enum_bit_or(mvd->psFlags, MSG_PS_EXTENSIONS);
         mvd->csr = &cs_remap_q2pro_new;
     }
     if (mvd->version >= PROTOCOL_VERSION_MVD_EXTENDED_LIMITS_2 && enum_has(mvd->flags, MVF_EXTLIMITS_2)) {
-        enum_or_assign(mvd->esFlags, MSG_ES_EXTENSIONS_2);
-        enum_or_assign(mvd->psFlags, MSG_PS_EXTENSIONS_2);
+        mvd->esFlags = enum_bit_or(mvd->esFlags, MSG_ES_EXTENSIONS_2);
+        mvd->psFlags = enum_bit_or(mvd->psFlags, MSG_PS_EXTENSIONS_2);
         if (!enum_has(mvd->flags, MVF_EXTLIMITS)) {
             MVD_Destroyf(mvd, "MVF_EXTLIMITS_2 without MVF_EXTLIMITS");
         }
         if (mvd->version >= PROTOCOL_VERSION_MVD_PLAYERFOG)
-            enum_or_assign(mvd->psFlags, MSG_PS_MOREBITS);
+            mvd->psFlags = enum_bit_or(mvd->psFlags, MSG_PS_MOREBITS);
     }
 
     /* HACKY: is_game_rerelease must match the value that was used on the server


### PR DESCRIPTION
## Summary
- add reusable enum bitmask helpers to keep protocol flag operations in their enum domains
- update MVD parsing and serialization code to call the helpers and return strongly typed flag values

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f40b60bf1c832894ce193aa59d4909