### PR TITLE
Fix include path for g_spawn

### DIFF
--- a/src/game/g_spawn.cpp
+++ b/src/game/g_spawn.cpp
@@ -16,7 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#include "g_local.hpppp"
+#include "g_local.hpp"
 
 typedef struct {
     char    *name;


### PR DESCRIPTION
## Summary
- correct g_spawn.cpp to include the proper g_local.hpp header

## Testing
- meson setup build (fails: wrap-redirect /workspace/WORR/subprojects/ffmpeg/subprojects/nasm.wrap filename does not exist)


------
https://chatgpt.com/codex/tasks/task_e_68fd4b7041148328b39b96afefcf8276