### PR TITLE
Ensure MSVC builds request C++20 standard

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -345,6 +345,7 @@ endif
 common_link_args = []
 exe_link_args = []
 dll_link_args = []
+msvc_cpp_args = []
 
 if cc.get_argument_syntax() == 'gcc'
   if x86
@@ -382,12 +383,24 @@ if cc.get_argument_syntax() == 'gcc'
   endif
 elif cc.get_id() == 'msvc'
   common_args += ['/wd4146', '/wd4244', '/wd4305', '/D_CRT_SECURE_NO_WARNINGS', '/wd4267', '/wd4018']
+
+  if cppc.has_argument('/std:c++20')
+    msvc_cpp_args += '/std:c++20'
+  elif cppc.has_argument('/std:c++latest')
+    msvc_cpp_args += '/std:c++latest'
+  else
+    error('MSVC does not support the required C++20 standard flag')
+  endif
 endif
 
 foreach lang : ['c', 'cpp']
   add_project_arguments(common_args, language: lang)
   add_project_link_arguments(common_link_args, language: lang)
 endforeach
+
+if msvc_cpp_args.length() > 0
+  add_project_arguments(msvc_cpp_args, language: 'cpp')
+endif
 
 config = configuration_data()
 


### PR DESCRIPTION
## Summary
- ensure the MSVC configuration explicitly enables the C++20 (or latest) language mode
- abort configure when the required standard flag is unavailable

## Testing
- not run (Windows/MSVC build not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f55e9a24bc8328a15752b8c780596c