### PR TITLE
Fix particle texture flags type

### DIFF
--- a/src/refresh/texture.cpp
+++ b/src/refresh/texture.cpp
@@ -1054,7 +1054,7 @@ static void GL_InitParticleTexture(void)
     float x, y, f;
     int i, j;
     int shape = Cvar_ClampInteger(gl_partshape, 0, 2);
-    int flags = IF_TRANSPARENT;
+    imageflags_t flags = IF_TRANSPARENT;
 
     if (shape == 0 || shape == 2) {
         dst = pixels;


### PR DESCRIPTION
## Summary
- change the particle texture flag variable to use imageflags_t before uploading or configuring filters

## Testing
- meson setup build *(fails: wrap-redirect /workspace/WORR/subprojects/ffmpeg/subprojects/nasm.wrap filename does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68fcff5036108328a37d3488e7994d31