### PR TITLE
Fix strict string compilation errors in game module

### DIFF
--- a/src/game/g_local.hpp
+++ b/src/game/g_local.hpp
@@ -238,23 +238,23 @@ typedef struct {
 #define WEAP_BFG                11
 
 typedef struct gitem_s {
-    char        *classname; // spawning name
+    const char  *classname; // spawning name
     bool        (*pickup)(struct game3_edict_s *ent, struct game3_edict_s *other);
     void        (*use)(struct game3_edict_s *ent, const struct gitem_s *item);
     void        (*drop)(struct game3_edict_s *ent, const struct gitem_s *item);
     void        (*weaponthink)(struct game3_edict_s *ent);
-    char        *pickup_sound;
-    char        *world_model;
+    const char  *pickup_sound;
+    const char  *world_model;
     int         world_model_flags;
-    char        *view_model;
+    const char  *view_model;
 
     // client side info
-    char        *icon;
-    char        *pickup_name;   // for printing on pickup
+    const char  *icon;
+    const char  *pickup_name;   // for printing on pickup
     int         count_width;    // number of digits to display by icon
 
     int         quantity;       // for ammo how much, for weapons how much is used per shot
-    char        *ammo;          // for weapons
+    const char  *ammo;          // for weapons
     int         flags;          // IT_* flags
 
     int         weapmodel;      // weapon model index (for weapons)
@@ -1014,7 +1014,7 @@ struct game3_edict_s {
     int         movetype;
     int         flags;
 
-    char        *model;
+    const char  *model;
     float       freetime;           // sv.time when the object was freed
 
     //
@@ -1027,13 +1027,13 @@ struct game3_edict_s {
     int         timestamp;
 
     float       angle;          // set in qe3, -1 = up, -2 = down
-    char        *target;
-    char        *targetname;
-    char        *killtarget;
-    char        *team;
-    char        *pathtarget;
-    char        *deathtarget;
-    char        *combattarget;
+    const char  *target;
+    const char  *targetname;
+    const char  *killtarget;
+    const char  *team;
+    const char  *pathtarget;
+    const char  *deathtarget;
+    const char  *combattarget;
     edict_t     *target_ent;
 
     float       speed, accel, decel;
@@ -1075,7 +1075,7 @@ struct game3_edict_s {
 
     int         powerarmor_framenum;
 
-    char        *map;           // target_changelevel
+    const char  *map;           // target_changelevel
 
     int         viewheight;     // height above origin where eyesight is determined
     int         takedamage;

--- a/src/game/g_save.cpp
+++ b/src/game/g_save.cpp
@@ -847,13 +847,13 @@ static void read_field(gzFile f, const save_field_t *field, void *base)
         break;
 
     case F_EDICT:
-        *(edict_t **)p = read_index(f, sizeof(edict_t), g_edicts, game.maxentities - 1);
+        *(edict_t **)p = static_cast<edict_t *>(read_index(f, sizeof(edict_t), g_edicts, game.maxentities - 1));
         break;
     case F_CLIENT:
-        *(gclient_t **)p = read_index(f, sizeof(gclient_t), game.clients, game.maxclients - 1);
+        *(gclient_t **)p = static_cast<gclient_t *>(read_index(f, sizeof(gclient_t), game.clients, game.maxclients - 1));
         break;
     case F_ITEM:
-        *(gitem_t **)p = read_index(f, sizeof(gitem_t), itemlist, game.num_items - 1);
+        *(gitem_t **)p = static_cast<gitem_t *>(read_index(f, sizeof(gitem_t), itemlist, game.num_items - 1));
         break;
 
     case F_POINTER:
@@ -1119,10 +1119,11 @@ void ReadLevel(const char *filename)
 
         if (ent->think == func_clock_think || ent->use == func_clock_use) {
             const char *msg = ent->message;
-            ent->message = G_TagMalloc<char>(CLOCK_MESSAGE_SIZE, TAG_LEVEL);
+            char *message = G_TagMalloc<char>(CLOCK_MESSAGE_SIZE, TAG_LEVEL);
+            ent->message = message;
             if (msg) {
-                Q_strlcpy(ent->message, msg, CLOCK_MESSAGE_SIZE);
-                gi.TagFree(msg);
+                Q_strlcpy(message, msg, CLOCK_MESSAGE_SIZE);
+                gi.TagFree(const_cast<char *>(msg));
             }
         }
     }


### PR DESCRIPTION
## Summary
- make gitem and edict string fields const-correct for use with strict string literals
- update clock entities to write through mutable buffers safely
- add explicit casts when restoring pointers during savegame loading

## Testing
- meson compile -C builddir *(fails: /workspace/WORR/builddir is not a Meson build directory in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_69063ea4ab588328864f53d8d922c1b6