### PR TITLE
Fix tess texnum copy to use std::copy

### DIFF
--- a/src/refresh/tess.cpp
+++ b/src/refresh/tess.cpp
@@ -17,6 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "gl.hpp"
+#include <algorithm>
 #include <array>
 #include <type_traits>
 
@@ -812,7 +813,7 @@ static void GL_DrawFace(const mface_t *surf)
     }
     tess.numindices += numindices;
 
-    memcpy(tess.texnum, texnum, sizeof(texnum));
+    std::copy(texnum.begin(), texnum.end(), tess.texnum);
     tess.flags = state;
 
     c.facesTris += numtris;


### PR DESCRIPTION
## Summary
- include <algorithm> in tess.cpp to use standard copy routines
- replace memcpy on the tess texnum array with std::copy to avoid pointer conversion issues

## Testing
- meson setup builddir *(fails: wrap-redirect /workspace/WORR/subprojects/ffmpeg/subprojects/nasm.wrap filename does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68fcfc3d98d08328b4606dc3d4e909e5