### PR TITLE
Fix const-correctness issues in game strings

### DIFF
--- a/src/game/g_func.cpp
+++ b/src/game/g_func.cpp
@@ -1397,7 +1397,7 @@ void train_blocked(edict_t *self, edict_t *other)
 void train_wait(edict_t *self)
 {
     if (self->target_ent->pathtarget) {
-        char    *savetarget;
+        const char  *savetarget;
         edict_t *ent;
 
         ent = self->target_ent;

--- a/src/game/g_local.hpp
+++ b/src/game/g_local.hpp
@@ -362,19 +362,19 @@ typedef struct {
 // in edict_t during gameplay
 typedef struct {
     // world vars
-    char        *sky;
+    const char  *sky;
     float       skyrotate;
     vec3_t      skyaxis;
-    char        *nextmap;
-    char        *musictrack;
+    const char  *nextmap;
+    const char  *musictrack;
 
     int         lip;
     int         distance;
     int         height;
-    char        *noise;
+    const char  *noise;
     float       pausetime;
-    char        *item;
-    char        *gravity;
+    const char  *item;
+    const char  *gravity;
 
     float       minyaw;
     float       maxyaw;

--- a/src/game/g_misc.cpp
+++ b/src/game/g_misc.cpp
@@ -317,7 +317,7 @@ void path_corner_touch(edict_t *self, edict_t *other, cplane_t *plane, csurface_
         return;
 
     if (self->pathtarget) {
-        char *savetarget;
+        const char *savetarget;
 
         savetarget = self->target;
         self->target = self->pathtarget;
@@ -406,7 +406,7 @@ void point_combat_touch(edict_t *self, edict_t *other, cplane_t *plane, csurface
     }
 
     if (self->pathtarget) {
-        char *savetarget;
+        const char *savetarget;
 
         savetarget = self->target;
         self->target = self->pathtarget;

--- a/src/game/g_spawn.cpp
+++ b/src/game/g_spawn.cpp
@@ -423,7 +423,7 @@ static bool ED_ParseField(const spawn_field_t *fields, const char *key, const ch
             // found it
             switch (f->type) {
             case F_LSTRING:
-                *(char **)(b + f->ofs) = ED_NewString(value);
+                *(const char **)(b + f->ofs) = ED_NewString(value);
                 break;
             case F_VECTOR:
                 if (sscanf(value, "%f %f %f", &vec[0], &vec[1], &vec[2]) != 3) {

--- a/src/game/m_actor.cpp
+++ b/src/game/m_actor.cpp
@@ -506,7 +506,7 @@ void target_actor_touch(edict_t *self, edict_t *other, cplane_t *plane, csurface
     }
 
     if (!(self->spawnflags & 6) && (self->pathtarget)) {
-        char *savetarget;
+        const char *savetarget;
 
         savetarget = self->target;
         self->target = self->pathtarget;


### PR DESCRIPTION
## Summary
- mark temporary spawn string fields as immutable pointers to fix MSVC strict string literal conversion errors
- update string pointer saves in gameplay logic to use const-qualified storage when relaying targets
- adjust spawn field parsing to write const-qualified string pointers

## Testing
- ⚠️ `meson setup builddir` *(fails: wrap-redirect /workspace/WORR/subprojects/ffmpeg/subprojects/nasm.wrap filename does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6906512faac883289b997d1954e94c68