### PR TITLE
Improve SV error type bitmask handling

### DIFF
--- a/src/server/init.cpp
+++ b/src/server/init.cpp
@@ -397,7 +397,8 @@ void SV_InitGame(unsigned mvd_spawn)
 
     if (svs.initialized) {
         // cause any connected clients to reconnect
-        SV_Shutdown("Server restarted\n", ERR_RECONNECT | mvd_spawn);
+        const error_type_t shutdown_type = SV_ErrorTypeWithMask(ERR_RECONNECT, mvd_spawn);
+        SV_Shutdown("Server restarted\n", shutdown_type);
     } else {
         // make sure the client is down
         CL_Disconnect(ERR_RECONNECT);

--- a/src/server/main.cpp
+++ b/src/server/main.cpp
@@ -2315,12 +2315,12 @@ void SV_Shutdown(const char *finalmsg, error_type_t type)
     R_ClearDebugLines();    // for local system
 
 #if USE_MVD_CLIENT
-    if (ge != &mvd_ge && !(type & MVD_SPAWN_INTERNAL)) {
+    if (ge != &mvd_ge && !SV_ErrorTypeHasAny(type, MVD_SPAWN_INTERNAL)) {
         // shutdown MVD client now if not already running the built-in MVD game module
         // don't shutdown if called from internal MVD spawn function (ugly hack)!
         MVD_Shutdown();
     }
-    type &= ~MVD_SPAWN_MASK;
+    type = SV_ErrorTypeWithoutMask(type, MVD_SPAWN_MASK);
 #endif
 
     AC_Disconnect();

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -102,6 +102,28 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define MVD_SPAWN_INTERNAL  BIT(31)
 #define MVD_SPAWN_MASK      (MVD_SPAWN_ENABLED | MVD_SPAWN_INTERNAL)
 
+static inline unsigned SV_ErrorTypeBits(error_type_t type)
+{
+    return static_cast<unsigned>(type);
+}
+
+static inline bool SV_ErrorTypeHasAny(error_type_t type, unsigned mask)
+{
+    return (SV_ErrorTypeBits(type) & mask) != 0u;
+}
+
+static inline error_type_t SV_ErrorTypeWithMask(error_type_t type, unsigned mask)
+{
+    const unsigned combined = SV_ErrorTypeBits(type) | mask;
+    return static_cast<error_type_t>(combined);
+}
+
+static inline error_type_t SV_ErrorTypeWithoutMask(error_type_t type, unsigned mask)
+{
+    const unsigned filtered = SV_ErrorTypeBits(type) & ~mask;
+    return static_cast<error_type_t>(filtered);
+}
+
 typedef struct {
     int         number;
     int         num_entities;


### PR DESCRIPTION
## Summary
- add inline helpers to convert error_type_t values when applying mask operations
- use the helpers to clear MVD spawn flags safely inside SV_Shutdown
- update SV_InitGame to combine reconnect errors with spawn flags via the helper for future mask safety

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f4bac9b670832883fa20c9c9396cb8