### PR TITLE
Fix MSVC PNG_ALLOCATED macro for libpng headers

### DIFF
--- a/src/refresh/images.cpp
+++ b/src/refresh/images.cpp
@@ -39,14 +39,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #if USE_PNG
 #define PNG_SKIP_SETJMP_CHECK
 #if defined(_MSC_VER) && defined(__cplusplus) && !defined(PNG_ALLOCATED)
-#if defined(restrict)
-#pragma push_macro("restrict")
-#undef restrict
-#define PNG_ALLOCATED __declspec(restrict)
-#pragma pop_macro("restrict")
-#else
-#define PNG_ALLOCATED __declspec(restrict)
-#endif
+// MSVC does not allow applying __declspec(restrict) to const-qualified
+// return types when compiling as C++.  libpng uses PNG_ALLOCATED on several
+// APIs that return const pointers, which triggers compile errors when the
+// macro expands to __declspec(restrict).  An empty definition preserves
+// compatibility with libpng while keeping the code buildable with MSVC.
+#define PNG_ALLOCATED
 #endif
 #include <png.h>
 #endif // USE_PNG


### PR DESCRIPTION
## Summary
- avoid redefining PNG_ALLOCATED to __declspec(restrict) when compiling with MSVC in C++ mode
- prevent libpng headers from emitting compile errors when returning const pointers

## Testing
- meson compile -C build (fails: not a Meson build directory in the container)

------
https://chatgpt.com/codex/tasks/task_e_69063d96dc8c8328865239dd09382619