### PR TITLE
Fix Windows service table entry type

### DIFF
--- a/src/windows/system.cpp
+++ b/src/windows/system.cpp
@@ -1444,8 +1444,10 @@ static void WINAPI ServiceMain(DWORD argc, LPSTR *argv)
     SetServiceStatus(statusHandle, &status);
 }
 
+static char serviceName[] = APPLICATION;
+
 static const SERVICE_TABLE_ENTRYA serviceTable[] = {
-    { APPLICATION, ServiceMain },
+    { serviceName, ServiceMain },
     { NULL, NULL }
 };
 


### PR DESCRIPTION
## Summary
- replace the literal application name in the Windows service table with a mutable buffer to satisfy the LPSTR requirement

## Testing
- `meson compile -C build` *(fails: `/workspace/WORR/build` is not a Meson build directory in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fd36f61bb88328aa695d7dd2b59bac