### PR TITLE
Fix async queue typed pointer usage

### DIFF
--- a/src/common/async.cpp
+++ b/src/common/async.cpp
@@ -72,7 +72,7 @@ void Com_QueueAsyncWork(asyncwork_t *work)
     }
 
     pthread_mutex_lock(&work_lock);
-    append_work(&pend_head, Z_CopyStruct(work));
+    append_work(&pend_head, (asyncwork_t *)Z_CopyStruct(work));
     pthread_mutex_unlock(&work_lock);
 
     pthread_cond_signal(&work_cond);


### PR DESCRIPTION
## Summary
- cast queued async work allocations to `asyncwork_t*` to avoid implicit void pointer conversions in C++
- verify remaining `Z_CopyStruct` call sites do not rely on implicit conversions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f4ac89bf488328bef7310ce8c26c75