### PR TITLE
Fix win32 mode change flag type

### DIFF
--- a/src/windows/client.cpp
+++ b/src/windows/client.cpp
@@ -340,7 +340,7 @@ static LONG set_fullscreen_mode(void)
     win.flags |= QVF_FULLSCREEN;
     Win_SetPosition();
     Win_ModeChanged();
-    win.mode_changed = 0;
+    win.mode_changed = 0u;
 
     return ret;
 }
@@ -399,7 +399,7 @@ void Win_SetMode(void)
     win.flags &= ~QVF_FULLSCREEN;
     Win_SetPosition();
     Win_ModeChanged();
-    win.mode_changed = 0;
+    win.mode_changed = 0u;
 }
 
 /*
@@ -916,7 +916,7 @@ void Win_PumpEvents(void)
         if (win.mode_changed & win_state_t::MODE_SIZE) {
             Win_ModeChanged();
         }
-        win.mode_changed = 0;
+        win.mode_changed = 0u;
     }
 }
 

--- a/src/windows/client.h
+++ b/src/windows/client.h
@@ -102,12 +102,14 @@ typedef struct {
 
     bool    alttab_disabled;
 
-    enum {
+    enum ModeChangedFlags : unsigned {
         MODE_SIZE       = BIT(0),
         MODE_POS        = BIT(1),
         MODE_STYLE      = BIT(2),
         MODE_REPOSITION = BIT(3),
-    } mode_changed;
+    };
+
+    unsigned mode_changed;
 
     struct {
         bool        initialized;


### PR DESCRIPTION
## Summary
- define the Windows client mode-change flags with an explicit unsigned underlying type
- store the mode-change state in an unsigned field and update zero-initialisation

## Testing
- not run (Windows build required)


------
https://chatgpt.com/codex/tasks/task_e_68f563d534a083288f83c4bb4b72d383