### PR TITLE
Handle userinfo ban reason as const pointer

### DIFF
--- a/src/server/main.cpp
+++ b/src/server/main.cpp
@@ -861,10 +861,10 @@ static bool parse_userinfo(const q2proto_connect_t *parsed_connect, conn_params_
 
     // reject if there is a kickable userinfo ban
     if ((ban = SV_CheckInfoBans(userinfo, true)) != NULL) {
-        s = ban->comment;
-        if (!s)
-            s = "Userinfo banned.";
-        return reject("%s\nConnection refused.\n", s);
+        const char *reason = ban->comment;
+        if (!reason)
+            reason = "Userinfo banned.";
+        return reject("%s\nConnection refused.\n", reason);
     }
 
     return true;


### PR DESCRIPTION
## Summary
- keep the modifiable userinfo buffer while reading the ban comment through a const pointer
- default the rejection reason to "Userinfo banned." before forwarding it to reject

## Testing
- not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68f563cd5bc88328977fbb1d774ff926