### PR TITLE
Use bool when toggling area portal state

### DIFF
--- a/src/game/g_misc.cpp
+++ b/src/game/g_misc.cpp
@@ -29,7 +29,9 @@ void Use_Areaportal(edict_t *ent, edict_t *other, edict_t *activator)
 {
     ent->count ^= 1;        // toggle state
 //  gi.dprintf ("portalstate: %i = %i\n", ent->style, ent->count);
-    gi.SetAreaPortalState(ent->style, ent->count);
+
+    const bool open = (ent->count != 0);
+    gi.SetAreaPortalState(ent->style, open);
 }
 
 /*QUAKED func_areaportal (0 0 0) ?


### PR DESCRIPTION
## Summary
- update Use_Areaportal to forward a bool to gi.SetAreaPortalState instead of relying on integer toggles

## Testing
- ninja -C build *(fails: build directory missing)*
- meson compile -C build *(fails: /workspace/WORR/build is not a meson build directory)*
- meson setup build *(fails: wrap-redirect /workspace/WORR/subprojects/ffmpeg/subprojects/nasm.wrap filename does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68fd4ddbfbf48328b7783632bddb9b39