### PR TITLE
Define modtype enum for renderer models

### DIFF
--- a/src/refresh/gl.h
+++ b/src/refresh/gl.h
@@ -542,13 +542,15 @@ typedef struct {
 
 #endif
 
+enum modtype_t {
+    MOD_FREE,
+    MOD_ALIAS,
+    MOD_SPRITE,
+    MOD_EMPTY
+};
+
 typedef struct {
-    enum {
-        MOD_FREE,
-        MOD_ALIAS,
-        MOD_SPRITE,
-        MOD_EMPTY
-    } type;
+    modtype_t type;
 
     char name[MAX_QPATH];
     unsigned registration_sequence;


### PR DESCRIPTION
## Summary
- define a named `modtype_t` enumeration in `gl.h` for renderer model types
- update `model_t` to store the `modtype_t` value instead of an anonymous enum

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f6036f14f483288f5c596d3760c05d