### PR TITLE
Adjust libpng MSVC postconf script invocation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -452,7 +452,7 @@ endif
 config.set10('USE_ZLIB', zlib.found())
 config.set10('USE_PNG', png.found())
 
-if host_machine.system() == 'windows' and c_compiler.get_id() == 'msvc' and png.found() and png.type_name() == 'internal'
+if host_machine.system() == 'windows' and c_compiler.get_id() == 'msvc' and png.found()
   python_mod = import('python')
   python3 = python_mod.find_installation()
   meson.add_postconf_script(python3, files('tools/fix_libpng_msvc.py'))

--- a/tools/fix_libpng_msvc.py
+++ b/tools/fix_libpng_msvc.py
@@ -90,7 +90,7 @@ def main() -> int:
             any_changed = True
 
     if not any_changed:
-        raise RuntimeError('Failed to update libpng headers: no replacements applied.')
+        print('No libpng headers required updates; nothing to do.')
 
     return 0
 


### PR DESCRIPTION
## Summary
- ensure the libpng post-configuration fix-up script always runs on Windows when building with MSVC
- make the fix_libpng_msvc helper tolerate already-correct headers without raising an error

## Testing
- Not run (not on Windows)

------
https://chatgpt.com/codex/tasks/task_e_68fd5fcc96d88328b55fd04011ebecd1