### PR TITLE
Refactor fade distance call

### DIFF
--- a/src/client/view.cpp
+++ b/src/client/view.cpp
@@ -155,7 +155,8 @@ void V_AddLightEx(cl_shadow_light_t *light)
     if (r_numdlights >= MAX_DLIGHTS)
         return;
     
-    float fade = fade_distance_to_light((const vec2_t) { light->fade_start, light->fade_end }, light->origin, cl.refdef.vieworg);
+    const vec2_t fade_range = { light->fade_start, light->fade_end };
+    float fade = fade_distance_to_light(fade_range, light->origin, cl.refdef.vieworg);
 
     if (fade <= 0.0f)
         return;


### PR DESCRIPTION
## Summary
- replace the compound literal passed to `fade_distance_to_light` with a temporary `vec2_t` variable

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f4ae710b1483288c9fdae8842422f6