### PR TITLE
Fix wheel slot comparator casts

### DIFF
--- a/src/client/wheel.cpp
+++ b/src/client/wheel.cpp
@@ -243,8 +243,8 @@ static cvar_t *ww_ammo_scale;
 
 static int wheel_slot_compare(const void *a, const void *b)
 {
-    const cl_wheel_slot_t *sa = a;
-    const cl_wheel_slot_t *sb = b;
+    const cl_wheel_slot_t *sa = static_cast<const cl_wheel_slot_t *>(a);
+    const cl_wheel_slot_t *sb = static_cast<const cl_wheel_slot_t *>(b);
 
     if (sa->sort_id == sb->sort_id)
         return sa->item_index - sb->item_index;


### PR DESCRIPTION
## Summary
- replace the implicit void* conversions in wheel_slot_compare with static_cast to cl_wheel_slot_t

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f4af4bdc8c83288f2b53006d8dce29