### PR TITLE
Update Meson projects to C++23

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,14 +4,14 @@ project('worr', ['cpp', 'c'],
   meson_version: '>= 0.60.0',
   default_options: [
     meson.version().version_compare('>=1.3.0') ? 'c_std=gnu11,c11' : 'c_std=gnu11',
-    'cpp_std=c++17',
+    'cpp_std=c++23',
     'buildtype=debugoptimized',
   ],
 )
 
 cpp_compiler = meson.get_compiler('cpp')
 if cpp_compiler.get_id() == 'msvc'
-  add_project_arguments('/std:c++17', language: 'cpp')
+  add_project_arguments('/std:c++23', language: 'cpp')
 endif
 
 common_src = [

--- a/subprojects/rerelease-game/meson.build
+++ b/subprojects/rerelease-game/meson.build
@@ -2,7 +2,7 @@ project('quake2-rerelease-dll', 'cpp',
   license: 'GPL-2.0-or-later',
   version: run_command(find_program('python3'), 'version.py', check: true).stdout().strip(),
   default_options: [
-    'cpp_std=c++17',
+    'cpp_std=c++23',
     'buildtype=debugoptimized',
     'b_vscrt=static_from_buildtype',
   ],
@@ -10,7 +10,7 @@ project('quake2-rerelease-dll', 'cpp',
 
 cpp_compiler = meson.get_compiler('cpp')
 if cpp_compiler.get_id() == 'msvc'
-  add_project_arguments('/std:c++17', language: 'cpp')
+  add_project_arguments('/std:c++23', language: 'cpp')
 endif
 
 src = [


### PR DESCRIPTION
## Summary
- bump the root Meson project to use the C++23 language standard by default
- ensure the Windows builds pass /std:c++23 to MSVC
- align the rerelease game subproject with the same C++23 settings

## Testing
- meson setup --reconfigure build *(fails: wrap-redirect /workspace/WORR/subprojects/ffmpeg/subprojects/nasm.wrap filename does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68f57b7558dc8328b13f437a706f8c60