### PR TITLE
Use bool for ClientConnect handling

### DIFF
--- a/src/game/g_local.hpp
+++ b/src/game/g_local.hpp
@@ -760,7 +760,7 @@ void respawn(edict_t *self);
 void InitBodyQue(void);
 void ClientBeginServerFrame(edict_t *ent);
 void ClientBegin(edict_t *ent);
-qboolean ClientConnect(edict_t *ent, char *userinfo);
+bool ClientConnect(edict_t *ent, char *userinfo);
 void ClientDisconnect(edict_t *ent);
 void ClientThink(edict_t *ent, usercmd_t *ucmd);
 void ClientUserinfoChanged(edict_t *ent, char *userinfo);

--- a/src/game/g_main.cpp
+++ b/src/game/g_main.cpp
@@ -74,6 +74,7 @@ cvar_t  *sv_maplist;
 cvar_t  *sv_features;
 
 static void G_RunFrame(void);
+static qboolean ClientConnect_qboolean(edict_t *ent, char *userinfo);
 
 //===================================================================
 
@@ -85,6 +86,11 @@ static void ShutdownGame(void)
 
     gi.FreeTags(TAG_LEVEL);
     gi.FreeTags(TAG_GAME);
+}
+
+static qboolean ClientConnect_qboolean(edict_t *ent, char *userinfo)
+{
+    return ClientConnect(ent, userinfo) ? qtrue : qfalse;
 }
 
 /*
@@ -212,7 +218,7 @@ q_exported game3_export_t *GetGameAPI(game3_import_t *import)
     globals.ReadLevel = ReadLevel;
 
     globals.ClientThink = ClientThink;
-    globals.ClientConnect = ClientConnect;
+    globals.ClientConnect = ClientConnect_qboolean;
     globals.ClientUserinfoChanged = ClientUserinfoChanged;
     globals.ClientDisconnect = ClientDisconnect;
     globals.ClientBegin = ClientBegin;

--- a/src/game/p_client.cpp
+++ b/src/game/p_client.cpp
@@ -1377,7 +1377,7 @@ Changing levels will NOT cause this to be called again, but
 loadgames will.
 ============
 */
-qboolean ClientConnect(edict_t *ent, char *userinfo)
+bool ClientConnect(edict_t *ent, char *userinfo)
 {
     char    *value;
 
@@ -1424,7 +1424,7 @@ qboolean ClientConnect(edict_t *ent, char *userinfo)
 
     // if there is already a body waiting for us (a loadgame), just
     // take it, otherwise spawn one from scratch
-    if (ent->inuse == false) {
+    if (!ent->inuse) {
         // clear the respawning variables
         InitClientResp(ent->client);
         if (!game.autosaved || !ent->client->pers.weapon)


### PR DESCRIPTION
## Summary
- switch the game-side ClientConnect signature to return a native bool
- add a qboolean-compatible wrapper so the legacy game3 export remains intact
- clean up the inuse check to use a native boolean comparison

## Testing
- ninja -C build *(fails: build directory is not configured in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fd4dd632d083289e5c1d403ef69079