### PR TITLE
Fix MSVC restrict attribute in libpng fallback

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -14,6 +14,8 @@ if cpp_compiler.get_id() == 'msvc'
   add_project_arguments('/std:c++latest', language: 'cpp')
 endif
 
+c_compiler = meson.get_compiler('c')
+
 common_src = [
   'src/common/bsp.cpp',
   'src/common/cmd.cpp',
@@ -438,6 +440,12 @@ endif
 
 config.set10('USE_ZLIB', zlib.found())
 config.set10('USE_PNG', png.found())
+
+if host_machine.system() == 'windows' and c_compiler.get_id() == 'msvc' and png.found() and png.type_name() == 'internal'
+  python_mod = import('python')
+  python3 = python_mod.find_installation('python3')
+  meson.add_postconf_script(python3, files('tools/fix_libpng_msvc.py'))
+endif
 
 curl = dependency('libcurl',
   version:         '>= 7.68.0',

--- a/subprojects/packagefiles/libpng/msvc-restrict.patch
+++ b/subprojects/packagefiles/libpng/msvc-restrict.patch
@@ -1,0 +1,8 @@
+--- a/pngconf.h
++++ b/pngconf.h
+@@
+-#        define PNG_ALLOCATED __declspec(PNG_RESTRICT)
++#        define PNG_ALLOCATED __declspec(restrict)
+@@
+-#        define PNG_ALLOCATED __declspec(__restrict)
++#        define PNG_ALLOCATED __declspec(restrict)

--- a/tools/fix_libpng_msvc.py
+++ b/tools/fix_libpng_msvc.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+
+def main() -> int:
+    source_root = Path(os.environ.get('MESON_SOURCE_ROOT', Path(__file__).resolve().parents[1]))
+    header = source_root / 'subprojects' / 'libpng-1.6.50' / 'pngconf.h'
+
+    if not header.exists():
+        return 0
+
+    original = header.read_text(encoding='utf-8')
+    updated = original
+    changed = False
+
+    patch_path = source_root / 'subprojects' / 'packagefiles' / 'libpng' / 'msvc-restrict.patch'
+    replacements: list[tuple[str, str]] = []
+    if patch_path.exists():
+        pending: str | None = None
+        for line in patch_path.read_text(encoding='utf-8').splitlines():
+            if line.startswith(('---', '+++', '@@')):
+                pending = None
+                continue
+            if line.startswith('-') and not line.startswith('--'):
+                pending = line[1:]
+                continue
+            if line.startswith('+') and not line.startswith('++') and pending is not None:
+                replacements.append((pending, line[1:]))
+                pending = None
+
+    replacements.extend([
+        ('__declspec(PNG_RESTRICT)', '__declspec(restrict)'),
+        ('__declspec(__restrict)', '__declspec(restrict)'),
+    ])
+
+    for old, new in replacements:
+        if old in updated:
+            updated = updated.replace(old, new)
+            changed = True
+
+    pattern = re.compile(r'(#\s*define\s+PNG_ALLOCATED\s+__declspec\()\s*PNG_RESTRICT\s*(\))')
+    updated, count = pattern.subn(r'\1restrict\2', updated)
+    if count > 0:
+        changed = True
+
+    if changed:
+        header.write_text(updated, encoding='utf-8')
+
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- ensure the Meson build patches the libpng fallback header on MSVC to emit `__declspec(restrict)` instead of `__declspec(__restrict)`
- record the intended header change as a patch fragment under `subprojects/packagefiles/libpng`

## Testing
- not run (MSVC toolchain unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f5fcdbcad4832880a0862c45d8aba3