### PR TITLE
Fix flare scale shift warning

### DIFF
--- a/src/refresh/tess.cpp
+++ b/src/refresh/tess.cpp
@@ -495,7 +495,7 @@ void GL_DrawFlares(void)
         if (def)
             tess.flags |= GLS_DEFAULT_FLARE;
 
-        scale = (25 << def) * (ent->scale[0] * q->frac);
+        scale = (25 << static_cast<int>(def)) * (ent->scale[0] * q->frac);
 
         if (ent->flags & RF_FLARE_LOCK_ANGLE) {
             VectorScale(glr.viewaxis[1],  scale, left);


### PR DESCRIPTION
## Summary
- ensure the flare scaling bitshift operates on an integer to avoid warnings when IF_DEFAULT_FLARE is set

## Testing
- `meson setup build` *(fails: wrap-redirect subprojects/ffmpeg/subprojects/nasm.wrap filename does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68fcff4fd7a48328a380eeda6be81dbd