### PR TITLE
Remove redundant MSVC /std overrides

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -9,10 +9,6 @@ project('worr', ['cpp', 'c'],
   ],
 )
 
-cpp_compiler = meson.get_compiler('cpp')
-if cpp_compiler.get_id() == 'msvc'
-  add_project_arguments('/std:c++latest', language: 'cpp')
-endif
 
 common_src = [
   'src/common/bsp.cpp',

--- a/subprojects/rerelease-game/meson.build
+++ b/subprojects/rerelease-game/meson.build
@@ -8,10 +8,6 @@ project('quake2-rerelease-dll', 'cpp',
   ],
 )
 
-cpp_compiler = meson.get_compiler('cpp')
-if cpp_compiler.get_id() == 'msvc'
-  add_project_arguments('/std:c++23', language: 'cpp')
-endif
 
 src = [
   'rerelease/cg_local.h',


### PR DESCRIPTION
## Summary
- rely on Meson's cpp_std option to supply the MSVC /std flag
- drop redundant /std overrides from the top-level and rerelease game builds

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f5fcdbf2e083288a1982a2a6528508