### PR TITLE
Rename X11 delete atom field

### DIFF
--- a/src/unix/video/x11.cpp
+++ b/src/unix/video/x11.cpp
@@ -60,7 +60,7 @@ static struct {
     int         dpi_scale;
 
     struct {
-        Atom    delete;
+        Atom    delete_window;
         Atom    wm_state;
         Atom    fs;
         Atom    hidden;
@@ -366,8 +366,8 @@ static bool init(void)
     XStoreName(x11.dpy, x11.win, PRODUCT);
     XSetIconName(x11.dpy, x11.win, PRODUCT);
 
-    x11.atom.delete = XA(WM_DELETE_WINDOW);
-    XSetWMProtocols(x11.dpy, x11.win, &x11.atom.delete, 1);
+    x11.atom.delete_window = XA(WM_DELETE_WINDOW);
+    XSetWMProtocols(x11.dpy, x11.win, &x11.atom.delete_window, 1);
 
     x11.atom.wm_state = XA(_NET_WM_STATE);
 
@@ -570,7 +570,7 @@ static void button_event(XButtonEvent *event)
 
 static void message_event(XClientMessageEvent *event)
 {
-    if (event->format == 32 && event->data.l[0] == x11.atom.delete)
+    if (event->format == 32 && event->data.l[0] == x11.atom.delete_window)
         Com_Quit(NULL, ERR_DISCONNECT);
 }
 


### PR DESCRIPTION
## Summary
- rename the X11 atom field previously named delete to delete_window
- update WM protocol registration and event handling to use the new field name

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fcec6a4b9c8328b6d457aff63065ab