### PR TITLE
Extend libpng MSVC fix to cover png.h

### DIFF
--- a/subprojects/packagefiles/libpng/msvc-restrict.patch
+++ b/subprojects/packagefiles/libpng/msvc-restrict.patch
@@ -6,3 +6,11 @@
 @@
 -#        define PNG_ALLOCATED __declspec(__restrict)
 +#        define PNG_ALLOCATED __declspec(restrict)
+--- a/png.h
++++ b/png.h
+@@
+-__declspec(PNG_RESTRICT)
++__declspec(restrict)
+@@
+-__declspec(__restrict)
++__declspec(restrict)

--- a/tools/fix_libpng_msvc.py
+++ b/tools/fix_libpng_msvc.py
@@ -6,36 +6,44 @@ import re
 from pathlib import Path
 
 
-def main() -> int:
-    source_root = Path(os.environ.get('MESON_SOURCE_ROOT', Path(__file__).resolve().parents[1]))
-    header = source_root / 'subprojects' / 'libpng-1.6.50' / 'pngconf.h'
+def _find_headers(source_root: Path, filename: str) -> list[Path]:
+    subprojects = source_root / 'subprojects'
+    headers: list[Path] = []
+    seen: set[Path] = set()
 
-    if not header.exists():
-        return 0
+    for candidate in subprojects.glob(f'libpng-1.6.50*/**/{filename}'):
+        if candidate.is_file() and candidate not in seen:
+            seen.add(candidate)
+            headers.append(candidate)
 
+    return sorted(headers)
+
+
+def _collect_patch_replacements(patch_path: Path) -> list[tuple[str, str]]:
+    replacements: list[tuple[str, str]] = []
+
+    if not patch_path.exists():
+        return replacements
+
+    pending: str | None = None
+    for line in patch_path.read_text(encoding='utf-8').splitlines():
+        if line.startswith(('---', '+++', '@@')):
+            pending = None
+            continue
+        if line.startswith('-') and not line.startswith('--'):
+            pending = line[1:]
+            continue
+        if line.startswith('+') and not line.startswith('++') and pending is not None:
+            replacements.append((pending, line[1:]))
+            pending = None
+
+    return replacements
+
+
+def _apply_replacements(header: Path, replacements: list[tuple[str, str]]) -> bool:
     original = header.read_text(encoding='utf-8')
     updated = original
     changed = False
-
-    patch_path = source_root / 'subprojects' / 'packagefiles' / 'libpng' / 'msvc-restrict.patch'
-    replacements: list[tuple[str, str]] = []
-    if patch_path.exists():
-        pending: str | None = None
-        for line in patch_path.read_text(encoding='utf-8').splitlines():
-            if line.startswith(('---', '+++', '@@')):
-                pending = None
-                continue
-            if line.startswith('-') and not line.startswith('--'):
-                pending = line[1:]
-                continue
-            if line.startswith('+') and not line.startswith('++') and pending is not None:
-                replacements.append((pending, line[1:]))
-                pending = None
-
-    replacements.extend([
-        ('__declspec(PNG_RESTRICT)', '__declspec(restrict)'),
-        ('__declspec(__restrict)', '__declspec(restrict)'),
-    ])
 
     for old, new in replacements:
         if old in updated:
@@ -49,6 +57,29 @@ def main() -> int:
 
     if changed:
         header.write_text(updated, encoding='utf-8')
+
+    return changed
+
+
+def main() -> int:
+    source_root = Path(os.environ.get('MESON_SOURCE_ROOT', Path(__file__).resolve().parents[1]))
+
+    headers = []
+    for name in ('pngconf.h', 'png.h'):
+        headers.extend(_find_headers(source_root, name))
+
+    if not headers:
+        return 0
+
+    patch_path = source_root / 'subprojects' / 'packagefiles' / 'libpng' / 'msvc-restrict.patch'
+    replacements = _collect_patch_replacements(patch_path)
+    replacements.extend([
+        ('__declspec(PNG_RESTRICT)', '__declspec(restrict)'),
+        ('__declspec(__restrict)', '__declspec(restrict)'),
+    ])
+
+    for header in headers:
+        _apply_replacements(header, replacements)
 
     return 0
 


### PR DESCRIPTION
## Summary
- extend the libpng MSVC fix script to locate both pngconf.h and png.h and apply the restrict replacements
- mirror the script updates in msvc-restrict.patch so both headers receive the same __declspec adjustments

## Testing
- python tools/fix_libpng_msvc.py

------
https://chatgpt.com/codex/tasks/task_e_68fcfb7e95c48328a91fd74c19a95a6c