### PR TITLE
Add helper for av_channel_layout_default

### DIFF
--- a/src/client/cin.cpp
+++ b/src/client/cin.cpp
@@ -17,6 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "client.h"
+#include "ffmpeg_utils.h"
 
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
@@ -605,7 +606,7 @@ static bool open_codec_context(enum AVMediaType type)
             sample_rate = dec_ctx->sample_rate;
 
         int out_channels = (dec_ctx->ch_layout.nb_channels >= 2) ? 2 : 1;
-        ret = av_channel_layout_default(&out->ch_layout, out_channels);
+        ret = Q_AVChannelLayoutDefault(&out->ch_layout, out_channels);
         if (ret < 0) {
             Com_EPrintf("Failed to set audio channel layout\n");
             return false;

--- a/src/client/ffmpeg_utils.h
+++ b/src/client/ffmpeg_utils.h
@@ -1,0 +1,35 @@
+/*
+Copyright (C) 2024 Andrey Nazarov
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include <type_traits>
+
+#include <libavutil/channel_layout.h>
+
+static inline int Q_AVChannelLayoutDefault(AVChannelLayout *layout, int nb_channels)
+{
+    using ChannelLayoutDefaultFn = decltype(&av_channel_layout_default);
+
+    if constexpr (std::is_same_v<ChannelLayoutDefaultFn, int (*)(AVChannelLayout *, int)>) {
+        return av_channel_layout_default(layout, nb_channels);
+    }
+
+    av_channel_layout_default(layout, nb_channels);
+    return 0;
+}

--- a/src/client/sound/ogg.cpp
+++ b/src/client/sound/ogg.cpp
@@ -18,6 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "sound.h"
 #include "common/hash_map.h"
+#include "../ffmpeg_utils.h"
 
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
@@ -400,7 +401,7 @@ static int reconfigure_swr(void)
     swr_close(ogg_swr_ctx);
     av_frame_unref(out);
 
-    ret = av_channel_layout_default(&out->ch_layout, 2);
+    ret = Q_AVChannelLayoutDefault(&out->ch_layout, 2);
     if (ret < 0)
         return ret;
     out->format = s_supports_float ? AV_SAMPLE_FMT_FLT : AV_SAMPLE_FMT_S16;
@@ -517,8 +518,11 @@ drain:
         }
 
         // work around swr channel layout bug
-        if (in->ch_layout.order == AV_CHANNEL_ORDER_UNSPEC)
-            av_channel_layout_default(&in->ch_layout, in->ch_layout.nb_channels);
+        if (in->ch_layout.order == AV_CHANNEL_ORDER_UNSPEC) {
+            ret = Q_AVChannelLayoutDefault(&in->ch_layout, in->ch_layout.nb_channels);
+            if (ret < 0)
+                return ret;
+        }
 
         // now that we have a frame, configure swr
         if (!swr_is_initialized(ogg_swr_ctx)) {


### PR DESCRIPTION
## Summary
- add a shared FFmpeg utility helper that normalizes av_channel_layout_default return values
- update the cinematic and Ogg decoders to use the helper and handle errors consistently

## Testing
- not run (MSVC build required to verify the original issue)

------
https://chatgpt.com/codex/tasks/task_e_68f563d033f883289879f0ceae929e29