### PR TITLE
refactor: replace designated initializers in precache

### DIFF
--- a/src/client/precache.cpp
+++ b/src/client/precache.cpp
@@ -425,7 +425,8 @@ CL_LoadWheelIcons
 */
 static cl_wheel_icon_t CL_LoadWheelIcons(int icon_index)
 {
-    cl_wheel_icon_t icons = { .main = cl.image_precache[icon_index] };
+    cl_wheel_icon_t icons{};
+    icons.main = cl.image_precache[icon_index];
 
     char path[MAX_QPATH];
     Q_snprintf(path, sizeof(path), "wheel/%s", cl.configstrings[cl.csr.images + icon_index]);


### PR DESCRIPTION
## Summary
- replace the designated initializer in `CL_LoadWheelIcons` with default initialization followed by explicit member assignment
- ensure `src/client/precache.cpp` no longer uses designated initializers

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f4ae72cb288328a78b0afdaf4efd3a