### PR TITLE
Fix raw_tag initialization in R_RegisterModel

### DIFF
--- a/src/refresh/models.cpp
+++ b/src/refresh/models.cpp
@@ -1606,6 +1606,7 @@ qhandle_t R_RegisterModel(const char *name)
     model_t *model;
     byte *rawdata;
     int (*load)(model_t *, const void *, size_t);
+    uint32_t raw_tag = 0;
     int ret;
 
     Q_assert(name);
@@ -1652,7 +1653,7 @@ qhandle_t R_RegisterModel(const char *name)
     }
 
     // check ident
-    const auto raw_tag = LittleLong(*reinterpret_cast<const uint32_t *>(rawdata));
+    raw_tag = LittleLong(*reinterpret_cast<const uint32_t *>(rawdata));
     switch (raw_tag) {
     case MD2_IDENT:
         load = MOD_LoadMD2;


### PR DESCRIPTION
## Summary
- declare a reusable `raw_tag` variable at the top of `R_RegisterModel`
- assign the raw tag value before the switch so all code paths see the same initialized variable

## Testing
- not run (MSVC not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68fd3172574883289bfcaa7bf9c38379