### PR TITLE
Fix MSVC restrict attribute usage in libpng patch

### DIFF
--- a/subprojects/packagefiles/libpng/msvc-restrict.patch
+++ b/subprojects/packagefiles/libpng/msvc-restrict.patch
@@ -6,9 +6,6 @@
 @@
 -#        define PNG_ALLOCATED __declspec(__restrict)
 +#        define PNG_ALLOCATED __declspec(restrict)
-@@
--#        define PNG_RESTRICT __restrict
-+#        define PNG_RESTRICT restrict
 --- a/png.h
 +++ b/png.h
 @@


### PR DESCRIPTION
## Summary
- update the local libpng patch so __declspec attributes use the MSVC-supported restrict spelling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fea078d2988328a4428da2083dfbcd