### PR TITLE
Explicitly cast menu highlight control character

### DIFF
--- a/src/server/mvd/game.cpp
+++ b/src/server/mvd/game.cpp
@@ -265,7 +265,7 @@ static void MVD_LayoutMenu(mvd_client_t *client)
     size_t total;
 
     memset(cur, 0x20, sizeof(cur));
-    cur[clamp_menu_cursor(client)] = 0x8d;
+    cur[clamp_menu_cursor(client)] = static_cast<char>(0x8d);
 
     total = Q_scnprintf(layout, sizeof(layout), format,
                         cur[0], client->target ? "Leave" : "Enter", cur[1],


### PR DESCRIPTION
## Summary
- cast the menu highlight literal to `char` before storing it in the cursor buffer to make the narrowing explicit

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f4a578694083288ce2e2c9355de22d