### PR TITLE
Fix TagMalloc pointer casts for MSVC compatibility

### DIFF
--- a/src/game/g_local.hpp
+++ b/src/game/g_local.hpp
@@ -460,6 +460,12 @@ typedef struct {
 extern  game_locals_t   game;
 extern  level_locals_t  level;
 extern  game3_import_t  gi;
+
+template <typename T>
+inline T *G_TagMalloc(size_t size, int tag)
+{
+    return static_cast<T *>(gi.TagMalloc(size, tag));
+}
 extern  game3_export_t  globals;
 extern  spawn_temp_t    st;
 

--- a/src/game/g_main.cpp
+++ b/src/game/g_main.cpp
@@ -178,13 +178,13 @@ static void InitGame(void)
 
     // initialize all entities for this game
     game.maxentities = Q_clip(maxentities->value, (int)maxclients->value + 1, game.csr.max_edicts);
-    g_edicts = gi.TagMalloc(game.maxentities * sizeof(g_edicts[0]), TAG_GAME);
+    g_edicts = static_cast<edict_t *>(gi.TagMalloc(game.maxentities * sizeof(g_edicts[0]), TAG_GAME));
     globals.edicts = g_edicts;
     globals.max_edicts = game.maxentities;
 
     // initialize all clients for this game
     game.maxclients = maxclients->value;
-    game.clients = gi.TagMalloc(game.maxclients * sizeof(game.clients[0]), TAG_GAME);
+    game.clients = static_cast<gclient_t *>(gi.TagMalloc(game.maxclients * sizeof(game.clients[0]), TAG_GAME));
     globals.num_edicts = game.maxclients + 1;
 }
 

--- a/src/game/g_misc.cpp
+++ b/src/game/g_misc.cpp
@@ -1601,7 +1601,7 @@ void SP_func_clock(edict_t *self)
 
     func_clock_reset(self);
 
-    self->message = gi.TagMalloc(CLOCK_MESSAGE_SIZE, TAG_LEVEL);
+    self->message = G_TagMalloc<char>(CLOCK_MESSAGE_SIZE, TAG_LEVEL);
 
     self->think = func_clock_think;
 

--- a/src/game/g_save.cpp
+++ b/src/game/g_save.cpp
@@ -734,7 +734,7 @@ static char *read_string(gzFile f)
         gi.error("%s: bad length", __func__);
     }
 
-    s = gi.TagMalloc(len + 1, TAG_LEVEL);
+    s = G_TagMalloc<char>(len + 1, TAG_LEVEL);
     read_data(s, len, f);
     s[len] = 0;
 
@@ -971,11 +971,11 @@ void ReadGame(const char *filename)
         gi.error("Savegame has bad maxentities");
     }
 
-    g_edicts = gi.TagMalloc(game.maxentities * sizeof(g_edicts[0]), TAG_GAME);
+    g_edicts = static_cast<edict_t *>(gi.TagMalloc(game.maxentities * sizeof(g_edicts[0]), TAG_GAME));
     globals.edicts = g_edicts;
     globals.max_edicts = game.maxentities;
 
-    game.clients = gi.TagMalloc(game.maxclients * sizeof(game.clients[0]), TAG_GAME);
+    game.clients = static_cast<gclient_t *>(gi.TagMalloc(game.maxclients * sizeof(game.clients[0]), TAG_GAME));
     for (i = 0; i < game.maxclients; i++) {
         read_fields(f, clientfields, &game.clients[i]);
     }
@@ -1119,7 +1119,7 @@ void ReadLevel(const char *filename)
 
         if (ent->think == func_clock_think || ent->use == func_clock_use) {
             char *msg = ent->message;
-            ent->message = gi.TagMalloc(CLOCK_MESSAGE_SIZE, TAG_LEVEL);
+            ent->message = G_TagMalloc<char>(CLOCK_MESSAGE_SIZE, TAG_LEVEL);
             if (msg) {
                 Q_strlcpy(ent->message, msg, CLOCK_MESSAGE_SIZE);
                 gi.TagFree(msg);

--- a/src/game/g_spawn.cpp
+++ b/src/game/g_spawn.cpp
@@ -386,7 +386,7 @@ static char *ED_NewString(const char *string)
 
     l = strlen(string) + 1;
 
-    newb = gi.TagMalloc(l, TAG_LEVEL);
+    newb = G_TagMalloc<char>(l, TAG_LEVEL);
 
     new_p = newb;
 
@@ -572,7 +572,7 @@ void G_AddPrecache(void (*func)(void))
         if (prec->func == func)
             return;
 
-    prec = gi.TagMalloc(sizeof(*prec), TAG_GAME);
+    prec = G_TagMalloc<precache_t>(sizeof(*prec), TAG_GAME);
     prec->func = func;
     prec->next = game.precaches;
     game.precaches = prec;

--- a/src/game/g_utils.cpp
+++ b/src/game/g_utils.cpp
@@ -301,7 +301,7 @@ char *G_CopyString(char *in)
 {
     char    *out;
 
-    out = gi.TagMalloc(strlen(in) + 1, TAG_LEVEL);
+    out = G_TagMalloc<char>(strlen(in) + 1, TAG_LEVEL);
     strcpy(out, in);
     return out;
 }


### PR DESCRIPTION
## Summary
- add a typed TagMalloc helper to centralize conversions from void pointers
- cast TagMalloc results for edicts, clients, and string buffers to the appropriate types to satisfy C++ compilers

## Testing
- ninja -C build *(fails: missing build.ninja in existing directory)*
- meson setup builddir *(fails: wrap-redirect /workspace/WORR/subprojects/ffmpeg/subprojects/nasm.wrap filename does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68fd4b78ff688328b31a94e627b84e69