### PR TITLE
Declare AvErrorString in header

### DIFF
--- a/src/client/ffmpeg_utils.h
+++ b/src/client/ffmpeg_utils.h
@@ -18,6 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
+#include <string>
 #include <type_traits>
 
 #include <libavutil/channel_layout.h>
@@ -33,3 +34,9 @@ static inline int Q_AVChannelLayoutDefault(AVChannelLayout *layout, int nb_chann
     av_channel_layout_default(layout, nb_channels);
     return 0;
 }
+
+#ifdef USE_AVCODEC
+
+std::string AvErrorString(int err);
+
+#endif // USE_AVCODEC


### PR DESCRIPTION
## Summary
- include <string> in ffmpeg_utils.h to support std::string usage
- declare AvErrorString inside the USE_AVCODEC guard so consumers see its signature

## Testing
- meson compile -C build *(fails: build directory not configured due to missing nasm wrap)*

------
https://chatgpt.com/codex/tasks/task_e_68f5771ec41c8328b9a82208f0f9253c