### PR TITLE
Switch debug draw depth flags to bool

### DIFF
--- a/inc/client/client.hpp
+++ b/inc/client/client.hpp
@@ -169,22 +169,22 @@ void SCR_Cinematic_g(genctx_t *ctx);
 
 #if USE_REF
 void R_ClearDebugLines(void);
-void R_AddDebugLine(const vec3_t start, const vec3_t end, color_t color, uint32_t time, qboolean depth_test);
-void R_AddDebugPoint(const vec3_t point, float size, color_t color, uint32_t time, qboolean depth_test);
-void R_AddDebugAxis(const vec3_t origin, const vec3_t angles, float size, uint32_t time, qboolean depth_test);
-void R_AddDebugBounds(const vec3_t mins, const vec3_t maxs, color_t color, uint32_t time, qboolean depth_test);
-void R_AddDebugSphere(const vec3_t origin, float radius, color_t color, uint32_t time, qboolean depth_test);
-void R_AddDebugCircle(const vec3_t origin, float radius, color_t color, uint32_t time, qboolean depth_test);
+void R_AddDebugLine(const vec3_t start, const vec3_t end, color_t color, uint32_t time, bool depth_test);
+void R_AddDebugPoint(const vec3_t point, float size, color_t color, uint32_t time, bool depth_test);
+void R_AddDebugAxis(const vec3_t origin, const vec3_t angles, float size, uint32_t time, bool depth_test);
+void R_AddDebugBounds(const vec3_t mins, const vec3_t maxs, color_t color, uint32_t time, bool depth_test);
+void R_AddDebugSphere(const vec3_t origin, float radius, color_t color, uint32_t time, bool depth_test);
+void R_AddDebugCircle(const vec3_t origin, float radius, color_t color, uint32_t time, bool depth_test);
 void R_AddDebugCylinder(const vec3_t origin, float half_height, float radius, color_t color, uint32_t time,
-                        qboolean depth_test);
+                        bool depth_test);
 void R_DrawArrowCap(const vec3_t apex, const vec3_t dir, float size,
-                    color_t color, uint32_t time, qboolean depth_test);
+                    color_t color, uint32_t time, bool depth_test);
 void R_AddDebugArrow(const vec3_t start, const vec3_t end, float size, color_t line_color,
-                     color_t arrow_color, uint32_t time, qboolean depth_test);
+                     color_t arrow_color, uint32_t time, bool depth_test);
 void R_AddDebugCurveArrow(const vec3_t start, const vec3_t ctrl, const vec3_t end, float size,
-                          color_t line_color, color_t arrow_color, uint32_t time, qboolean depth_test);
+                          color_t line_color, color_t arrow_color, uint32_t time, bool depth_test);
 void R_AddDebugText(const vec3_t origin, const vec3_t angles, const char *text,
-                    float size, color_t color, uint32_t time, qboolean depth_test);
+                    float size, color_t color, uint32_t time, bool depth_test);
 #else
 #define R_ClearDebugLines() (void)0
 #endif

--- a/inc/shared/gameext.hpp
+++ b/inc/shared/gameext.hpp
@@ -50,18 +50,18 @@ typedef struct {
 
 typedef struct {
     void (*ClearDebugLines)(void);
-    void (*AddDebugLine)(const vec3_t start, const vec3_t end, color_t color, uint32_t time, qboolean depth_test);
-    void (*AddDebugPoint)(const vec3_t point, float size, color_t color, uint32_t time, qboolean depth_test);
-    void (*AddDebugAxis)(const vec3_t origin, const vec3_t angles, float size, uint32_t time, qboolean depth_test);
-    void (*AddDebugBounds)(const vec3_t mins, const vec3_t maxs, color_t color, uint32_t time, qboolean depth_test);
-    void (*AddDebugSphere)(const vec3_t origin, float radius, color_t color, uint32_t time, qboolean depth_test);
-    void (*AddDebugCircle)(const vec3_t origin, float radius, color_t color, uint32_t time, qboolean depth_test);
+    void (*AddDebugLine)(const vec3_t start, const vec3_t end, color_t color, uint32_t time, bool depth_test);
+    void (*AddDebugPoint)(const vec3_t point, float size, color_t color, uint32_t time, bool depth_test);
+    void (*AddDebugAxis)(const vec3_t origin, const vec3_t angles, float size, uint32_t time, bool depth_test);
+    void (*AddDebugBounds)(const vec3_t mins, const vec3_t maxs, color_t color, uint32_t time, bool depth_test);
+    void (*AddDebugSphere)(const vec3_t origin, float radius, color_t color, uint32_t time, bool depth_test);
+    void (*AddDebugCircle)(const vec3_t origin, float radius, color_t color, uint32_t time, bool depth_test);
     void (*AddDebugCylinder)(const vec3_t origin, float half_height, float radius, color_t color, uint32_t time,
-                             qboolean depth_test);
+                             bool depth_test);
     void (*AddDebugArrow)(const vec3_t start, const vec3_t end, float size, color_t line_color,
-                          color_t arrow_color, uint32_t time, qboolean depth_test);
+                          color_t arrow_color, uint32_t time, bool depth_test);
     void (*AddDebugCurveArrow)(const vec3_t start, const vec3_t ctrl, const vec3_t end, float size,
-                               color_t line_color, color_t arrow_color, uint32_t time, qboolean depth_test);
+                               color_t line_color, color_t arrow_color, uint32_t time, bool depth_test);
     void (*AddDebugText)(const vec3_t origin, const vec3_t angles, const char *text,
-                         float size, color_t color, uint32_t time, qboolean depth_test);
+                         float size, color_t color, uint32_t time, bool depth_test);
 } debug_draw_api_v1_t;

--- a/src/refresh/debug.cpp
+++ b/src/refresh/debug.cpp
@@ -81,7 +81,7 @@ static inline bool R_DebugTimeExpired(const uint32_t time)
     return time <= R_DebugCurrentTime();
 }
 
-void R_AddDebugLine(const vec3_t start, const vec3_t end, color_t color, uint32_t time, qboolean depth_test)
+void R_AddDebugLine(const vec3_t start, const vec3_t end, color_t color, uint32_t time, bool depth_test)
 {
     debug_line_t *l = LIST_FIRST(debug_line_t, &debug_lines_free, entry);
 
@@ -119,14 +119,14 @@ void R_AddDebugLine(const vec3_t start, const vec3_t end, color_t color, uint32_
         l->bits |= GLS_DEPTHTEST_DISABLE;
 }
 
-static inline void R_DebugDrawLine(float sx, float sy, float sz, float ex, float ey, float ez, color_t color, uint32_t time, qboolean depth_test)
+static inline void R_DebugDrawLine(float sx, float sy, float sz, float ex, float ey, float ez, color_t color, uint32_t time, bool depth_test)
 {
     vec3_t start{ sx, sy, sz };
     vec3_t end{ ex, ey, ez };
     R_AddDebugLine(start, end, color, time, depth_test);
 }
 
-void R_AddDebugPoint(const vec3_t point, float size, color_t color, uint32_t time, qboolean depth_test)
+void R_AddDebugPoint(const vec3_t point, float size, color_t color, uint32_t time, bool depth_test)
 {
     size *= 0.5f;
     R_DebugDrawLine(point[0] - size, point[1], point[2], point[0] + size, point[1], point[2], color, time, depth_test);
@@ -134,7 +134,7 @@ void R_AddDebugPoint(const vec3_t point, float size, color_t color, uint32_t tim
     R_DebugDrawLine(point[0], point[1], point[2] - size, point[0], point[1], point[2] + size, color, time, depth_test);
 }
 
-void R_AddDebugAxis(const vec3_t origin, const vec3_t angles, float size, uint32_t time, qboolean depth_test)
+void R_AddDebugAxis(const vec3_t origin, const vec3_t angles, float size, uint32_t time, bool depth_test)
 {
     std::array<vec3_t, 3> axis{};
     vec3_t end;
@@ -161,7 +161,7 @@ void R_AddDebugAxis(const vec3_t origin, const vec3_t angles, float size, uint32
     R_AddDebugLine(origin, end, color, time, depth_test);
 }
 
-void R_AddDebugBounds(const vec3_t mins, const vec3_t maxs, color_t color, uint32_t time, qboolean depth_test)
+void R_AddDebugBounds(const vec3_t mins, const vec3_t maxs, color_t color, uint32_t time, bool depth_test)
 {
     for (int i = 0; i < 4; i++) {
         // draw column
@@ -179,7 +179,7 @@ void R_AddDebugBounds(const vec3_t mins, const vec3_t maxs, color_t color, uint3
 }
 
 // https://danielsieger.com/blog/2021/03/27/generating-spheres.html
-void R_AddDebugSphere(const vec3_t origin, float radius, color_t color, uint32_t time, qboolean depth_test)
+void R_AddDebugSphere(const vec3_t origin, float radius, color_t color, uint32_t time, bool depth_test)
 {
     std::array<vec3_t, 160> verts{};
     const int n_stacks = min(4 + radius / 32, 10);
@@ -236,7 +236,7 @@ void R_AddDebugSphere(const vec3_t origin, float radius, color_t color, uint32_t
     }
 }
 
-void R_AddDebugCircle(const vec3_t origin, float radius, color_t color, uint32_t time, qboolean depth_test)
+void R_AddDebugCircle(const vec3_t origin, float radius, color_t color, uint32_t time, bool depth_test)
 {
     int vert_count = min(5 + radius / 8, 16);
     float rads = (2 * M_PIf) / vert_count;
@@ -258,7 +258,7 @@ void R_AddDebugCircle(const vec3_t origin, float radius, color_t color, uint32_t
     }
 }
 
-void R_AddDebugCylinder(const vec3_t origin, float half_height, float radius, color_t color, uint32_t time, qboolean depth_test)
+void R_AddDebugCylinder(const vec3_t origin, float half_height, float radius, color_t color, uint32_t time, bool depth_test)
 {
     int vert_count = min(5 + radius / 8, 16);
     float rads = (2 * M_PIf) / vert_count;
@@ -283,7 +283,7 @@ void R_AddDebugCylinder(const vec3_t origin, float half_height, float radius, co
 }
 
 void R_DrawArrowCap(const vec3_t apex, const vec3_t dir, float size,
-                    color_t color, uint32_t time, qboolean depth_test)
+                    color_t color, uint32_t time, bool depth_test)
 {
     vec3_t cap_end;
     VectorMA(apex, size, dir, cap_end);
@@ -301,7 +301,7 @@ void R_DrawArrowCap(const vec3_t apex, const vec3_t dir, float size,
 }
 
 void R_AddDebugArrow(const vec3_t start, const vec3_t end, float size, color_t line_color,
-                     color_t arrow_color, uint32_t time, qboolean depth_test)
+                     color_t arrow_color, uint32_t time, bool depth_test)
 {
     vec3_t dir;
     VectorSubtract(end, start, dir);
@@ -318,7 +318,7 @@ void R_AddDebugArrow(const vec3_t start, const vec3_t end, float size, color_t l
 }
 
 void R_AddDebugCurveArrow(const vec3_t start, const vec3_t ctrl, const vec3_t end, float size,
-                          color_t line_color, color_t arrow_color, uint32_t time, qboolean depth_test)
+                          color_t line_color, color_t arrow_color, uint32_t time, bool depth_test)
 {
     int num_points = Q_clip(Distance(start, end) / 32, 3, 24);
     vec3_t last_point;
@@ -348,7 +348,7 @@ void R_AddDebugCurveArrow(const vec3_t start, const vec3_t ctrl, const vec3_t en
 
 static void R_AddDebugTextInternal(const vec3_t origin, const vec3_t angles, const char *text,
                                    size_t len, float size, color_t color, uint32_t time,
-                                   qboolean depth_test)
+                                   bool depth_test)
 {
     if (!len)
         return;
@@ -397,7 +397,7 @@ static void R_AddDebugTextInternal(const vec3_t origin, const vec3_t angles, con
 }
 
 static void R_AddDebugTextTexture(const vec3_t origin, const vec3_t angles, const char *text,
-                                  float size, color_t color, uint32_t time, qboolean depth_test)
+                                  float size, color_t color, uint32_t time, bool depth_test)
 {
     vec3_t down, pos, up;
     const char *s, *p;
@@ -430,7 +430,7 @@ static void R_AddDebugTextTexture(const vec3_t origin, const vec3_t angles, cons
 }
 
 void R_AddDebugText(const vec3_t origin, const vec3_t angles, const char *text,
-                    float size, color_t color, uint32_t time, qboolean depth_test)
+                    float size, color_t color, uint32_t time, bool depth_test)
 {
     if (debug_text_style == DEBUG_TEXT_LINES)
         GL_AddDebugTextLines(origin, angles, text, size, color, time, depth_test);

--- a/src/refresh/debug_text.cpp
+++ b/src/refresh/debug_text.cpp
@@ -98,7 +98,7 @@ static cvar_t *gl_debug_font;
 #define GL_DRAWLINEV(s, e) \
     R_AddDebugLine(s, e, color, time, depth_test)
 
-void GL_AddDebugTextLines(const vec3_t origin, const vec3_t angles, const char *text, float size, color_t color, uint32_t time, qboolean depth_test)
+void GL_AddDebugTextLines(const vec3_t origin, const vec3_t angles, const char *text, float size, color_t color, uint32_t time, bool depth_test)
 {
     int total_lines = 1;
     float scale = (1.0f / dbg_font->height) * (size * 32);

--- a/src/refresh/gl.hpp
+++ b/src/refresh/gl.hpp
@@ -1135,4 +1135,4 @@ void GL_ExpireDebugObjects(void);
  *
  */
 void GL_InitDebugTextLines(void);
-void GL_AddDebugTextLines(const vec3_t origin, const vec3_t angles, const char *text, float size, color_t color, uint32_t time, qboolean depth_test);
+void GL_AddDebugTextLines(const vec3_t origin, const vec3_t angles, const char *text, float size, color_t color, uint32_t time, bool depth_test);

--- a/src/server/game.cpp
+++ b/src/server/game.cpp
@@ -850,54 +850,54 @@ static void PF_Loc_Print(edict_t* ent, int level, const char* base, const char**
 
 static void PF_Draw_Line(const vec3_t start, const vec3_t end, const rgba_t* color, const float lifeTime, const bool depthTest)
 {
-    const qboolean depth = depthTest ? qtrue : qfalse;
+    const bool depth = depthTest;
     R_AddDebugLine(start, end, *((color_t *) color), lifeTime * 1000, depth);
 }
 static void PF_Draw_Point(const vec3_t point, const float size, const rgba_t* color, const float lifeTime, const bool depthTest)
 {
-    const qboolean depth = depthTest ? qtrue : qfalse;
+    const bool depth = depthTest;
     R_AddDebugPoint(point, size, *((color_t *) color), lifeTime * 1000, depth);
 }
 static void PF_Draw_Circle(const vec3_t origin, const float radius, const rgba_t* color, const float lifeTime, const bool depthTest)
 {
-    const qboolean depth = depthTest ? qtrue : qfalse;
+    const bool depth = depthTest;
     R_AddDebugCircle(origin, radius, *((color_t *) color), lifeTime * 1000, depth);
 }
 static void PF_Draw_Bounds(const vec3_t mins, const vec3_t maxs, const rgba_t* color, const float lifeTime, const bool depthTest)
 {
-    const qboolean depth = depthTest ? qtrue : qfalse;
+    const bool depth = depthTest;
     R_AddDebugBounds(mins, maxs, *((color_t *) color), lifeTime * 1000, depth);
 }
 static void PF_Draw_Sphere(const vec3_t origin, const float radius, const rgba_t* color, const float lifeTime, const bool depthTest)
 {
-    const qboolean depth = depthTest ? qtrue : qfalse;
+    const bool depth = depthTest;
     R_AddDebugSphere(origin, radius, *((color_t *) color), lifeTime * 1000, depth);
 }
 static void PF_Draw_OrientedWorldText(const vec3_t origin, const char * text, const rgba_t* color, const float size, const float lifeTime, const bool depthTest)
 {
-    const qboolean depth = depthTest ? qtrue : qfalse;
+    const bool depth = depthTest;
     R_AddDebugText(origin, NULL, text, size, *((color_t *) color), lifeTime * 1000, depth);
 }
 static void PF_Draw_StaticWorldText(const vec3_t origin, const vec3_t angles, const char * text, const rgba_t* color, const float size, const float lifeTime, const bool depthTest)
 {
-    const qboolean depth = depthTest ? qtrue : qfalse;
+    const bool depth = depthTest;
     R_AddDebugText(origin, angles, text, size, *((color_t *) color), lifeTime * 1000, depth);
 }
 static void PF_Draw_Cylinder(const vec3_t origin, const float halfHeight, const float radius, const rgba_t* color, const float lifeTime, const bool depthTest)
 {
-    const qboolean depth = depthTest ? qtrue : qfalse;
+    const bool depth = depthTest;
     R_AddDebugCylinder(origin, halfHeight, radius, *((color_t *) color), lifeTime * 1000, depth);
 }
 static void PF_Draw_Ray(const vec3_t origin, const vec3_t direction, const float length, const float size, const rgba_t* color, const float lifeTime, const bool depthTest)
 {
-    const qboolean depth = depthTest ? qtrue : qfalse;
+    const bool depth = depthTest;
     vec3_t end;
     VectorMA(origin, length, direction, end);
     R_AddDebugArrow(origin, end, size, *((color_t *) color), *((color_t *) color), lifeTime * 1000, depth);
 }
 static void PF_Draw_Arrow(const vec3_t start, const vec3_t end, const float size, const rgba_t* lineColor, const rgba_t* arrowColor, const float lifeTime, const bool depthTest)
 {
-    const qboolean depth = depthTest ? qtrue : qfalse;
+    const bool depth = depthTest;
     R_AddDebugArrow(start, end, size, *((color_t *) lineColor), *((color_t *) arrowColor), lifeTime * 1000, depth);
 }
 #else

--- a/src/server/nav.cpp
+++ b/src/server/nav.cpp
@@ -867,22 +867,22 @@ static void Nav_DebugPath(const PathInfo *path, const PathRequest *request)
     color_t path_color = ColorSetAlpha(COLOR_RED, static_cast<uint8_t>(64));
     color_t arrow_color = ColorSetAlpha(COLOR_YELLOW, static_cast<uint8_t>(64));
 
-    R_AddDebugSphere(request->start, 8.0f, path_color, time, qfalse);
-    R_AddDebugSphere(request->goal, 8.0f, path_color, time, qfalse);
+    R_AddDebugSphere(request->start, 8.0f, path_color, time, false);
+    R_AddDebugSphere(request->goal, 8.0f, path_color, time, false);
 
     if (request->pathPoints.count) {
-        R_AddDebugArrow(request->start, request->pathPoints.posArray[0], 8.0f, arrow_color, arrow_color, time, qfalse);
+        R_AddDebugArrow(request->start, request->pathPoints.posArray[0], 8.0f, arrow_color, arrow_color, time, false);
 
         for (int64_t i = 0; i < request->pathPoints.count - 1; i++)
-            R_AddDebugArrow(request->pathPoints.posArray[i], request->pathPoints.posArray[i + 1], 8.0f, arrow_color, arrow_color, time, qfalse);
+            R_AddDebugArrow(request->pathPoints.posArray[i], request->pathPoints.posArray[i + 1], 8.0f, arrow_color, arrow_color, time, false);
 
-        R_AddDebugArrow(request->pathPoints.posArray[request->pathPoints.count - 1], request->goal, 8.0f, arrow_color, arrow_color, time, qfalse);
+        R_AddDebugArrow(request->pathPoints.posArray[request->pathPoints.count - 1], request->goal, 8.0f, arrow_color, arrow_color, time, false);
     } else {
-        R_AddDebugArrow(request->start, request->goal, 8.0f, arrow_color, arrow_color, time, qfalse);
+        R_AddDebugArrow(request->start, request->goal, 8.0f, arrow_color, arrow_color, time, false);
     }
 
-    R_AddDebugSphere(path->firstMovePoint, 16.0f, path_color, time, qfalse);
-    R_AddDebugArrow(path->firstMovePoint, path->secondMovePoint, 16.0f, path_color, path_color, time, qfalse);
+    R_AddDebugSphere(path->firstMovePoint, 16.0f, path_color, time, false);
+    R_AddDebugArrow(path->firstMovePoint, path->secondMovePoint, 16.0f, path_color, path_color, time, false);
 }
 #endif
 
@@ -1128,27 +1128,27 @@ static inline void Nav_GetCurveControlPoint(const vec3_t a, const vec3_t b, vec3
 // just to reduce verbosity at call sites
 static inline void Nav_AddDebugLine(const vec3_t s, const vec3_t e, const color_t c)
 {
-    R_AddDebugLine(s, e, c, SV_FRAMETIME, qtrue);
+    R_AddDebugLine(s, e, c, SV_FRAMETIME, true);
 }
 static inline void Nav_AddDebugArrow(const vec3_t s, const vec3_t e, const color_t lc, const color_t ac)
 {
-    R_AddDebugArrow(s, e, 8.0f, lc, ac, SV_FRAMETIME, qtrue);
+    R_AddDebugArrow(s, e, 8.0f, lc, ac, SV_FRAMETIME, true);
 }
 static inline void Nav_AddDebugCurveArrow(const vec3_t s, const vec3_t c, const vec3_t e, const color_t lc, const color_t ac)
 {
-    R_AddDebugCurveArrow(s, c, e, 8.0f, lc, ac, SV_FRAMETIME, qtrue);
+    R_AddDebugCurveArrow(s, c, e, 8.0f, lc, ac, SV_FRAMETIME, true);
 }
 static inline void Nav_AddDebugCircle(const vec3_t o, const float r, const color_t c)
 {
-    R_AddDebugCircle(o, r, c, SV_FRAMETIME, qtrue);
+    R_AddDebugCircle(o, r, c, SV_FRAMETIME, true);
 }
 static inline void Nav_AddDebugBounds(const vec3_t min, const vec3_t max, const color_t c)
 {
-    R_AddDebugBounds(min, max, c, SV_FRAMETIME, qtrue);
+    R_AddDebugBounds(min, max, c, SV_FRAMETIME, true);
 }
 static inline void Nav_AddDebugText(const vec3_t o, const vec3_t a, const char *t, float s, color_t c)
 {
-    R_AddDebugText(o, a, t, s, c, SV_FRAMETIME, qtrue);
+    R_AddDebugText(o, a, t, s, c, SV_FRAMETIME, true);
 }
 
 static void Nav_RenderLinkEdict(const vec3_t start, const vec3_t end, const nav_edict_t *edict)
@@ -1159,9 +1159,9 @@ static void Nav_RenderLinkEdict(const vec3_t start, const vec3_t end, const nav_
     LerpVector(start, end, 0.5f, e);
     VectorMA(e, 24.f, u, e);
     
-    R_AddDebugLine(start, e, COLOR_BLUE, SV_FRAMETIME, qtrue);
-    R_AddDebugLine(end, e, COLOR_BLUE, SV_FRAMETIME, qtrue);
-    R_AddDebugSphere(e, 8.0f, COLOR_RED, SV_FRAMETIME, qtrue);
+    R_AddDebugLine(start, e, COLOR_BLUE, SV_FRAMETIME, true);
+    R_AddDebugLine(end, e, COLOR_BLUE, SV_FRAMETIME, true);
+    R_AddDebugSphere(e, 8.0f, COLOR_RED, SV_FRAMETIME, true);
 
     vec3_t d;
     VectorSubtract(glr.fd.vieworg, e, d);
@@ -1176,14 +1176,14 @@ static void Nav_RenderLinkEdict(const vec3_t start, const vec3_t end, const nav_
                      (e[i] > edict->game_edict->absmax[i]) ? edict->game_edict->absmax[i] :
                       e[i];
 
-        R_AddDebugLine(org, e, COLOR_GREEN, SV_FRAMETIME, qfalse);
-        R_AddDebugBounds(edict->game_edict->absmin, edict->game_edict->absmax, COLOR_GREEN, SV_FRAMETIME, qfalse);
+        R_AddDebugLine(org, e, COLOR_GREEN, SV_FRAMETIME, false);
+        R_AddDebugBounds(edict->game_edict->absmin, edict->game_edict->absmax, COLOR_GREEN, SV_FRAMETIME, false);
     }
     
     e[2] += 16.f;
     R_AddDebugText(e, NULL, va("entity %i\nmodel %i\nclassname %s", 
         edict->game_edict->s.number, edict->game_edict->s.modelindex, edict->game_edict->sv.classname ? edict->game_edict->sv.classname : "!noclass!"),
-        0.25f, COLOR_YELLOW, SV_FRAMETIME, qfalse);
+        0.25f, COLOR_YELLOW, SV_FRAMETIME, false);
 }
 
 static void Nav_RenderLink(const nav_node_t *node, int node_id, const vec3_t node_origin, const nav_link_t *link, uint8_t alpha)
@@ -1305,7 +1305,7 @@ static void Nav_Debug(void)
 
         t[2] -= 18;
 
-        R_AddDebugText(t, NULL, Nav_NodeFlagsToString(node->flags), 0.1f, ColorSetAlpha(COLOR_GREEN, alpha), SV_FRAMETIME, qfalse);
+        R_AddDebugText(t, NULL, Nav_NodeFlagsToString(node->flags), 0.1f, ColorSetAlpha(COLOR_GREEN, alpha), SV_FRAMETIME, false);
         
         for (const nav_link_t *link = node->links; link != node->links + node->num_links; link++)
             Nav_RenderLink(node, i, s, link, alpha);


### PR DESCRIPTION
## Summary
- replace the qboolean depth-test parameters in the debug drawing API with plain bools
- update the renderer, server helpers, and navigation debugging utilities to pass the new bool flags

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fcece9c0508328a69e675c696ee339