### PR TITLE
Use positional initializer for GL identity matrix

### DIFF
--- a/src/refresh/state.cpp
+++ b/src/refresh/state.cpp
@@ -22,7 +22,12 @@ glState_t gls;
 
 const glbackend_t *gl_backend;
 
-const mat4_t gl_identity = { [0] = 1, [5] = 1, [10] = 1, [15] = 1 };
+const mat4_t gl_identity = {
+    1.0f, 0.0f, 0.0f, 0.0f,
+    0.0f, 1.0f, 0.0f, 0.0f,
+    0.0f, 0.0f, 1.0f, 0.0f,
+    0.0f, 0.0f, 0.0f, 1.0f,
+};
 
 // for uploading
 void GL_ForceTexture(glTmu_t tmu, GLuint texnum)


### PR DESCRIPTION
## Summary
- replace the designated initializer for `gl_identity` with a positional initializer that spells out the 4x4 identity matrix

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f60174b0c883288705927cd53edf84