### PR TITLE
Add type-safe bitwise operators for refresh enums

### DIFF
--- a/inc/refresh/refresh.h
+++ b/inc/refresh/refresh.h
@@ -18,6 +18,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
+#include <type_traits>
+
 #include "common/cvar.h"
 #include "common/error.h"
 
@@ -209,6 +211,48 @@ typedef enum {
     IF_OPTIONAL         = BIT(16),  // don't warn if not found
     IF_KEEP_EXTENSION   = BIT(17),  // don't override extension
 } imageflags_t;
+
+constexpr imageflags_t operator|(imageflags_t lhs, imageflags_t rhs) noexcept
+{
+    using U = std::underlying_type_t<imageflags_t>;
+    return static_cast<imageflags_t>(static_cast<U>(lhs) | static_cast<U>(rhs));
+}
+
+constexpr imageflags_t operator&(imageflags_t lhs, imageflags_t rhs) noexcept
+{
+    using U = std::underlying_type_t<imageflags_t>;
+    return static_cast<imageflags_t>(static_cast<U>(lhs) & static_cast<U>(rhs));
+}
+
+constexpr imageflags_t operator^(imageflags_t lhs, imageflags_t rhs) noexcept
+{
+    using U = std::underlying_type_t<imageflags_t>;
+    return static_cast<imageflags_t>(static_cast<U>(lhs) ^ static_cast<U>(rhs));
+}
+
+constexpr imageflags_t operator~(imageflags_t value) noexcept
+{
+    using U = std::underlying_type_t<imageflags_t>;
+    return static_cast<imageflags_t>(~static_cast<U>(value));
+}
+
+constexpr imageflags_t &operator|=(imageflags_t &lhs, imageflags_t rhs) noexcept
+{
+    lhs = lhs | rhs;
+    return lhs;
+}
+
+constexpr imageflags_t &operator&=(imageflags_t &lhs, imageflags_t rhs) noexcept
+{
+    lhs = lhs & rhs;
+    return lhs;
+}
+
+constexpr imageflags_t &operator^=(imageflags_t &lhs, imageflags_t rhs) noexcept
+{
+    lhs = lhs ^ rhs;
+    return lhs;
+}
 
 typedef enum {
     IT_PIC,

--- a/src/client/screen.cpp
+++ b/src/client/screen.cpp
@@ -1260,7 +1260,7 @@ void SCR_RegisterMedia(void)
     scr.inven_pic = R_RegisterPic("inventory");
     scr.field_pic = R_RegisterPic("field_3");
     scr.backtile_pic = R_RegisterImage("backtile", IT_PIC,
-        static_cast<imageflags_t>(IF_PERMANENT | IF_REPEAT));
+        IF_PERMANENT | IF_REPEAT);
     scr.pause_pic = R_RegisterPic("pause");
     scr.loading_pic = R_RegisterPic("loading");
 
@@ -1269,7 +1269,7 @@ void SCR_RegisterMedia(void)
 
     scr.net_pic = R_RegisterPic("net");
     scr.hit_marker_pic = R_RegisterImage("marker", IT_PIC,
-        static_cast<imageflags_t>(IF_PERMANENT | IF_OPTIONAL));
+        IF_PERMANENT | IF_OPTIONAL);
 
     scr_crosshair_changed(scr_crosshair);
 

--- a/src/refresh/gl.h
+++ b/src/refresh/gl.h
@@ -18,6 +18,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
+#include <type_traits>
+
 #include "shared/shared.h"
 #include "common/bsp.h"
 #include "common/cmd.h"
@@ -51,6 +53,12 @@ typedef GLuint glIndex_t;
 #endif
 
 typedef uint64_t glStateBits_t;
+
+template <typename Enum>
+constexpr auto to_underlying(Enum value) noexcept -> std::underlying_type_t<Enum>
+{
+    return static_cast<std::underlying_type_t<Enum>>(value);
+}
 
 #define TAB_SIN(x)  gl_static.sintab[(x) & 255]
 #define TAB_COS(x)  gl_static.sintab[((x) + 64) & 255]
@@ -184,6 +192,90 @@ typedef enum {
     QGL_CAP_SHADER_STORAGE              = BIT(14),
     QGL_CAP_SKELETON_MASK               = QGL_CAP_BUFFER_TEXTURE | QGL_CAP_SHADER_STORAGE,
 } glcap_t;
+
+constexpr glArrayBits_t operator|(glArrayBits_t lhs, glArrayBits_t rhs) noexcept
+{
+    using U = std::underlying_type_t<glArrayBits_t>;
+    return static_cast<glArrayBits_t>(static_cast<U>(lhs) | static_cast<U>(rhs));
+}
+
+constexpr glArrayBits_t operator&(glArrayBits_t lhs, glArrayBits_t rhs) noexcept
+{
+    using U = std::underlying_type_t<glArrayBits_t>;
+    return static_cast<glArrayBits_t>(static_cast<U>(lhs) & static_cast<U>(rhs));
+}
+
+constexpr glArrayBits_t operator^(glArrayBits_t lhs, glArrayBits_t rhs) noexcept
+{
+    using U = std::underlying_type_t<glArrayBits_t>;
+    return static_cast<glArrayBits_t>(static_cast<U>(lhs) ^ static_cast<U>(rhs));
+}
+
+constexpr glArrayBits_t operator~(glArrayBits_t value) noexcept
+{
+    using U = std::underlying_type_t<glArrayBits_t>;
+    return static_cast<glArrayBits_t>(~static_cast<U>(value));
+}
+
+constexpr glArrayBits_t &operator|=(glArrayBits_t &lhs, glArrayBits_t rhs) noexcept
+{
+    lhs = lhs | rhs;
+    return lhs;
+}
+
+constexpr glArrayBits_t &operator&=(glArrayBits_t &lhs, glArrayBits_t rhs) noexcept
+{
+    lhs = lhs & rhs;
+    return lhs;
+}
+
+constexpr glArrayBits_t &operator^=(glArrayBits_t &lhs, glArrayBits_t rhs) noexcept
+{
+    lhs = lhs ^ rhs;
+    return lhs;
+}
+
+constexpr glcap_t operator|(glcap_t lhs, glcap_t rhs) noexcept
+{
+    using U = std::underlying_type_t<glcap_t>;
+    return static_cast<glcap_t>(static_cast<U>(lhs) | static_cast<U>(rhs));
+}
+
+constexpr glcap_t operator&(glcap_t lhs, glcap_t rhs) noexcept
+{
+    using U = std::underlying_type_t<glcap_t>;
+    return static_cast<glcap_t>(static_cast<U>(lhs) & static_cast<U>(rhs));
+}
+
+constexpr glcap_t operator^(glcap_t lhs, glcap_t rhs) noexcept
+{
+    using U = std::underlying_type_t<glcap_t>;
+    return static_cast<glcap_t>(static_cast<U>(lhs) ^ static_cast<U>(rhs));
+}
+
+constexpr glcap_t operator~(glcap_t value) noexcept
+{
+    using U = std::underlying_type_t<glcap_t>;
+    return static_cast<glcap_t>(~static_cast<U>(value));
+}
+
+constexpr glcap_t &operator|=(glcap_t &lhs, glcap_t rhs) noexcept
+{
+    lhs = lhs | rhs;
+    return lhs;
+}
+
+constexpr glcap_t &operator&=(glcap_t &lhs, glcap_t rhs) noexcept
+{
+    lhs = lhs & rhs;
+    return lhs;
+}
+
+constexpr glcap_t &operator^=(glcap_t &lhs, glcap_t rhs) noexcept
+{
+    lhs = lhs ^ rhs;
+    return lhs;
+}
 
 #define QGL_VER(major, minor)   ((major) * 100 + (minor))
 #define QGL_UNPACK_VER(ver)     (ver) / 100, (ver) % 100

--- a/src/refresh/images.cpp
+++ b/src/refresh/images.cpp
@@ -32,6 +32,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "format/pcx.h"
 #include "format/wal.h"
 #include <array>
+#include <type_traits>
 #include "images.h"
 
 #if USE_PNG
@@ -1781,7 +1782,8 @@ static bool need_override_image(imagetype_t type, imageformat_t fmt)
         return false;
     if (r_override_textures->integer == 1 && fmt > IM_WAL)
         return false;
-    return r_texture_overrides->integer & (1 << type);
+    using U = std::underlying_type_t<imagetype_t>;
+    return r_texture_overrides->integer & (1 << static_cast<U>(type));
 }
 
 #endif // USE_PNG || USE_JPG || USE_TGA
@@ -2298,7 +2300,7 @@ void IMG_Init(void)
     
     // &r_images[R_NUM_AUTO_IMG] == white pic
     R_RegisterImage("_white", IT_PIC,
-        static_cast<imageflags_t>(IF_PERMANENT | IF_REPEAT | IF_SPECIAL));
+        IF_PERMANENT | IF_REPEAT | IF_SPECIAL);
 }
 
 void IMG_Shutdown(void)

--- a/src/refresh/main.cpp
+++ b/src/refresh/main.cpp
@@ -752,6 +752,48 @@ typedef enum {
     PP_BLOOM     = BIT(1),
 } pp_flags_t;
 
+constexpr pp_flags_t operator|(pp_flags_t lhs, pp_flags_t rhs) noexcept
+{
+    using U = std::underlying_type_t<pp_flags_t>;
+    return static_cast<pp_flags_t>(static_cast<U>(lhs) | static_cast<U>(rhs));
+}
+
+constexpr pp_flags_t operator&(pp_flags_t lhs, pp_flags_t rhs) noexcept
+{
+    using U = std::underlying_type_t<pp_flags_t>;
+    return static_cast<pp_flags_t>(static_cast<U>(lhs) & static_cast<U>(rhs));
+}
+
+constexpr pp_flags_t operator^(pp_flags_t lhs, pp_flags_t rhs) noexcept
+{
+    using U = std::underlying_type_t<pp_flags_t>;
+    return static_cast<pp_flags_t>(static_cast<U>(lhs) ^ static_cast<U>(rhs));
+}
+
+constexpr pp_flags_t operator~(pp_flags_t value) noexcept
+{
+    using U = std::underlying_type_t<pp_flags_t>;
+    return static_cast<pp_flags_t>(~static_cast<U>(value));
+}
+
+constexpr pp_flags_t &operator|=(pp_flags_t &lhs, pp_flags_t rhs) noexcept
+{
+    lhs = lhs | rhs;
+    return lhs;
+}
+
+constexpr pp_flags_t &operator&=(pp_flags_t &lhs, pp_flags_t rhs) noexcept
+{
+    lhs = lhs & rhs;
+    return lhs;
+}
+
+constexpr pp_flags_t &operator^=(pp_flags_t &lhs, pp_flags_t rhs) noexcept
+{
+    lhs = lhs ^ rhs;
+    return lhs;
+}
+
 static pp_flags_t GL_BindFramebuffer(void)
 {
     pp_flags_t flags = PP_NONE;

--- a/src/refresh/qgl.cpp
+++ b/src/refresh/qgl.cpp
@@ -16,8 +16,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#include <type_traits>
-
 #define QGLAPI
 #include "gl.h"
 
@@ -37,20 +35,14 @@ typedef struct {
     const glfunction_t *functions;
 } glsection_t;
 
-template <typename Enum>
-constexpr auto to_underlying(Enum value) noexcept -> std::underlying_type_t<Enum>
-{
-    return static_cast<std::underlying_type_t<Enum>>(value);
-}
-
 static constexpr glcap_t add_caps(glcap_t lhs, glcap_t rhs) noexcept
 {
-    return static_cast<glcap_t>(to_underlying(lhs) | to_underlying(rhs));
+    return lhs | rhs;
 }
 
 static constexpr glcap_t remove_caps(glcap_t lhs, glcap_t rhs) noexcept
 {
-    return static_cast<glcap_t>(to_underlying(lhs) & ~to_underlying(rhs));
+    return lhs & ~rhs;
 }
 
 #define QGL_FN(x)   { "gl"#x, &qgl##x }
@@ -280,7 +272,7 @@ static const glsection_t sections[] = {
         .ver_es = QGL_VER(1, 0),
         .excl_gl = QGL_VER(3, 1),
         .excl_es = QGL_VER(2, 0),
-        .caps = static_cast<glcap_t>(QGL_CAP_LEGACY | QGL_CAP_CLIENT_VA),
+        .caps = QGL_CAP_LEGACY | QGL_CAP_CLIENT_VA,
         .functions = kGl11CompatFunctions
     },
 
@@ -326,13 +318,13 @@ static const glsection_t sections[] = {
     // ES 1.1
     {
         .ver_es = QGL_VER(1, 1),
-        .caps = static_cast<glcap_t>(QGL_CAP_TEXTURE_CLAMP_TO_EDGE | QGL_CAP_CLIENT_VA),
+        .caps = QGL_CAP_TEXTURE_CLAMP_TO_EDGE | QGL_CAP_CLIENT_VA,
     },
 
     // GL 1.2
     {
         .ver_gl = QGL_VER(1, 2),
-        .caps = static_cast<glcap_t>(QGL_CAP_TEXTURE_CLAMP_TO_EDGE | QGL_CAP_TEXTURE_MAX_LEVEL),
+        .caps = QGL_CAP_TEXTURE_CLAMP_TO_EDGE | QGL_CAP_TEXTURE_MAX_LEVEL,
     },
 
     // GL 1.3
@@ -404,7 +396,7 @@ static const glsection_t sections[] = {
         .ver_es = QGL_VER(3, 0),
         // NPOT textures are technically GL 2.0, but only enable them on 3.0 to
         // ensure full hardware support, including mipmaps.
-        .caps = static_cast<glcap_t>(QGL_CAP_TEXTURE_MAX_LEVEL | QGL_CAP_TEXTURE_NON_POWER_OF_TWO),
+        .caps = QGL_CAP_TEXTURE_MAX_LEVEL | QGL_CAP_TEXTURE_NON_POWER_OF_TWO,
         .functions = kGl30Es30Functions
     },
 


### PR DESCRIPTION
## Summary
- add constexpr bitwise helpers for OpenGL array and capability flags using their underlying integer types
- provide the same operator set for image and post-process flags and clean up the associated call sites
- cast enum-based bit shifts through the underlying type to avoid implicit integral hacks

## Testing
- `ninja -C build` *(fails: build.ninja missing in repo checkout)*

------
https://chatgpt.com/codex/tasks/task_e_68f601767a848328a93f218411ef7ef0