### PR TITLE
Raise Meson minimum version for C++23

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('worr', ['cpp', 'c'],
   license: 'GPL-2.0-or-later',
   version: run_command(find_program('python3'), 'version.py', check: true).stdout().strip(),
-  meson_version: '>= 0.60.0',
+  meson_version: '>= 1.3.0',
   default_options: [
     meson.version().version_compare('>=1.3.0') ? 'c_std=gnu11,c11' : 'c_std=gnu11',
     'cpp_std=c++23',


### PR DESCRIPTION
## Summary
- raise the project's advertised minimum Meson version to 1.3.0 so cpp_std=c++23 is recognized

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f5fda6e66c8328ac5134ec7ba9e4e5