### PR TITLE
Fix UnitControl_Init signature

### DIFF
--- a/src/client/ui/menu.cpp
+++ b/src/client/ui/menu.cpp
@@ -577,7 +577,7 @@ static void EpisodeControl_Init(menuEpisodeSelector_t *s)
 EpisodeControl_Init
 =================
 */
-static void UnitControl_Init(menuEpisodeSelector_t *s)
+static void UnitControl_Init(menuUnitSelector_t *s)
 {
     SpinControl_Init(&s->spin);
 }


### PR DESCRIPTION
## Summary
- update the UnitControl_Init helper to take a menuUnitSelector_t pointer
- ensure the unit selector initialization matches its definition to avoid MSVC signature mismatches

## Testing
- ninja -C build *(fails: build directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_68f55e94f6d083288165ef608d445d06