### PR TITLE
Fix Common_DoEnter return type

### DIFF
--- a/src/client/ui/menu.cpp
+++ b/src/client/ui/menu.cpp
@@ -1887,7 +1887,7 @@ MISC
 Common_DoEnter
 =================
 */
-static int Common_DoEnter(menuCommon_t *item)
+static menuSound_t Common_DoEnter(menuCommon_t *item)
 {
     if (item->activate) {
         menuSound_t sound = item->activate(item);


### PR DESCRIPTION
## Summary
- update Common_DoEnter to return menuSound_t so callers no longer rely on implicit conversions

## Testing
- not run (meson/ninja tooling unavailable in container environment)


------
https://chatgpt.com/codex/tasks/task_e_68f55e9684ac83288b6db3a0aadc78cc