### PR TITLE
Fix explicit pointer casts for MSVC compatibility

### DIFF
--- a/src/client/download.cpp
+++ b/src/client/download.cpp
@@ -460,7 +460,7 @@ static void check_skins(const char *name)
     uint32_t        ident;
     char            fn[MAX_QPATH];
 
-    len = FS_LoadFile(name, (void **)&model);
+    len = FS_LoadFile(name, reinterpret_cast<void **>(&model));
     if (!model) {
         // couldn't load it
         return;

--- a/src/client/locs.cpp
+++ b/src/client/locs.cpp
@@ -68,7 +68,7 @@ void LOC_LoadLocations(void)
     // load from main directory
     Q_concat(path, sizeof(path), "locs/", cl.mapname, ".loc");
 
-    ret = FS_LoadFile(path, (void **)&buffer);
+    ret = FS_LoadFile(path, reinterpret_cast<void **>(&buffer));
     if (!buffer) {
         if (ret != Q_ERR(ENOENT)) {
             Com_EPrintf("Couldn't load %s: %s\n", path, Q_ErrorString(ret));

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -1790,7 +1790,7 @@ void CL_LoadFilterList(string_entry_t **list, const char *name, const char *comm
     *list = NULL;
 
     // load new list
-    len = FS_LoadFileEx(name, (void **)&raw, FS_TYPE_REAL, TAG_FILESYSTEM);
+    len = FS_LoadFileEx(name, reinterpret_cast<void **>(&raw), FS_TYPE_REAL, TAG_FILESYSTEM);
     if (!raw) {
         if (len != Q_ERR(ENOENT))
             Com_EPrintf("Couldn't load %s: %s\n", name, Q_ErrorString(len));

--- a/src/client/sound/mem.cpp
+++ b/src/client/sound/mem.cpp
@@ -507,7 +507,7 @@ sfxcache_t *S_LoadSound(sfx_t *s)
     else
         name = s->name;
 
-    len = FS_LoadFile(name, (void **)&data);
+    len = FS_LoadFile(name, reinterpret_cast<void **>(&data));
     if (!data) {
         if (len != Q_ERR(ENOENT))
             Com_EPrintf("Couldn't load %s: %s\n", Com_MakePrintable(name), Q_ErrorString(len));

--- a/src/client/ui/demos.cpp
+++ b/src/client/ui/demos.cpp
@@ -177,7 +177,8 @@ static char *LoadCache(void)
     if (Q_concat(buffer, sizeof(buffer), m_demos.browse, "/" COM_DEMOCACHE_NAME) >= sizeof(buffer)) {
         return NULL;
     }
-    len = FS_LoadFileEx(buffer, (void **)&cache, FS_TYPE_REAL | FS_PATH_GAME | FS_DIR_HOME, TAG_FILESYSTEM);
+    len = FS_LoadFileEx(buffer, reinterpret_cast<void **>(&cache),
+                        FS_TYPE_REAL | FS_PATH_GAME | FS_DIR_HOME, TAG_FILESYSTEM);
     if (!cache) {
         return NULL;
     }

--- a/src/client/ui/menu.cpp
+++ b/src/client/ui/menu.cpp
@@ -1910,9 +1910,11 @@ void Menu_AddItem(menuFrameWork_t *menu, void *item)
     Q_assert(menu->nitems < MAX_MENU_ITEMS);
 
     if (!menu->nitems) {
-        menu->items = UI_Malloc(MIN_MENU_ITEMS * sizeof(void *));
+        menu->items = reinterpret_cast<void **>(
+            UI_Malloc(MIN_MENU_ITEMS * sizeof(void *)));
     } else {
-        menu->items = Z_Realloc(menu->items, Q_ALIGN(menu->nitems + 1, MIN_MENU_ITEMS) * sizeof(void *));
+        menu->items = reinterpret_cast<void **>(Z_Realloc(
+            menu->items, Q_ALIGN(menu->nitems + 1, MIN_MENU_ITEMS) * sizeof(void *)));
     }
 
     menu->items[menu->nitems++] = item;

--- a/src/client/ui/servers.cpp
+++ b/src/client/ui/servers.cpp
@@ -120,8 +120,9 @@ static void UpdateSelection(void)
 
     if (s && s->status == serverslot_t::SLOT_VALID && s->numRules && uis.width >= 640) {
         m_servers.info.generic.flags &= ~QMF_HIDDEN;
-        if (m_servers.info.items != (void **)s->rules || m_servers.info.numItems != s->numRules) {
-            m_servers.info.items = (void **)s->rules;
+        auto **rules = reinterpret_cast<void **>(s->rules);
+        if (m_servers.info.items != rules || m_servers.info.numItems != s->numRules) {
+            m_servers.info.items = rules;
             m_servers.info.numItems = s->numRules;
             m_servers.info.curvalue = -1;
             m_servers.info.prestep = 0;
@@ -134,8 +135,9 @@ static void UpdateSelection(void)
 
     if (s && s->status == serverslot_t::SLOT_VALID && s->numPlayers) {
         m_servers.players.generic.flags &= ~QMF_HIDDEN;
-        if (m_servers.players.items != (void **)s->players || m_servers.players.numItems != s->numPlayers) {
-            m_servers.players.items = (void **)s->players;
+        auto **players = reinterpret_cast<void **>(s->players);
+        if (m_servers.players.items != players || m_servers.players.numItems != s->numPlayers) {
+            m_servers.players.items = players;
             m_servers.players.numItems = s->numPlayers;
             m_servers.players.curvalue = -1;
             m_servers.players.prestep = 0;
@@ -814,8 +816,8 @@ static int addresscmp(serverslot_t *s1, serverslot_t *s2)
 
 static int slotcmp(const void *p1, const void *p2)
 {
-    serverslot_t *s1 = *(serverslot_t **)p1;
-    serverslot_t *s2 = *(serverslot_t **)p2;
+    auto s1 = *reinterpret_cast<serverslot_t *const *>(p1);
+    auto s2 = *reinterpret_cast<serverslot_t *const *>(p2);
     int r;
 
     // sort by validity

--- a/src/common/cmd.cpp
+++ b/src/common/cmd.cpp
@@ -1654,7 +1654,7 @@ int Cmd_ExecuteFile(const char *path, unsigned flags)
     int len, ret;
     cmdbuf_t *buf;
 
-    len = FS_LoadFileEx(path, (void **)&f, flags, TAG_FILESYSTEM);
+    len = FS_LoadFileEx(path, reinterpret_cast<void **>(&f), flags, TAG_FILESYSTEM);
     if (!f) {
         return len;
     }

--- a/src/common/cmodel.cpp
+++ b/src/common/cmodel.cpp
@@ -77,12 +77,12 @@ static void load_entstring_override(cm_t *cm)
         ret = Q_ERR(ENAMETOOLONG);
         goto fail;
     }
-    ret = FS_LoadFileEx(buffer, (void **)&data, 0, TAG_CMODEL);
+    ret = FS_LoadFileEx(buffer, reinterpret_cast<void **>(&data), 0, TAG_CMODEL);
 
     // fall back to no hash
     if (ret == Q_ERR(ENOENT)) {
         Q_snprintf(buffer, sizeof(buffer), "%s/%s.ent", path, name);
-        ret = FS_LoadFileEx(buffer, (void **)&data, 0, TAG_CMODEL);
+        ret = FS_LoadFileEx(buffer, reinterpret_cast<void **>(&data), 0, TAG_CMODEL);
     }
     if (ret == Q_ERR(ENOENT))
         return;
@@ -132,7 +132,7 @@ void CM_LoadOverride(cm_t *cm, char *server, size_t server_size)
         goto fail;
     }
 
-    ret = FS_LoadFile(buffer, (void **)&data);
+    ret = FS_LoadFile(buffer, reinterpret_cast<void **>(&data));
     if (!data) {
         if (ret == Q_ERR(ENOENT))
             return;

--- a/src/refresh/draw.cpp
+++ b/src/refresh/draw.cpp
@@ -532,7 +532,7 @@ void SCR_LoadKFont(kfont_t *font, const char *filename)
 
     char *buffer;
 
-    if (FS_LoadFile(filename, (void **) &buffer) < 0)
+    if (FS_LoadFile(filename, reinterpret_cast<void **>(&buffer)) < 0)
         return;
 
     const char *data = buffer;

--- a/src/refresh/images.cpp
+++ b/src/refresh/images.cpp
@@ -2218,7 +2218,7 @@ void IMG_GetPalette(void)
     int         i, ret;
 
     // get the palette
-    ret = FS_LoadFile(R_COLORMAP_PCX, (void **)&data);
+    ret = FS_LoadFile(R_COLORMAP_PCX, reinterpret_cast<void **>(&data));
     if (!data)
         goto fail;
 

--- a/src/refresh/models.cpp
+++ b/src/refresh/models.cpp
@@ -1140,7 +1140,7 @@ static void MD5_LoadScales(const md5_model_t *model, const char *path, joint_inf
     char *data;
     int len, ret;
 
-    len = FS_LoadFile(path, (void **)&data);
+    len = FS_LoadFile(path, reinterpret_cast<void **>(&data));
     if (!data) {
         if (len != Q_ERR(ENOENT))
             MOD_PrintError(path, len);
@@ -1586,7 +1586,7 @@ qhandle_t R_RegisterModel(const char *name)
         goto done;
     }
 
-    ret = FS_LoadFile(normalized, (void **)&rawdata);
+    ret = FS_LoadFile(normalized, reinterpret_cast<void **>(&rawdata));
     if (!rawdata)
         goto fail1;
 

--- a/src/server/ac.cpp
+++ b/src/server/ac.cpp
@@ -402,7 +402,7 @@ static bool AC_ParseFile(const char *path, ac_parse_t parse, int depth)
     int linenum = 1;
     int ret;
 
-    ret = FS_LoadFile(path, (void **)&raw);
+    ret = FS_LoadFile(path, reinterpret_cast<void **>(&raw));
     if (!raw) {
         if (ret != Q_ERR(ENOENT) || depth) {
             Com_WPrintf("ANTICHEAT: Could not %s %s: %s\n",

--- a/src/server/save.cpp
+++ b/src/server/save.cpp
@@ -471,7 +471,7 @@ static int read_server_file(void)
         Com_Error(ERR_DROP, "Game does not support enhanced savegames");
 
     // read game state
-    FS_LoadFile("save/" SAVE_CURRENT "/game.ssv", (void **)&buf);
+    FS_LoadFile("save/" SAVE_CURRENT "/game.ssv", reinterpret_cast<void **>(&buf));
     if (!buf)
         Com_Error(ERR_DROP, "Couldn't read game.ssv");
     ge->ReadGameJson(static_cast<const char *>(buf));
@@ -543,7 +543,7 @@ static int read_level_file(void)
     if (Q_snprintf(name, MAX_OSPATH, "save/" SAVE_CURRENT "/%s.sav", sv.name) >= MAX_OSPATH)
         Com_Error(ERR_DROP, "Savegame path too long");
 
-    FS_LoadFile(name, (void **)&data);
+    FS_LoadFile(name, reinterpret_cast<void **>(&data));
     if (!data)
         Com_Error(ERR_DROP, "Couldn't read %s", name);
     ge->ReadLevelJson(static_cast<const char *>(data));

--- a/src/windows/dsound.cpp
+++ b/src/windows/dsound.cpp
@@ -338,8 +338,9 @@ static void DS_BeginPainting(void)
     reps = 0;
     dma.buffer = NULL;
 
-    while ((hresult = IDirectSoundBuffer_Lock(pDSBuf, 0, gSndBufSize, (void **)&pbuf, &locksize,
-                      (void **)&pbuf2, &dwSize2, 0)) != DS_OK) {
+    while ((hresult = IDirectSoundBuffer_Lock(pDSBuf, 0, gSndBufSize,
+                      reinterpret_cast<void **>(&pbuf), &locksize,
+                      reinterpret_cast<void **>(&pbuf2), &dwSize2, 0)) != DS_OK) {
         if (hresult != DSERR_BUFFERLOST) {
             Com_EPrintf("DS_BeginPainting: Lock failed with error '%s'\n", DSoundError(hresult));
             DS_Shutdown();


### PR DESCRIPTION
## Summary
- replace implicit pointer conversions with explicit casts across UI, renderer, and server subsystems to satisfy MSVC
- ensure menu item allocations use explicit casts when storing void** arrays

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f55e9769c48328a1bcaca8c71b2513