### PR TITLE
Adjust MSVC libpng patch to avoid redefining restrict

### DIFF
--- a/subprojects/packagefiles/libpng/msvc-restrict.patch
+++ b/subprojects/packagefiles/libpng/msvc-restrict.patch
@@ -2,19 +2,10 @@
 +++ b/pngconf.h
 @@
 -#        define PNG_ALLOCATED __declspec(PNG_RESTRICT)
-+#        ifndef restrict
-+#          define restrict __restrict
-+#        endif
 +#        define PNG_ALLOCATED __declspec(restrict)
 @@
 -#        define PNG_ALLOCATED __declspec(__restrict)
-+#        ifndef restrict
-+#          define restrict __restrict
-+#        endif
 +#        define PNG_ALLOCATED __declspec(restrict)
-@@
--#        define PNG_RESTRICT __restrict
-+#        define PNG_RESTRICT restrict
 --- a/png.h
 +++ b/png.h
 @@


### PR DESCRIPTION
## Summary
- remove the fallback that redefined `restrict` before the `__declspec` annotations in the libpng MSVC patch
- keep the `PNG_ALLOCATED` attribute using the literal `restrict` while leaving pointer qualifiers on MSVC as `__restrict`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fd4d9a9fbc83289a10ebbf8dbc06a6