### PR TITLE
Wire libpng MSVC restrict patch

### DIFF
--- a/subprojects/libpng.wrap
+++ b/subprojects/libpng.wrap
@@ -6,6 +6,7 @@ source_hash = 71158e53cfdf2877bc99bcab33641d78df3f48e6e0daad030afe9cb8c031aa46
 patch_filename = libpng_1.6.50-1_patch.zip
 patch_url = https://wrapdb.mesonbuild.com/v2/libpng_1.6.50-1/get_patch
 patch_hash = d8f364bb5b5aa342ee0cfa17ef65746ebc37ad0aa9fabfe383f185dfdaa7d4ab
+patch_directory = packagefiles/libpng
 source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/libpng_1.6.50-1/libpng-1.6.50.tar.gz
 wrapdb_version = 1.6.50-1
 


### PR DESCRIPTION
## Summary
- update the libpng.wrap to look for additional patches under packagefiles/libpng so the MSVC restrict fix is applied during fetch

## Testing
- meson subprojects download libpng *(fails in CI sandbox: wrap download returns 403 Forbidden because outbound network access is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68fd316b0f308328b8b86b902b2872a3