### PR TITLE
Fix snddma driver initialization for C++17

### DIFF
--- a/src/unix/sound/sdl.cpp
+++ b/src/unix/sound/sdl.cpp
@@ -140,10 +140,10 @@ static void Activate(bool active)
 }
 
 const snddma_driver_t snddma_sdl = {
-    .name = "sdl",
-    .init = Init,
-    .shutdown = Shutdown,
-    .begin_painting = BeginPainting,
-    .submit = Submit,
-    .activate = Activate,
+    "sdl",
+    Init,
+    Shutdown,
+    BeginPainting,
+    Submit,
+    Activate,
 };

--- a/src/windows/dsound.cpp
+++ b/src/windows/dsound.cpp
@@ -396,10 +396,10 @@ static void DS_Activate(bool active)
 }
 
 const snddma_driver_t snddma_dsound = {
-    .name = "dsound",
-    .init = DS_Init,
-    .shutdown = DS_Shutdown,
-    .begin_painting = DS_BeginPainting,
-    .submit = DS_Submit,
-    .activate = DS_Activate,
+    "dsound",
+    DS_Init,
+    DS_Shutdown,
+    DS_BeginPainting,
+    DS_Submit,
+    DS_Activate,
 };


### PR DESCRIPTION
## Summary
- replace designated initializers in the SDL and DirectSound snddma drivers with ordered aggregate initialization so they compile under C++17

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f5572fee048328b7d53fc82048245e