### PR TITLE
Cast texture unit index before binding textures

### DIFF
--- a/src/refresh/tess.cpp
+++ b/src/refresh/tess.cpp
@@ -723,7 +723,7 @@ void GL_Flush3D(void)
             qglBindTextures(0, count, tess.texnum);
     } else {
         for (int i = 0; i < MAX_TMUS && tess.texnum[i]; i++)
-            GL_BindTexture(i, tess.texnum[i]);
+            GL_BindTexture(static_cast<glTmu_t>(i), tess.texnum[i]);
     }
 
     GL_DrawIndexed(SHOWTRIS_WORLD);


### PR DESCRIPTION
## Summary
- cast the texture unit loop index to `glTmu_t` before calling `GL_BindTexture` in `GL_Flush3D`

## Testing
- meson setup build *(fails: wrap-redirect subprojects/ffmpeg/subprojects/nasm.wrap filename does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68fcfc39def083288e9856f941f1b593