### PR TITLE
Fix map command cleanup compliance

### DIFF
--- a/src/server/commands.cpp
+++ b/src/server/commands.cpp
@@ -249,14 +249,13 @@ another level:
 
 static void abort_func(void *arg)
 {
-    CM_FreeMap(arg);
+    CM_FreeMap(static_cast<cm_t *>(arg));
 }
 
 static void SV_Map(bool restart)
 {
-    mapcmd_t cmd = {
-        .endofunit = restart,   // wipe savegames
-    };
+    mapcmd_t cmd{};
+    cmd.endofunit = restart;   // wipe savegames
 
     // save the mapcmd
     if (Cmd_ArgvBuffer(1, cmd.buffer, sizeof(cmd.buffer)) >= sizeof(cmd.buffer)) {
@@ -511,7 +510,7 @@ static void SV_Map_c(genctx_t *ctx, int argnum)
         Prompt_AddMatch(ctx, va("%.*s", len, s));
     }
 
-    FS_FreeList(list);
+    FS_FreeList(reinterpret_cast<void **>(list));
 }
 
 static void SV_DemoMap_c(genctx_t *ctx, int argnum)


### PR DESCRIPTION
## Summary
- cast abort cleanup callback arguments to `cm_t *`
- replace designated initializer for `mapcmd_t` with standard C++17 initialization
- pass file list arrays to `FS_FreeList` using `void **` pointers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f4bac9c8d88328ab2bec94f66438de