### PR TITLE
Make SV_FilterPacket use const input pointer

### DIFF
--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -767,7 +767,7 @@ void player_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage
 // g_svcmds.c
 //
 void ServerCommand(void);
-bool SV_FilterPacket(char *from);
+bool SV_FilterPacket(const char *from);
 
 //
 // p_view.c

--- a/src/game/g_svcmds.cpp
+++ b/src/game/g_svcmds.cpp
@@ -109,7 +109,7 @@ static bool StringToFilter(char *s, ipfilter_t *f)
 SV_FilterPacket
 =================
 */
-bool SV_FilterPacket(char *from)
+bool SV_FilterPacket(const char *from)
 {
     int     i;
     unsigned    in;
@@ -117,7 +117,7 @@ bool SV_FilterPacket(char *from)
         byte b[4];
         unsigned u32;
     } m;
-    char *p;
+    const char *p;
 
     m.u32 = 0;
 


### PR DESCRIPTION
## Summary
- change SV_FilterPacket to take a const input pointer and treat its iterator as const to avoid writing to string literals
- update the public declaration to match the new const-correct signature

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f5572fe260832885792640c3e71ea3