### PR TITLE
Fix Windows hunk alignment calculations

### DIFF
--- a/src/windows/hunk.cpp
+++ b/src/windows/hunk.cpp
@@ -33,11 +33,13 @@ void Hunk_Init(void)
 
 void Hunk_Begin(memhunk_t *hunk, size_t maxsize)
 {
-    Q_assert(maxsize <= SIZE_MAX - (pagesize - 1));
+    const size_t page_size = static_cast<size_t>(pagesize);
+
+    Q_assert(maxsize <= SIZE_MAX - (page_size - 1));
 
     // reserve a huge chunk of memory, but don't commit any yet
     hunk->cursize = 0;
-    hunk->maxsize = Q_ALIGN(maxsize, pagesize);
+    hunk->maxsize = Q_ALIGN(maxsize, page_size);
     hunk->base = VirtualAlloc(NULL, hunk->maxsize, MEM_RESERVE, PAGE_NOACCESS);
     if (!hunk->base)
         Com_Error(ERR_FATAL,
@@ -81,7 +83,8 @@ void Hunk_FreeToWatermark(memhunk_t *hunk, size_t size)
 {
     Q_assert(size <= hunk->cursize);
 
-    size_t newsize = Q_ALIGN(size, pagesize);
+    const size_t page_size = static_cast<size_t>(pagesize);
+    size_t newsize = Q_ALIGN(size, page_size);
     if (newsize < hunk->cursize) {
         Q_assert(hunk->base);
         Q_assert(newsize <= hunk->maxsize);
@@ -96,7 +99,8 @@ void Hunk_End(memhunk_t *hunk)
     Q_assert(hunk->cursize <= hunk->maxsize);
 
     // for statistics
-    hunk->mapped = Q_ALIGN(hunk->cursize, pagesize);
+    const size_t page_size = static_cast<size_t>(pagesize);
+    hunk->mapped = Q_ALIGN(hunk->cursize, page_size);
 }
 
 void Hunk_Free(memhunk_t *hunk)


### PR DESCRIPTION
## Summary
- promote the Windows hunk page size to size_t before invoking Q_ALIGN
- ensure all alignment calculations in the Windows hunk code operate on size_t values to avoid MSVC C4319 warnings

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f4a57d1564832892891f143f5443e8