### PR TITLE
Make spawn tables and utilities const-correct

### DIFF
--- a/src/game/g_local.hpp
+++ b/src/game/g_local.hpp
@@ -629,9 +629,9 @@ void Touch_Item(edict_t *ent, edict_t *other, cplane_t *plane, csurface_t *surf)
 //
 bool    KillBox(edict_t *ent);
 void    G_ProjectSource(const vec3_t point, const vec3_t distance, const vec3_t forward, const vec3_t right, vec3_t result);
-edict_t *G_Find(edict_t *from, int fieldofs, char *match);
+edict_t *G_Find(edict_t *from, int fieldofs, const char *match);
 edict_t *findradius(edict_t *from, vec3_t org, float rad);
-edict_t *G_PickTarget(char *targetname);
+edict_t *G_PickTarget(const char *targetname);
 void    G_UseTargets(edict_t *ent, edict_t *activator);
 void    G_SetMovedir(vec3_t angles, vec3_t movedir);
 
@@ -641,7 +641,7 @@ void    G_FreeEdict(edict_t *e);
 
 void    G_TouchTriggers(edict_t *ent);
 
-char    *G_CopyString(char *in);
+char    *G_CopyString(const char *in);
 
 float vectoyaw(vec3_t vec);
 void vectoangles(vec3_t vec, vec3_t angles);
@@ -695,9 +695,9 @@ void M_CheckGround(edict_t *ent);
 //
 // g_misc.c
 //
-void ThrowHead(edict_t *self, char *gibname, int damage, int type);
+void ThrowHead(edict_t *self, const char *gibname, int damage, int type);
 void ThrowClientHead(edict_t *self, int damage);
-void ThrowGib(edict_t *self, char *gibname, int damage, int type);
+void ThrowGib(edict_t *self, const char *gibname, int damage, int type);
 void BecomeExplosion1(edict_t *self);
 
 #define CLOCK_MESSAGE_SIZE  16
@@ -726,7 +726,7 @@ bool FacingIdeal(edict_t *self);
 //
 // g_weapon.c
 //
-void ThrowDebris(edict_t *self, char *modelname, float speed, vec3_t origin);
+void ThrowDebris(edict_t *self, const char *modelname, float speed, vec3_t origin);
 bool fire_hit(edict_t *self, vec3_t aim, int damage, int kick);
 void fire_bullet(edict_t *self, vec3_t start, vec3_t aimdir, int damage, int kick, int hspread, int vspread, int mod);
 void fire_shotgun(edict_t *self, vec3_t start, vec3_t aimdir, int damage, int kick, int hspread, int vspread, int count, int mod);

--- a/src/game/g_misc.cpp
+++ b/src/game/g_misc.cpp
@@ -115,7 +115,7 @@ void gib_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage, v
     G_FreeEdict(self);
 }
 
-void ThrowGib(edict_t *self, char *gibname, int damage, int type)
+void ThrowGib(edict_t *self, const char *gibname, int damage, int type)
 {
     edict_t *gib;
     vec3_t  vd;
@@ -158,7 +158,7 @@ void ThrowGib(edict_t *self, char *gibname, int damage, int type)
     gi.linkentity(gib);
 }
 
-void ThrowHead(edict_t *self, char *gibname, int damage, int type)
+void ThrowHead(edict_t *self, const char *gibname, int damage, int type)
 {
     vec3_t  vd;
     float   vscale;
@@ -203,7 +203,7 @@ void ThrowHead(edict_t *self, char *gibname, int damage, int type)
 void ThrowClientHead(edict_t *self, int damage)
 {
     vec3_t  vd;
-    char    *gibname;
+    const char  *gibname;
 
     if (Q_rand() & 1) {
         gibname = "models/objects/gibs/head2/tris.md2";
@@ -250,7 +250,7 @@ void debris_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage
     G_FreeEdict(self);
 }
 
-void ThrowDebris(edict_t *self, char *modelname, float speed, vec3_t origin)
+void ThrowDebris(edict_t *self, const char *modelname, float speed, vec3_t origin)
 {
     edict_t *chunk;
     vec3_t  v;

--- a/src/game/g_save.cpp
+++ b/src/game/g_save.cpp
@@ -35,7 +35,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 typedef struct {
     fieldtype_t type;
 #if USE_DEBUG
-    char *name;
+    const char  *name;
 #endif
     unsigned ofs;
     unsigned size;

--- a/src/game/g_spawn.cpp
+++ b/src/game/g_spawn.cpp
@@ -19,12 +19,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "g_local.hpppp"
 
 typedef struct {
-    char    *name;
+    const char  *name;
     void (*spawn)(edict_t *ent);
 } spawn_func_t;
 
 typedef struct {
-    char    *name;
+    const char  *name;
     unsigned ofs;
     fieldtype_t type;
 } spawn_field_t;

--- a/src/game/g_utils.cpp
+++ b/src/game/g_utils.cpp
@@ -38,7 +38,7 @@ NULL will be returned if the end of the list is reached.
 
 =============
 */
-edict_t *G_Find(edict_t *from, int fieldofs, char *match)
+edict_t *G_Find(edict_t *from, int fieldofs, const char *match)
 {
     char    *s;
 
@@ -107,7 +107,7 @@ NULL will be returned if the end of the list is reached.
 */
 #define MAXCHOICES  8
 
-edict_t *G_PickTarget(char *targetname)
+edict_t *G_PickTarget(const char *targetname)
 {
     edict_t *ent = NULL;
     int     num_choices = 0;
@@ -297,7 +297,7 @@ void vectoangles(vec3_t value1, vec3_t angles)
     angles[ROLL] = 0;
 }
 
-char *G_CopyString(char *in)
+char *G_CopyString(const char *in)
 {
     char    *out;
 


### PR DESCRIPTION
## Summary
- declare spawn and save table names as const char* so string literals work under strict compilers
- update misc and utility helpers that only read strings to take const char* inputs
- propagate the const changes through shared headers and call sites

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fd4b7949948328bc360afdf290e69f