### PR TITLE
Fix renderer debug helper compatibility with MSVC

### DIFF
--- a/src/refresh/debug.cpp
+++ b/src/refresh/debug.cpp
@@ -119,18 +119,19 @@ void R_AddDebugLine(const vec3_t start, const vec3_t end, color_t color, uint32_
         l->bits |= GLS_DEPTHTEST_DISABLE;
 }
 
-#define GL_DRAWLINE(sx, sy, sz, ex, ey, ez) \
-    R_AddDebugLine((const vec3_t) { (sx), (sy), (sz) }, (const vec3_t) { (ex), (ey), (ez) }, color, time, depth_test)
-
-#define GL_DRAWLINEV(s, e) \
-    R_AddDebugLine(s, e, color, time, depth_test)
+static inline void R_DebugDrawLine(float sx, float sy, float sz, float ex, float ey, float ez, color_t color, uint32_t time, qboolean depth_test)
+{
+    vec3_t start{ sx, sy, sz };
+    vec3_t end{ ex, ey, ez };
+    R_AddDebugLine(start, end, color, time, depth_test);
+}
 
 void R_AddDebugPoint(const vec3_t point, float size, color_t color, uint32_t time, qboolean depth_test)
 {
     size *= 0.5f;
-    GL_DRAWLINE(point[0] - size, point[1], point[2], point[0] + size, point[1], point[2]);
-    GL_DRAWLINE(point[0], point[1] - size, point[2], point[0], point[1] + size, point[2]);
-    GL_DRAWLINE(point[0], point[1], point[2] - size, point[0], point[1], point[2] + size);
+    R_DebugDrawLine(point[0] - size, point[1], point[2], point[0] + size, point[1], point[2], color, time, depth_test);
+    R_DebugDrawLine(point[0], point[1] - size, point[2], point[0], point[1] + size, point[2], color, time, depth_test);
+    R_DebugDrawLine(point[0], point[1], point[2] - size, point[0], point[1], point[2] + size, color, time, depth_test);
 }
 
 void R_AddDebugAxis(const vec3_t origin, const vec3_t angles, float size, uint32_t time, qboolean depth_test)
@@ -149,15 +150,15 @@ void R_AddDebugAxis(const vec3_t origin, const vec3_t angles, float size, uint32
 
     color = COLOR_RED;
     VectorMA(origin, size, axis[0], end);
-    GL_DRAWLINEV(origin, end);
+    R_AddDebugLine(origin, end, color, time, depth_test);
 
     color = COLOR_GREEN;
     VectorMA(origin, size, axis[1], end);
-    GL_DRAWLINEV(origin, end);
+    R_AddDebugLine(origin, end, color, time, depth_test);
 
     color = COLOR_BLUE;
     VectorMA(origin, size, axis[2], end);
-    GL_DRAWLINEV(origin, end);
+    R_AddDebugLine(origin, end, color, time, depth_test);
 }
 
 void R_AddDebugBounds(const vec3_t mins, const vec3_t maxs, color_t color, uint32_t time, qboolean depth_test)
@@ -166,14 +167,14 @@ void R_AddDebugBounds(const vec3_t mins, const vec3_t maxs, color_t color, uint3
         // draw column
         float x = ((i > 1) ? mins : maxs)[0];
         float y = ((((i + 1) % 4) > 1) ? mins : maxs)[1];
-        GL_DRAWLINE(x, y, mins[2], x, y, maxs[2]);
+        R_DebugDrawLine(x, y, mins[2], x, y, maxs[2], color, time, depth_test);
 
         // draw bottom & top
         int n = (i + 1) % 4;
         float x2 = ((n > 1) ? mins : maxs)[0];
         float y2 = ((((n + 1) % 4) > 1) ? mins : maxs)[1];
-        GL_DRAWLINE(x, y, mins[2], x2, y2, mins[2]);
-        GL_DRAWLINE(x, y, maxs[2], x2, y2, maxs[2]);
+        R_DebugDrawLine(x, y, mins[2], x2, y2, mins[2], color, time, depth_test);
+        R_DebugDrawLine(x, y, maxs[2], x2, y2, maxs[2], color, time, depth_test);
     }
 }
 
@@ -209,14 +210,14 @@ void R_AddDebugSphere(const vec3_t origin, float radius, color_t color, uint32_t
     for (int i = 0; i < n_slices; i++) {
         int i0 = i + 1;
         int i1 = (i + 1) % n_slices + 1;
-        GL_DRAWLINEV(verts[v0], verts[i1]);
-        GL_DRAWLINEV(verts[i1], verts[i0]);
-        GL_DRAWLINEV(verts[i0], verts[v0]);
+        R_AddDebugLine(verts[v0], verts[i1], color, time, depth_test);
+        R_AddDebugLine(verts[i1], verts[i0], color, time, depth_test);
+        R_AddDebugLine(verts[i0], verts[v0], color, time, depth_test);
         i0 = i + n_slices * (n_stacks - 2) + 1;
         i1 = (i + 1) % n_slices + n_slices * (n_stacks - 2) + 1;
-        GL_DRAWLINEV(verts[v1], verts[i0]);
-        GL_DRAWLINEV(verts[i0], verts[i1]);
-        GL_DRAWLINEV(verts[i1], verts[v1]);
+        R_AddDebugLine(verts[v1], verts[i0], color, time, depth_test);
+        R_AddDebugLine(verts[i0], verts[i1], color, time, depth_test);
+        R_AddDebugLine(verts[i1], verts[v1], color, time, depth_test);
     }
 
     for (int j = 0; j < n_stacks - 2; j++) {
@@ -227,10 +228,10 @@ void R_AddDebugSphere(const vec3_t origin, float radius, color_t color, uint32_t
             int i1 = j0 + (i + 1) % n_slices;
             int i2 = j1 + (i + 1) % n_slices;
             int i3 = j1 + i;
-            GL_DRAWLINEV(verts[i0], verts[i1]);
-            GL_DRAWLINEV(verts[i1], verts[i2]);
-            GL_DRAWLINEV(verts[i2], verts[i3]);
-            GL_DRAWLINEV(verts[i3], verts[i0]);
+            R_AddDebugLine(verts[i0], verts[i1], color, time, depth_test);
+            R_AddDebugLine(verts[i1], verts[i2], color, time, depth_test);
+            R_AddDebugLine(verts[i2], verts[i3], color, time, depth_test);
+            R_AddDebugLine(verts[i3], verts[i0], color, time, depth_test);
         }
     }
 }
@@ -253,7 +254,7 @@ void R_AddDebugCircle(const vec3_t origin, float radius, color_t color, uint32_t
         float x2 = c * radius + origin[0];
         float y2 = s * radius + origin[1];
 
-        GL_DRAWLINE(x, y, origin[2], x2, y2, origin[2]);
+        R_DebugDrawLine(x, y, origin[2], x2, y2, origin[2], color, time, depth_test);
     }
 }
 
@@ -275,9 +276,9 @@ void R_AddDebugCylinder(const vec3_t origin, float half_height, float radius, co
         float x2 = c * radius + origin[0];
         float y2 = s * radius + origin[1];
 
-        GL_DRAWLINE(x, y, origin[2] - half_height, x2, y2, origin[2] - half_height);
-        GL_DRAWLINE(x, y, origin[2] + half_height, x2, y2, origin[2] + half_height);
-        GL_DRAWLINE(x, y, origin[2] - half_height, x,  y,  origin[2] + half_height);
+        R_DebugDrawLine(x, y, origin[2] - half_height, x2, y2, origin[2] - half_height, color, time, depth_test);
+        R_DebugDrawLine(x, y, origin[2] + half_height, x2, y2, origin[2] + half_height, color, time, depth_test);
+        R_DebugDrawLine(x, y, origin[2] - half_height, x, y, origin[2] + half_height, color, time, depth_test);
     }
 }
 

--- a/src/refresh/draw.cpp
+++ b/src/refresh/draw.cpp
@@ -217,7 +217,7 @@ void GL_Blend(void)
         outer.b = glr.fd.damage_blend[2] * 255;
         outer.a = glr.fd.damage_blend[3] * 255;
 
-        inner = ColorSetAlpha(outer, 0);
+        inner = ColorSetAlpha(outer, static_cast<uint8_t>(0));
 
         if (gl_damageblend_frac->value > 0)
             GL_DrawVignette(Cvar_ClampValue(gl_damageblend_frac, 0, 0.5f), outer, inner);

--- a/src/refresh/images.cpp
+++ b/src/refresh/images.cpp
@@ -158,7 +158,7 @@ static int IMG_Unpack8(uint32_t *out, const uint8_t *in, int width, int height)
                 else
                     p = 0;
                 // copy rgb components
-                *out = ColorSetAlpha(ColorU32(d_8to24table[p]), 0).u32;
+                *out = ColorSetAlpha(ColorU32(d_8to24table[p]), static_cast<uint8_t>(0)).u32;
             } else {
                 *out = d_8to24table[p];
             }

--- a/src/server/nav.cpp
+++ b/src/server/nav.cpp
@@ -864,25 +864,25 @@ static void Nav_DebugPath(const PathInfo *path, const PathRequest *request)
 
     int time = (request->debugging.drawTime * 1000) + 6000;
     
-    color_t path_color = ColorSetAlpha(COLOR_RED, 64);
-    color_t arrow_color = ColorSetAlpha(COLOR_YELLOW, 64);
+    color_t path_color = ColorSetAlpha(COLOR_RED, static_cast<uint8_t>(64));
+    color_t arrow_color = ColorSetAlpha(COLOR_YELLOW, static_cast<uint8_t>(64));
 
-    R_AddDebugSphere(request->start, 8.0f, path_color, time, false);
-    R_AddDebugSphere(request->goal, 8.0f, path_color, time, false);
+    R_AddDebugSphere(request->start, 8.0f, path_color, time, qfalse);
+    R_AddDebugSphere(request->goal, 8.0f, path_color, time, qfalse);
 
     if (request->pathPoints.count) {
-        R_AddDebugArrow(request->start, request->pathPoints.posArray[0], 8.0f, arrow_color, arrow_color, time, false);
+        R_AddDebugArrow(request->start, request->pathPoints.posArray[0], 8.0f, arrow_color, arrow_color, time, qfalse);
 
         for (int64_t i = 0; i < request->pathPoints.count - 1; i++)
-            R_AddDebugArrow(request->pathPoints.posArray[i], request->pathPoints.posArray[i + 1], 8.0f, arrow_color, arrow_color, time, false);
+            R_AddDebugArrow(request->pathPoints.posArray[i], request->pathPoints.posArray[i + 1], 8.0f, arrow_color, arrow_color, time, qfalse);
 
-        R_AddDebugArrow(request->pathPoints.posArray[request->pathPoints.count - 1], request->goal, 8.0f, arrow_color, arrow_color, time, false);
+        R_AddDebugArrow(request->pathPoints.posArray[request->pathPoints.count - 1], request->goal, 8.0f, arrow_color, arrow_color, time, qfalse);
     } else {
-        R_AddDebugArrow(request->start, request->goal, 8.0f, arrow_color, arrow_color, time, false);
+        R_AddDebugArrow(request->start, request->goal, 8.0f, arrow_color, arrow_color, time, qfalse);
     }
 
-    R_AddDebugSphere(path->firstMovePoint, 16.0f, path_color, time, false);
-    R_AddDebugArrow(path->firstMovePoint, path->secondMovePoint, 16.0f, path_color, path_color, time, false);
+    R_AddDebugSphere(path->firstMovePoint, 16.0f, path_color, time, qfalse);
+    R_AddDebugArrow(path->firstMovePoint, path->secondMovePoint, 16.0f, path_color, path_color, time, qfalse);
 }
 #endif
 
@@ -1128,27 +1128,27 @@ static inline void Nav_GetCurveControlPoint(const vec3_t a, const vec3_t b, vec3
 // just to reduce verbosity at call sites
 static inline void Nav_AddDebugLine(const vec3_t s, const vec3_t e, const color_t c)
 {
-    R_AddDebugLine(s, e, c, SV_FRAMETIME, true);
+    R_AddDebugLine(s, e, c, SV_FRAMETIME, qtrue);
 }
 static inline void Nav_AddDebugArrow(const vec3_t s, const vec3_t e, const color_t lc, const color_t ac)
 {
-    R_AddDebugArrow(s, e, 8.0f, lc, ac, SV_FRAMETIME, true);
+    R_AddDebugArrow(s, e, 8.0f, lc, ac, SV_FRAMETIME, qtrue);
 }
 static inline void Nav_AddDebugCurveArrow(const vec3_t s, const vec3_t c, const vec3_t e, const color_t lc, const color_t ac)
 {
-    R_AddDebugCurveArrow(s, c, e, 8.0f, lc, ac, SV_FRAMETIME, true);
+    R_AddDebugCurveArrow(s, c, e, 8.0f, lc, ac, SV_FRAMETIME, qtrue);
 }
 static inline void Nav_AddDebugCircle(const vec3_t o, const float r, const color_t c)
 {
-    R_AddDebugCircle(o, r, c, SV_FRAMETIME, true);
+    R_AddDebugCircle(o, r, c, SV_FRAMETIME, qtrue);
 }
 static inline void Nav_AddDebugBounds(const vec3_t min, const vec3_t max, const color_t c)
 {
-    R_AddDebugBounds(min, max, c, SV_FRAMETIME, true);
+    R_AddDebugBounds(min, max, c, SV_FRAMETIME, qtrue);
 }
 static inline void Nav_AddDebugText(const vec3_t o, const vec3_t a, const char *t, float s, color_t c)
 {
-    R_AddDebugText(o, a, t, s, c, SV_FRAMETIME, true);
+    R_AddDebugText(o, a, t, s, c, SV_FRAMETIME, qtrue);
 }
 
 static void Nav_RenderLinkEdict(const vec3_t start, const vec3_t end, const nav_edict_t *edict)
@@ -1159,9 +1159,9 @@ static void Nav_RenderLinkEdict(const vec3_t start, const vec3_t end, const nav_
     LerpVector(start, end, 0.5f, e);
     VectorMA(e, 24.f, u, e);
     
-    R_AddDebugLine(start, e, COLOR_BLUE, SV_FRAMETIME, true);
-    R_AddDebugLine(end, e, COLOR_BLUE, SV_FRAMETIME, true);
-    R_AddDebugSphere(e, 8.0f, COLOR_RED, SV_FRAMETIME, true);
+    R_AddDebugLine(start, e, COLOR_BLUE, SV_FRAMETIME, qtrue);
+    R_AddDebugLine(end, e, COLOR_BLUE, SV_FRAMETIME, qtrue);
+    R_AddDebugSphere(e, 8.0f, COLOR_RED, SV_FRAMETIME, qtrue);
 
     vec3_t d;
     VectorSubtract(glr.fd.vieworg, e, d);
@@ -1176,14 +1176,14 @@ static void Nav_RenderLinkEdict(const vec3_t start, const vec3_t end, const nav_
                      (e[i] > edict->game_edict->absmax[i]) ? edict->game_edict->absmax[i] :
                       e[i];
 
-        R_AddDebugLine(org, e, COLOR_GREEN, SV_FRAMETIME, false);
-        R_AddDebugBounds(edict->game_edict->absmin, edict->game_edict->absmax, COLOR_GREEN, SV_FRAMETIME, false);
+        R_AddDebugLine(org, e, COLOR_GREEN, SV_FRAMETIME, qfalse);
+        R_AddDebugBounds(edict->game_edict->absmin, edict->game_edict->absmax, COLOR_GREEN, SV_FRAMETIME, qfalse);
     }
     
     e[2] += 16.f;
     R_AddDebugText(e, NULL, va("entity %i\nmodel %i\nclassname %s", 
         edict->game_edict->s.number, edict->game_edict->s.modelindex, edict->game_edict->sv.classname ? edict->game_edict->sv.classname : "!noclass!"),
-        0.25f, COLOR_YELLOW, SV_FRAMETIME, false);
+        0.25f, COLOR_YELLOW, SV_FRAMETIME, qfalse);
 }
 
 static void Nav_RenderLink(const nav_node_t *node, int node_id, const vec3_t node_origin, const nav_link_t *link, uint8_t alpha)
@@ -1238,11 +1238,9 @@ static void Nav_RenderLink(const nav_node_t *node, int node_id, const vec3_t nod
             // raise the other side's points slightly
             ctrl[2] += 32.f;
 
-            Nav_AddDebugCurveArrow((const vec3_t) {
-                e[0], e[1], e[2] + 32.f
-            }, ctrl, (const vec3_t) {
-                node_origin[0], node_origin[1], node_origin[2] + 32.f
-            }, traversal_color, arrow_color);
+            vec3_t raised_start{ e[0], e[1], e[2] + 32.f };
+            vec3_t raised_end{ node_origin[0], node_origin[1], node_origin[2] + 32.f };
+            Nav_AddDebugCurveArrow(raised_start, ctrl, raised_end, traversal_color, arrow_color);
 
             return;
         }
@@ -1307,7 +1305,7 @@ static void Nav_Debug(void)
 
         t[2] -= 18;
 
-        R_AddDebugText(t, NULL, Nav_NodeFlagsToString(node->flags), 0.1f, ColorSetAlpha(COLOR_GREEN, alpha), SV_FRAMETIME, false);
+        R_AddDebugText(t, NULL, Nav_NodeFlagsToString(node->flags), 0.1f, ColorSetAlpha(COLOR_GREEN, alpha), SV_FRAMETIME, qfalse);
         
         for (const nav_link_t *link = node->links; link != node->links + node->num_links; link++)
             Nav_RenderLink(node, i, s, link, alpha);


### PR DESCRIPTION
## Summary
- cast literal alpha arguments to `ColorSetAlpha` to an explicit uint8_t overload
- switch renderer debug helper calls to use `qboolean` instead of `bool`
- replace C99 `vec3_t` compound literals with helper usage that compiles under MSVC

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f4bc69b0c8832883f0092cd1036a41