### PR TITLE
Fix restrict keyword handling for MSVC builds

### DIFF
--- a/inc/shared/platform.hpp
+++ b/inc/shared/platform.hpp
@@ -25,6 +25,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#if defined(_MSC_VER) && !defined(restrict)
+#define restrict __restrict
+#endif
+
 #ifdef _WIN32
 #include <io.h>
 #include <direct.h>

--- a/src/refresh/images.cpp
+++ b/src/refresh/images.cpp
@@ -39,7 +39,14 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #if USE_PNG
 #define PNG_SKIP_SETJMP_CHECK
 #if defined(_MSC_VER) && defined(__cplusplus) && !defined(PNG_ALLOCATED)
+#if defined(restrict)
+#pragma push_macro("restrict")
+#undef restrict
 #define PNG_ALLOCATED __declspec(restrict)
+#pragma pop_macro("restrict")
+#else
+#define PNG_ALLOCATED __declspec(restrict)
+#endif
 #endif
 #include <png.h>
 #endif // USE_PNG


### PR DESCRIPTION
## Summary
- map the restrict keyword to __restrict when building with MSVC so quaternion helpers compile
- guard the PNG allocator macro so it still expands to __declspec(restrict) after redefining restrict

## Testing
- meson compile -C builddir *(fails: build directory not present in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_69063a36b2a883289a5308e9462ecb4f