### PR TITLE
Fix BSP visibility storage for MSVC compatibility

### DIFF
--- a/inc/format/bsp.h
+++ b/inc/format/bsp.h
@@ -71,8 +71,43 @@ typedef struct {
 
 typedef struct {
     uint32_t    numclusters;
-    uint32_t    bitofs[][2];    // bitofs[numclusters][2]
+    uint32_t    data[1];        // trailing storage (bit offsets + compressed data)
 } dvis_t;
+
+static inline uint32_t *DVis_BitOfsMutable(dvis_t *vis)
+{
+    return vis->data;
+}
+
+static inline const uint32_t *DVis_BitOfsConst(const dvis_t *vis)
+{
+    return vis->data;
+}
+
+static inline uint32_t DVis_BitOfsIndex(uint32_t cluster, int which)
+{
+    return cluster * 2u + (uint32_t)which;
+}
+
+static inline uint32_t DVis_GetBitOfs(const dvis_t *vis, uint32_t cluster, int which)
+{
+    return DVis_BitOfsConst(vis)[DVis_BitOfsIndex(cluster, which)];
+}
+
+static inline void DVis_SetBitOfs(dvis_t *vis, uint32_t cluster, int which, uint32_t value)
+{
+    DVis_BitOfsMutable(vis)[DVis_BitOfsIndex(cluster, which)] = value;
+}
+
+static inline unsigned char *DVis_VisData(dvis_t *vis)
+{
+    return (unsigned char *)(DVis_BitOfsMutable(vis) + vis->numclusters * 2u);
+}
+
+static inline const unsigned char *DVis_VisDataConst(const dvis_t *vis)
+{
+    return (const unsigned char *)(DVis_BitOfsConst(vis) + vis->numclusters * 2u);
+}
 
 //=============================================================================
 

--- a/src/common/bsp.cpp
+++ b/src/common/bsp.cpp
@@ -1130,7 +1130,7 @@ void BSP_ClusterVis(const bsp_t *bsp, visrow_t *mask, int cluster, int vis)
     // decompress vis
     const auto *vis_bytes = reinterpret_cast<const byte *>(bsp->vis);
     in_end = vis_bytes + bsp->numvisibility;
-    in = vis_bytes + bsp->vis->bitofs[cluster][vis];
+    in = vis_bytes + DVis_GetBitOfs(bsp->vis, (uint32_t)cluster, vis);
     out_end = mask->b + bsp->visrowsize;
     out = mask->b;
     do {

--- a/src/common/bsp_template.cpp
+++ b/src/common/bsp_template.cpp
@@ -80,11 +80,11 @@ BSP_LOAD(Visibility)
         for (int j = 0; j < 2; ++j) {
             const uint32_t bitofs = BSP_Long();
             BSP_ENSURE(bitofs >= hdrsize && bitofs < count, "Bad bitofs");
-            bsp->vis->bitofs[i][j] = bitofs;
+            DVis_SetBitOfs(bsp->vis, i, j, bitofs);
         }
     }
 
-    memcpy(bsp->vis->bitofs + numclusters, in, count - hdrsize);
+    memcpy(DVis_VisData(bsp->vis), in, count - hdrsize);
 
     return Q_ERR_SUCCESS;
 }


### PR DESCRIPTION
## Summary
- replace the BSP visibility header's 2-D flexible array with a trailing storage buffer and helper accessors that MSVC accepts
- adjust visibility lump loading and decoding code to use the new helper APIs while keeping serialized offsets unchanged

## Testing
- not run (MSVC build environment unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f4a1c7189883288599b9e1d2c8269a