### PR TITLE
Fix MSVC build issues in refresh subsystem

### DIFF
--- a/src/refresh/images.cpp
+++ b/src/refresh/images.cpp
@@ -38,6 +38,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #if USE_PNG
 #define PNG_SKIP_SETJMP_CHECK
+#if defined(_MSC_VER) && defined(__cplusplus) && !defined(PNG_ALLOCATED)
+#define PNG_ALLOCATED __declspec(restrict)
+#endif
 #include <png.h>
 #endif // USE_PNG
 


### PR DESCRIPTION
## Summary
- add a local override for PNG_ALLOCATED so libpng headers compile with MSVC
- replace MD5_CpuMalloc macro with an inline helper and clean up raw tag handling to appease MSVC

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fd330d4c8c83289e57b4c2afa8ad54