### PR TITLE
Fix MSVC enum conversions and const correctness in client parsing

### DIFF
--- a/src/client/gtv.cpp
+++ b/src/client/gtv.cpp
@@ -53,11 +53,13 @@ static void build_gamestate(void)
     }
 
     // set protocol flags
-    cls.gtv.esFlags = MSG_ES_UMASK | MSG_ES_BEAMORIGIN | (cl.esFlags & CL_ES_EXTENDED_MASK_2);
-    cls.gtv.psFlags = MSG_PS_FORCE | MSG_PS_RERELEASE | (cl.psFlags & CL_PS_EXTENDED_MASK_2);
+    cls.gtv.esFlags = enum_bit_or(MSG_ES_UMASK, MSG_ES_BEAMORIGIN);
+    cls.gtv.esFlags = enum_bit_or(cls.gtv.esFlags, static_cast<msgEsFlags_t>(cl.esFlags & CL_ES_EXTENDED_MASK_2));
+    cls.gtv.psFlags = enum_bit_or(MSG_PS_FORCE, MSG_PS_RERELEASE);
+    cls.gtv.psFlags = enum_bit_or(cls.gtv.psFlags, static_cast<msgPsFlags_t>(cl.psFlags & CL_PS_EXTENDED_MASK_2));
 
     if (cls.gtv.psFlags & MSG_PS_EXTENSIONS_2)
-        cls.gtv.psFlags |= MSG_PS_MOREBITS;
+        cls.gtv.psFlags = enum_bit_or(cls.gtv.psFlags, MSG_PS_MOREBITS);
 }
 
 static void emit_gamestate(void)

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -2008,7 +2008,7 @@ static bool match_ignore_nick(const char *nick, const char *s)
         return true;
 
     if (*s == '[') {
-        char *p = strstr(s + 1, "] ");
+        const char *p = strstr(s + 1, "] ");
         if (p)
             return match_ignore_nick_2(nick, p + 2);
     }

--- a/src/client/parse.cpp
+++ b/src/client/parse.cpp
@@ -271,9 +271,9 @@ static void apply_playerstate(const q2proto_svc_playerstate_t *playerstate,
     if (playerstate->delta_bits & Q2P_PSD_PM_TYPE) {
         // assume PM type & flags are from rerelease when using Q2rePRO protocol, vanilla otherwise
         if (cls.serverProtocol == PROTOCOL_VERSION_RERELEASE)
-            to->pmove.pm_type = playerstate->pm_type;
+            to->pmove.pm_type = static_cast<pmtype_t>(playerstate->pm_type);
         else
-            to->pmove.pm_type = pmtype_from_game3(playerstate->pm_type);
+            to->pmove.pm_type = pmtype_from_game3(static_cast<game3_pmtype_t>(playerstate->pm_type));
     }
 
     q2proto_maybe_read_diff_apply_float(&playerstate->pm_origin, to->pmove.origin);
@@ -642,9 +642,9 @@ static void CL_ParseServerData(const q2proto_svc_serverdata_t *serverdata)
             Com_DPrintf("R1Q2 strafejump hack enabled\n");
             cl.pmp.strafehack = true;
         }
-        cl.esFlags |= MSG_ES_BEAMORIGIN;
+        cl.esFlags = enum_bit_or(cl.esFlags, MSG_ES_BEAMORIGIN);
         if (cls.q2proto_ctx.features.has_solid32) {
-            cl.esFlags |= MSG_ES_LONGSOLID;
+            cl.esFlags = enum_bit_or(cl.esFlags, MSG_ES_LONGSOLID);
         }
         cl.pmp.speedmult = 2;
     } else if (cls.serverProtocol == PROTOCOL_VERSION_Q2PRO) {
@@ -683,18 +683,19 @@ static void CL_ParseServerData(const q2proto_svc_serverdata_t *serverdata)
                 Com_Error(ERR_DROP, "Q2PRO_PF_EXTENSIONS_2 without Q2PRO_PF_EXTENSIONS");
             }
             Com_DPrintf("WORR protocol extensions v2 enabled\n");
-            cl.esFlags |= MSG_ES_EXTENSIONS_2;
-            cl.psFlags |= MSG_PS_EXTENSIONS_2;
+            cl.esFlags = enum_bit_or(cl.esFlags, MSG_ES_EXTENSIONS_2);
+            cl.psFlags = enum_bit_or(cl.psFlags, MSG_PS_EXTENSIONS_2);
             if (cls.protocolVersion >= PROTOCOL_VERSION_Q2PRO_PLAYERFOG)
-                cl.psFlags |= MSG_PS_MOREBITS;
+                cl.psFlags = enum_bit_or(cl.psFlags, MSG_PS_MOREBITS);
             PmoveEnableExt(&cl.pmp);
         }
-        cl.esFlags |= MSG_ES_UMASK | MSG_ES_LONGSOLID;
+        cl.esFlags = enum_bit_or(cl.esFlags, MSG_ES_UMASK);
+        cl.esFlags = enum_bit_or(cl.esFlags, MSG_ES_LONGSOLID);
         if (cls.protocolVersion >= PROTOCOL_VERSION_Q2PRO_BEAM_ORIGIN) {
-            cl.esFlags |= MSG_ES_BEAMORIGIN;
+            cl.esFlags = enum_bit_or(cl.esFlags, MSG_ES_BEAMORIGIN);
         }
         if (cls.protocolVersion >= PROTOCOL_VERSION_Q2PRO_SHORT_ANGLES) {
-            cl.esFlags |= MSG_ES_SHORTANGLES;
+            cl.esFlags = enum_bit_or(cl.esFlags, MSG_ES_SHORTANGLES);
         }
         cl.pmp.speedmult = 2;
         cl.pmp.flyhack = true; // fly hack is unconditionally enabled
@@ -708,10 +709,12 @@ static void CL_ParseServerData(const q2proto_svc_serverdata_t *serverdata)
             cl.csr = cs_remap_rerelease;
         else if (cl.game_api >= Q2PROTO_GAME_Q2PRO_EXTENDED)
             cl.csr = cs_remap_q2pro_new;
-        cl.psFlags |= MSG_PS_RERELEASE | MSG_PS_EXTENSIONS;
+        cl.psFlags = enum_bit_or(cl.psFlags, MSG_PS_RERELEASE);
+        cl.psFlags = enum_bit_or(cl.psFlags, MSG_PS_EXTENSIONS);
         if (cl.game_api == Q2PROTO_GAME_Q2PRO_EXTENDED_V2)
-            cl.psFlags |= MSG_PS_EXTENSIONS_2;
-        cl.esFlags |= MSG_ES_RERELEASE | CL_ES_EXTENDED_MASK;
+            cl.psFlags = enum_bit_or(cl.psFlags, MSG_PS_EXTENSIONS_2);
+        cl.esFlags = enum_bit_or(cl.esFlags, MSG_ES_RERELEASE);
+        cl.esFlags = enum_bit_or(cl.esFlags, CL_ES_EXTENDED_MASK);
         set_server_fps(serverdata->q2repro.server_fps);
         /* Rerelease game assumes client & server framerate is in sync,
          * non-rerelease games w/ variable FPS (eg OpenFFA) seem to assume
@@ -736,17 +739,17 @@ static void CL_ParseServerData(const q2proto_svc_serverdata_t *serverdata)
     }
 
     if (cl.csr.extended) {
-        cl.esFlags |= CL_ES_EXTENDED_MASK;
-        cl.psFlags |= MSG_PS_EXTENSIONS;
+        cl.esFlags = enum_bit_or(cl.esFlags, CL_ES_EXTENDED_MASK);
+        cl.psFlags = enum_bit_or(cl.psFlags, MSG_PS_EXTENSIONS);
 
         // hack for demo playback
         if (EXTENDED_SUPPORTED(protocol)) {
             if (protocol >= PROTOCOL_VERSION_EXTENDED_LIMITS_2) {
-                cl.esFlags |= MSG_ES_EXTENSIONS_2;
-                cl.psFlags |= MSG_PS_EXTENSIONS_2;
+                cl.esFlags = enum_bit_or(cl.esFlags, MSG_ES_EXTENSIONS_2);
+                cl.psFlags = enum_bit_or(cl.psFlags, MSG_PS_EXTENSIONS_2);
             }
             if (protocol >= PROTOCOL_VERSION_EXTENDED_PLAYERFOG)
-                cl.psFlags |= MSG_PS_MOREBITS;
+                cl.psFlags = enum_bit_or(cl.psFlags, MSG_PS_MOREBITS);
         }
 
         cl.pmp.extended_server_ver = cl.psFlags & MSG_PS_EXTENSIONS_2 ? 2 : 1;
@@ -857,7 +860,7 @@ static void CL_ParseReconnect(void)
 #if USE_AUTOREPLY
 static void CL_CheckForVersion(const char *s)
 {
-    char *p;
+    const char *p;
 
     p = strstr(s, ": ");
     if (!p) {
@@ -1050,7 +1053,7 @@ static void CL_ParseDownload(const q2proto_svc_download_t *download)
         Com_Error(ERR_DROP, "%s: bad size: %d", __func__, size);
     }
 
-    CL_HandleDownload(download->data, size, percent);
+    CL_HandleDownload(static_cast<const byte *>(download->data), size, percent);
 }
 
 static void CL_ParseSetting(const q2proto_svc_setting_t *setting)


### PR DESCRIPTION
## Summary
- cast pm_type bytes to the proper enums before assignment or helper calls
- replace direct bitwise updates on cl.esFlags/cl.psFlags with enum_bit_or usage
- preserve const correctness in chat parsing helpers and download handling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f4a576b4348328aa50e87bb226fc0c