### PR TITLE
Ensure MSVC restrict compatibility

### DIFF
--- a/subprojects/packagefiles/libpng/msvc-restrict.patch
+++ b/subprojects/packagefiles/libpng/msvc-restrict.patch
@@ -2,9 +2,15 @@
 +++ b/pngconf.h
 @@
 -#        define PNG_ALLOCATED __declspec(PNG_RESTRICT)
++#        ifndef restrict
++#          define restrict __restrict
++#        endif
 +#        define PNG_ALLOCATED __declspec(restrict)
 @@
 -#        define PNG_ALLOCATED __declspec(__restrict)
++#        ifndef restrict
++#          define restrict __restrict
++#        endif
 +#        define PNG_ALLOCATED __declspec(restrict)
 @@
 -#        define PNG_RESTRICT __restrict


### PR DESCRIPTION
## Summary
- define a fallback macro that maps `restrict` to `__restrict` inside the MSVC libpng patch before substituting annotations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fd4ba9e6f48328a912ded9211baba6