### PR TITLE
Handle cpp standard defaults on older Meson releases

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,15 +4,30 @@ project('worr', ['cpp', 'c'],
   meson_version: '>= 0.60.0',
   default_options: [
     meson.version().version_compare('>=1.3.0') ? 'c_std=gnu11,c11' : 'c_std=gnu11',
-    'cpp_std=c++latest',
+    meson.version().version_compare('>=0.63.0') ? 'cpp_std=c++latest' : 'cpp_std=c++20',
     'buildtype=debugoptimized',
   ],
 )
 
 cpp_compiler = meson.get_compiler('cpp')
 
-if cpp_compiler.get_id() == 'msvc'
-  meson.override_default_options({'cpp_std': 'c++20'})
+if meson.version().version_compare('>=0.63.0')
+  if cpp_compiler.get_id() == 'msvc'
+    meson.override_default_options({'cpp_std': 'c++20'})
+  endif
+else
+  if cpp_compiler.get_id() != 'msvc'
+    cpp_latest_flags = []
+    if cpp_compiler.has_argument('-std=c++2b')
+      cpp_latest_flags += ['-std=c++2b']
+    elif cpp_compiler.has_argument('-std=c++2a')
+      cpp_latest_flags += ['-std=c++2a']
+    endif
+
+    if cpp_latest_flags.length() > 0
+      add_project_arguments(cpp_latest_flags, language: 'cpp')
+    endif
+  endif
 endif
 
 


### PR DESCRIPTION
## Summary
- gate the use of `meson.override_default_options()` on the Meson version
- keep MSVC on C++20 while non-MSVC toolchains retain a latest-standard build via fallback compiler flags on old Meson

## Testing
- meson setup builddir-modern *(fails: wrap-redirect /workspace/WORR/subprojects/ffmpeg/subprojects/nasm.wrap filename does not exist)*
- python3 -m pip install --user 'meson==0.60.3' *(fails: Cannot connect to proxy.)*

------
https://chatgpt.com/codex/tasks/task_e_68fd1b0e24b083288ea9b49112c76391