### PR TITLE
Add explicit casts for enum conversions in sound activation

### DIFF
--- a/src/client/sound/main.cpp
+++ b/src/client/sound/main.cpp
@@ -200,7 +200,7 @@ void S_Init(void)
     OGG_Play();
 
 fail:
-    Cvar_SetInteger(s_enable, s_started, FROM_CODE);
+    Cvar_SetInteger(s_enable, static_cast<int>(s_started), FROM_CODE);
     Com_Printf("----------------------\n");
 }
 
@@ -268,7 +268,7 @@ void S_Activate(void)
     if (!s_started)
         return;
 
-    level = Cvar_ClampInteger(s_auto_focus, ACT_MINIMIZED, ACT_ACTIVATED);
+    level = static_cast<active_t>(Cvar_ClampInteger(s_auto_focus, ACT_MINIMIZED, ACT_ACTIVATED));
 
     active = cls.active >= level;
 


### PR DESCRIPTION
## Summary
- cast the clamped auto-focus level to `active_t` before comparing to the client state
- cast the sound start state when writing it back to the `s_enable` cvar

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f4ac8a8ae08328aba94ebc93a7f2fb