### PR TITLE
Fix libpng wrap to apply local restrict patch

### DIFF
--- a/subprojects/libpng.wrap
+++ b/subprojects/libpng.wrap
@@ -6,7 +6,7 @@ source_hash = 71158e53cfdf2877bc99bcab33641d78df3f48e6e0daad030afe9cb8c031aa46
 patch_filename = libpng_1.6.50-1_patch.zip
 patch_url = https://wrapdb.mesonbuild.com/v2/libpng_1.6.50-1/get_patch
 patch_hash = d8f364bb5b5aa342ee0cfa17ef65746ebc37ad0aa9fabfe383f185dfdaa7d4ab
-diff_files = libpng/msvc-restrict.patch
+patch_directory = libpng
 source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/libpng_1.6.50-1/libpng-1.6.50.tar.gz
 wrapdb_version = 1.6.50-1
 


### PR DESCRIPTION
## Summary
- restore the local patch_directory reference so Meson applies the MSVC restrict fix alongside the wrapdb bundle

## Testing
- not run (network access required to fetch wrap dependencies)

------
https://chatgpt.com/codex/tasks/task_e_68fd4e15470c8328b22e5dcefd6cc695