### PR TITLE
Fix EGL initialization for C++ compatibility

### DIFF
--- a/src/windows/egl_import.h
+++ b/src/windows/egl_import.h
@@ -57,7 +57,9 @@ static bool egl_init_import(void)
     if (!egl.handle)
         return false;
 
-#define QEGL(type, func)    if ((q##func = Sys_GetProcAddress(egl.handle, #func)) == NULL) goto fail;
+#define QEGL(type, func)    \
+    q##func = reinterpret_cast<type>(Sys_GetProcAddress(egl.handle, #func)); \
+    if (q##func == NULL) goto fail;
     QEGL_IMP
 #undef QEGL
 


### PR DESCRIPTION
## Summary
- wrap QEGL imports with reinterpret_cast to satisfy C++ assignments
- declare EGL initialization temporaries ahead of failure jumps and replace designated initializers
- rewrite the Windows EGL driver table using positional initializers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f55aba2974832883237c75effd2d20