### PR TITLE
Fix MD5 CPU allocation pointer cast

### DIFF
--- a/src/refresh/models.cpp
+++ b/src/refresh/models.cpp
@@ -840,7 +840,7 @@ static void *MD5_HunkAlloc(memhunk_t *hunk, size_t size)
     MD5_HunkAlloc(gl_static.use_gpu_lerp ? &temp_hunk[1] : &model->hunk, size)
 
 #define MD5_CpuMalloc(size) \
-    (gl_static.use_gpu_lerp ? R_Mallocz(size) : MD5_HunkAlloc(&model->hunk, size))
+    (gl_static.use_gpu_lerp ? static_cast<void *>(R_Mallocz(size)) : MD5_HunkAlloc(&model->hunk, size))
 
 static void MD5_ParseExpect(const char **buffer, const char *expect)
 {


### PR DESCRIPTION
## Summary
- adjust the MD5_CpuMalloc macro so the CPU branch returns a void pointer like the hunk branch

## Testing
- not run (MSVC build environment unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68fd3168f6c483289c70f46f3c047cba