### PR TITLE
Ensure MSVC builds use C++20 standard

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -9,6 +9,12 @@ project('worr', ['cpp', 'c'],
   ],
 )
 
+cpp_compiler = meson.get_compiler('cpp')
+
+if cpp_compiler.get_id() == 'msvc'
+  meson.override_default_options({'cpp_std': 'c++20'})
+endif
+
 
 c_compiler = meson.get_compiler('c')
 


### PR DESCRIPTION
## Summary
- detect the MSVC compiler in Meson and override the default C++ standard to C++20

## Testing
- not run (not applicable on this platform)


------
https://chatgpt.com/codex/tasks/task_e_68fcfb7dd28c83288861ff491023f60e