### PR TITLE
Fix demo UI string storage and pointer casts

### DIFF
--- a/src/client/cin.cpp
+++ b/src/client/cin.cpp
@@ -823,7 +823,9 @@ void SCR_Cinematic_g(genctx_t *ctx)
 
     ctx->ignoredups = true;
     list = FS_ListFiles("video", extensions, flags, &count);
-    for (int i = 0; i < count; i++)
-        Prompt_AddMatch(ctx, va("%s.cin", (char *)list[i]));
+    for (int i = 0; i < count; i++) {
+        const char *name = static_cast<const char *>(list[i]);
+        Prompt_AddMatch(ctx, va("%s.cin", name));
+    }
     FS_FreeList(list);
 }

--- a/src/client/ui/menu.cpp
+++ b/src/client/ui/menu.cpp
@@ -690,7 +690,7 @@ void ImageSpinControl_Pop(menuSpinControl_t *s)
         Cvar_SetEx(s->cvar->name, va("%.*s", (int)file_name_length, file_value), FROM_MENU);
     }
 
-    FS_FreeList((void **) s->itemnames);
+    FS_FreeList(reinterpret_cast<void **>(s->itemnames));
     s->itemnames = NULL;
 }
 
@@ -705,7 +705,7 @@ static void ImageSpinControl_Free(menuSpinControl_t *s)
     Z_Free(s->generic.status);
     Z_Free(s->filter);
     Z_Free(s->path);
-    FS_FreeList((void **) s->itemnames);
+    FS_FreeList(reinterpret_cast<void **>(s->itemnames));
     Z_Free(s);
 }
 
@@ -737,7 +737,7 @@ ImageSpinControl_Init
 void ImageSpinControl_Init(menuSpinControl_t *s)
 {
     s->numItems = 0;
-    s->itemnames = (char **) FS_ListFiles(NULL, va("%s/%s", s->path, s->filter), FS_SEARCH_BYFILTER, &s->numItems);
+    s->itemnames = reinterpret_cast<char **>(FS_ListFiles(NULL, va("%s/%s", s->path, s->filter), FS_SEARCH_BYFILTER, &s->numItems));
 
     SpinControl_Init(s);
 

--- a/src/client/ui/playermodels.cpp
+++ b/src/client/ui/playermodels.cpp
@@ -74,7 +74,7 @@ void PlayerModel_Load(void)
     Q_assert(!uis.numPlayerModels);
 
     // get a list of directories
-    if (!(dirnames = (char **)FS_ListFiles("players", NULL, FS_SEARCH_DIRSONLY, &ndirs))) {
+    if (!(dirnames = reinterpret_cast<char **>(FS_ListFiles("players", NULL, FS_SEARCH_DIRSONLY, &ndirs)))) {
         return;
     }
 
@@ -94,7 +94,7 @@ void PlayerModel_Load(void)
 
         // verify the existence of at least one pcx skin
         Q_concat(scratch, sizeof(scratch), "players/", dirnames[i]);
-        pcxnames = (char **)FS_ListFiles(scratch, ".pcx", 0, &npcxfiles);
+        pcxnames = reinterpret_cast<char **>(FS_ListFiles(scratch, ".pcx", 0, &npcxfiles));
         if (!pcxnames) {
             continue;
         }
@@ -109,7 +109,7 @@ void PlayerModel_Load(void)
         }
 
         if (!nskins) {
-            FS_FreeList((void **)pcxnames);
+            FS_FreeList(reinterpret_cast<void **>(pcxnames));
             continue;
         }
 
@@ -126,7 +126,7 @@ void PlayerModel_Load(void)
             }
         }
 
-        FS_FreeList((void **)pcxnames);
+        FS_FreeList(reinterpret_cast<void **>(pcxnames));
 
         // at this point we have a valid player model
         pmi = &uis.pmi[uis.numPlayerModels++];
@@ -138,7 +138,7 @@ void PlayerModel_Load(void)
             break;
     }
 
-    FS_FreeList((void **)dirnames);
+    FS_FreeList(reinterpret_cast<void **>(dirnames));
 
     qsort(uis.pmi, uis.numPlayerModels, sizeof(uis.pmi[0]), pmicmpfnc);
 }

--- a/src/client/ui/servers.cpp
+++ b/src/client/ui/servers.cpp
@@ -270,10 +270,10 @@ void UI_StatusEvent(const serverStatus_t *status)
     if (ping > 999)
         ping = 999;
 
-    slot = UI_FormatColumns(SLOT_EXTRASIZE, host, mod, map,
+    slot = static_cast<serverslot_t *>(UI_FormatColumns(SLOT_EXTRASIZE, host, mod, map,
                             va("%d/%s", status->numPlayers, maxclients),
                             va("%u", ping),
-                            NULL);
+                            NULL));
     slot->status = SLOT_VALID;
     slot->address = net_from;
     slot->hostname = hostname;
@@ -294,17 +294,17 @@ void UI_StatusEvent(const serverStatus_t *status)
             strcpy(value, "<MISSING VALUE>");
 
         slot->rules[slot->numRules++] =
-            UI_FormatColumns(0, key, value, NULL);
+            static_cast<char *>(UI_FormatColumns(0, key, value, NULL));
     }
 
     slot->numPlayers = status->numPlayers;
     for (i = 0; i < status->numPlayers; i++) {
         slot->players[i] =
-            UI_FormatColumns(0,
+            static_cast<char *>(UI_FormatColumns(0,
                              va("%d", status->players[i].score),
                              va("%d", status->players[i].ping),
                              status->players[i].name,
-                             NULL);
+                             NULL));
     }
 
     slot->timestamp = timestamp;
@@ -356,8 +356,8 @@ void UI_ErrorEvent(const netadr_t *from)
     if (ping > 999)
         ping = 999;
 
-    slot = UI_FormatColumns(SLOT_EXTRASIZE, hostname,
-                            "???", "???", "down", va("%u", ping), NULL);
+    slot = static_cast<serverslot_t *>(UI_FormatColumns(SLOT_EXTRASIZE, hostname,
+                            "???", "???", "down", va("%u", ping), NULL));
     slot->status = SLOT_ERROR;
     slot->address = address;
     slot->hostname = hostname;
@@ -418,8 +418,8 @@ static menuSound_t PingSelected(void)
     hostname = slot->hostname;
     FreeSlot(slot);
 
-    slot = UI_FormatColumns(SLOT_EXTRASIZE, hostname,
-                            "???", "???", "?/?", "???", NULL);
+    slot = static_cast<serverslot_t *>(UI_FormatColumns(SLOT_EXTRASIZE, hostname,
+                            "???", "???", "?/?", "???", NULL));
     slot->status = SLOT_PENDING;
     slot->address = address;
     slot->hostname = hostname;
@@ -471,8 +471,8 @@ static void AddServer(const netadr_t *address, const char *hostname)
         return;
     }
 
-    slot = UI_FormatColumns(SLOT_EXTRASIZE, hostname,
-                            "???", "???", "?/?", "???", NULL);
+    slot = static_cast<serverslot_t *>(UI_FormatColumns(SLOT_EXTRASIZE, hostname,
+                            "???", "???", "?/?", "???", NULL));
     slot->status = SLOT_IDLE;
     slot->address = *address;
     slot->hostname = UI_CopyString(hostname);

--- a/src/common/tests.cpp
+++ b/src/common/tests.cpp
@@ -165,7 +165,7 @@ static void Com_PrintJunk_f(void)
 static void BSP_Test_f(void)
 {
     void **list;
-    char *name;
+    const char *name;
     int i, count, errors;
     bsp_t *bsp;
     int ret;
@@ -181,7 +181,7 @@ static void BSP_Test_f(void)
 
     errors = 0;
     for (i = 0; i < count; i++) {
-        name = list[i];
+        name = static_cast<const char *>(list[i]);
         ret = BSP_Load(name, &bsp);
         if (!bsp) {
             Com_EPrintf("Couldn't load %s: %s\n", name, BSP_ErrorString(ret));
@@ -563,7 +563,7 @@ static void Com_TestModels_f(void)
             R_EndRegistration();
             R_BeginRegistration(NULL);
         }
-        if (!R_RegisterModel(list[i])) {
+        if (!R_RegisterModel(static_cast<const char *>(list[i]))) {
             errors++;
             continue;
         }
@@ -605,7 +605,8 @@ static void Com_TestImages_f(void)
             R_EndRegistration();
             R_BeginRegistration(NULL);
         }
-        if (!R_RegisterImage(va("/%s", (char *)list[i]), IT_PIC, IF_KEEP_EXTENSION)) {
+        const char *name = static_cast<const char *>(list[i]);
+        if (!R_RegisterImage(va("/%s", name), IT_PIC, IF_KEEP_EXTENSION)) {
             errors++;
             continue;
         }
@@ -645,7 +646,8 @@ static void Com_TestSounds_f(void)
             S_EndRegistration();
             S_BeginRegistration();
         }
-        if (!S_RegisterSound(va("#%s", (char *)list[i]))) {
+        const char *name = static_cast<const char *>(list[i]);
+        if (!S_RegisterSound(va("#%s", name))) {
             errors++;
             continue;
         }


### PR DESCRIPTION
## Summary
- avoid compound literals in the demo browser and use typed static_cast calls for legacy void* APIs
- duplicate demo menu metadata strings so they no longer rely on string literal storage
- replace remaining C-style casts around FS_ListFiles/UI_FormatColumns usage with explicit casts

## Testing
- meson setup build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f55251f7448328b48c282aa1f979ff