### PR TITLE
Address Codex review feedback: enforce cgame tag upper bound

### DIFF
--- a/src/client/cgame.cpp
+++ b/src/client/cgame.cpp
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "common/loc.h"
 #include "common/gamedll.h"
 
+#include <cstdint>
 #include <limits>
 #include <type_traits>
 
@@ -111,6 +112,12 @@ static memtag_t CG_ValidateGameTag(int tag, const char *func)
 
     constexpr underlying_tag_t offset = static_cast<underlying_tag_t>(TAG_MAX);
     const long long converted = static_cast<long long>(tag) + static_cast<long long>(offset);
+    const long long allocator_limit = static_cast<long long>(std::numeric_limits<std::uint16_t>::max());
+
+    if (converted > allocator_limit) {
+        Com_Error(ERR_DROP, "%s: bad tag", func);
+    }
+
     const long long max_value = static_cast<long long>(std::numeric_limits<underlying_tag_t>::max());
 
     if (converted > max_value) {


### PR DESCRIPTION
## Summary
- restore the allocator upper bound check in `CG_ValidateGameTag` so cgame tags stay within the 16-bit zone range

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f4a9f98a808328a869f87ddc357b8d