### PR TITLE
Add Windows max macro guard to cgame helper

### DIFF
--- a/src/client/cgame.cpp
+++ b/src/client/cgame.cpp
@@ -25,6 +25,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <limits>
 #include <type_traits>
 
+#ifdef max
+#undef max
+#endif
+
 static cvar_t   *scr_alpha;
 static cvar_t   *scr_font;
 


### PR DESCRIPTION
## Summary
- undefine the Windows max macro in cgame.cpp so std::numeric_limits::max() resolves properly

## Testing
- not run (MSVC-specific guard change)

------
https://chatgpt.com/codex/tasks/task_e_68f4af48510c8328b2778caeb60f6474