### PR TITLE
Fix MSVC restrict annotations in libpng headers

### DIFF
--- a/subprojects/packagefiles/libpng/msvc-restrict.patch
+++ b/subprojects/packagefiles/libpng/msvc-restrict.patch
@@ -6,6 +6,9 @@
 @@
 -#        define PNG_ALLOCATED __declspec(__restrict)
 +#        define PNG_ALLOCATED __declspec(restrict)
+@@
+-#        define PNG_RESTRICT __restrict
++#        define PNG_RESTRICT restrict
 --- a/png.h
 +++ b/png.h
 @@


### PR DESCRIPTION
## Summary
- ensure libpng's MSVC-specific attributes expand to plain `restrict`
- update the custom libpng patch so Meson applies the safer declarations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fd3703755c8328b7afa8dfb024e16a