### PR TITLE
Fix add_texture_format invocation casts

### DIFF
--- a/src/refresh/images.cpp
+++ b/src/refresh/images.cpp
@@ -1785,7 +1785,7 @@ static void r_texture_formats_changed(cvar_t *self)
         // handle "png jpg tga" format
         for (i = IM_WAL + 1; i < IM_MAX; i++) {
             if (!Q_stricmp(tok, img_loaders[i].ext)) {
-                add_texture_format(i);
+                add_texture_format(static_cast<imageformat_t>(i));
                 break;
             }
         }
@@ -1796,7 +1796,7 @@ static void r_texture_formats_changed(cvar_t *self)
         while (*tok) {
             for (i = IM_WAL + 1; i < IM_MAX; i++) {
                 if (Q_tolower(*tok) == img_loaders[i].ext[0]) {
-                    add_texture_format(i);
+                    add_texture_format(static_cast<imageformat_t>(i));
                     break;
                 }
             }


### PR DESCRIPTION
## Summary
- cast parsed texture format indices to `imageformat_t` before forwarding to `add_texture_format`

## Testing
- meson compile -C build *(fails: `/workspace/WORR/build` is not a Meson build directory in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fcfb7fe8908328acef2ce7c4f9bdda