### PR TITLE
Replace std::span usage in qal

### DIFF
--- a/src/client/sound/qal.cpp
+++ b/src/client/sound/qal.cpp
@@ -26,8 +26,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <AL/alc.h>
 
 #include <array>
+#include <cstddef>
 #include <functional>
-#include <span>
 
 #define QALAPI
 #include "qal.h"
@@ -77,9 +77,17 @@ static alfunction_t make_alfunction(const char *name, T &destination, T builtin)
 #define QALC_FN(x)  make_alfunction("alc"#x, qalc##x, alc##x)
 #define QAL_FN(x)   make_alfunction("al"#x, qal##x, al##x)
 
+struct alfunction_view {
+    const alfunction_t *data = nullptr;
+    std::size_t size = 0;
+
+    const alfunction_t *begin() const { return data; }
+    const alfunction_t *end() const { return data + size; }
+};
+
 struct alsection_t {
     const char *extension;
-    std::span<const alfunction_t> functions;
+    alfunction_view functions;
 };
 
 static const std::array<alfunction_t, 36> core_functions = {
@@ -138,8 +146,8 @@ static const std::array<alfunction_t, 13> efx_functions = {
 };
 
 static const std::array<alsection_t, 2> sections = { {
-    { nullptr, std::span<const alfunction_t>(core_functions) },
-    { "ALC_EXT_EFX", std::span<const alfunction_t>(efx_functions) },
+    { nullptr, { core_functions.data(), core_functions.size() } },
+    { "ALC_EXT_EFX", { efx_functions.data(), efx_functions.size() } },
 } };
 
 static cvar_t   *al_device;


### PR DESCRIPTION
## Summary
- remove the std::span include from qal.cpp to avoid requiring C++20 headers
- introduce a lightweight view struct for OpenAL function tables and update section initialization
- keep existing range-for loops working with the new view implementation

## Testing
- `meson setup build` *(fails: wrap-redirect /workspace/WORR/subprojects/ffmpeg/subprojects/nasm.wrap filename does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68f5771a8b7c8328b18b8dda247ddddc