### PR TITLE
Refine OpenAL function sections

### DIFF
--- a/src/client/sound/qal.cpp
+++ b/src/client/sound/qal.cpp
@@ -77,25 +77,6 @@ static alfunction_t make_alfunction(const char *name, T &destination, T builtin)
 #define QALC_FN(x)  make_alfunction("alc"#x, qalc##x, alc##x)
 #define QAL_FN(x)   make_alfunction("al"#x, qal##x, al##x)
 
-struct alfunction_range {
-    const alfunction_t *begin_ptr;
-    const alfunction_t *end_ptr;
-
-    constexpr const alfunction_t *begin() const { return begin_ptr; }
-    constexpr const alfunction_t *end() const { return end_ptr; }
-};
-
-template <typename ArrayT>
-constexpr alfunction_range make_alfunction_range(const ArrayT &array)
-{
-    return { array.data(), array.data() + array.size() };
-}
-
-struct alsection_t {
-    const char *extension;
-    alfunction_range functions;
-};
-
 struct alfunction_view {
     const alfunction_t *data = nullptr;
     std::size_t size = 0;
@@ -103,6 +84,12 @@ struct alfunction_view {
     const alfunction_t *begin() const { return data; }
     const alfunction_t *end() const { return data + size; }
 };
+
+template <typename ArrayT>
+constexpr alfunction_view make_alfunction_view(const ArrayT &array)
+{
+    return { array.data(), array.size() };
+}
 
 struct alsection_t {
     const char *extension;
@@ -165,8 +152,8 @@ static const std::array<alfunction_t, 13> efx_functions = {
 };
 
 static const std::array<alsection_t, 2> sections = { {
-    { nullptr, { core_functions.data(), core_functions.size() } },
-    { "ALC_EXT_EFX", { efx_functions.data(), efx_functions.size() } },
+    { nullptr, make_alfunction_view(core_functions) },
+    { "ALC_EXT_EFX", make_alfunction_view(efx_functions) },
 } };
 
 static cvar_t   *al_device;


### PR DESCRIPTION
## Summary
- drop the unused alfunction_range helper and rely on alfunction_view for section iteration
- provide a helper to construct alfunction_view instances and update the section table accordingly

## Testing
- ninja -C build *(fails: build directory lacks build.ninja prior to Meson setup)*
- meson setup build *(fails: wrap redirect for nasm.wrap is missing in subprojects)*

------
https://chatgpt.com/codex/tasks/task_e_68f57b76ccd88328a6b4ab9c6da35cd3