### PR TITLE
Use const pointers for static string references

### DIFF
--- a/src/game/p_client.cpp
+++ b/src/game/p_client.cpp
@@ -193,10 +193,10 @@ static bool IsNeutral(edict_t *ent)
 
 static void ClientObituary(edict_t *self, edict_t *inflictor, edict_t *attacker)
 {
-    int         mod;
-    char        *message;
-    char        *message2;
-    int         ff;
+    int             mod;
+    const char      *message;
+    const char      *message2;
+    int             ff;
 
     if (coop->value && attacker->client)
         meansOfDeath |= MOD_FRIENDLY_FIRE;
@@ -205,7 +205,7 @@ static void ClientObituary(edict_t *self, edict_t *inflictor, edict_t *attacker)
         ff = meansOfDeath & MOD_FRIENDLY_FIRE;
         mod = meansOfDeath & ~MOD_FRIENDLY_FIRE;
         message = NULL;
-        message2 = const_cast<char *>(""); // safe placeholder for optional second message
+        message2 = "";
 
         switch (mod) {
         case MOD_SUICIDE:
@@ -768,9 +768,9 @@ static edict_t *SelectDeathmatchSpawnPoint(void)
 
 static edict_t *SelectCoopSpawnPoint(edict_t *ent)
 {
-    int     index;
-    edict_t *spot = NULL;
-    char    *target;
+    int         index;
+    edict_t     *spot = NULL;
+    const char  *target;
 
     index = ent->client - game.clients;
 
@@ -788,7 +788,7 @@ static edict_t *SelectCoopSpawnPoint(edict_t *ent)
 
         target = spot->targetname;
         if (!target)
-            target = const_cast<char *>(""); // safe placeholder when target name is absent
+            target = "";
         if (Q_stricmp(game.spawnpoint, target) == 0) {
             // this is a coop spawn point for one of the clients here
             index--;

--- a/src/game/p_hud.cpp
+++ b/src/game/p_hud.cpp
@@ -287,8 +287,8 @@ Draw help computer.
 */
 static void HelpComputer(edict_t *ent)
 {
-    char    string[1024];
-    char    *sk;
+    char        string[1024];
+    const char  *sk;
 
     if (skill->value == 0)
         sk = "easy";

--- a/src/game/p_view.cpp
+++ b/src/game/p_view.cpp
@@ -725,7 +725,7 @@ G_SetClientSound
 */
 static void G_SetClientSound(edict_t *ent)
 {
-    char    *weap;
+    const char  *weap;
 
     if (ent->client->pers.game_helpchanged != game.helpchanged) {
         ent->client->pers.game_helpchanged = game.helpchanged;
@@ -741,7 +741,7 @@ static void G_SetClientSound(edict_t *ent)
     if (ent->client->pers.weapon)
         weap = ent->client->pers.weapon->classname;
     else
-        weap = const_cast<char *>(""); // point at immutable empty string literal safely
+        weap = "";
 
     if (ent->waterlevel && (ent->watertype & (CONTENTS_LAVA | CONTENTS_SLIME)))
         ent->s.sound = gi.soundindex("player/fry.wav");


### PR DESCRIPTION
## Summary
- use const-qualified pointers for weapon and skill string selections to avoid casting away constness
- apply const char* to obituary messaging helpers and coop spawn point target name handling

## Testing
- `meson setup build` *(fails: wrap-redirect /workspace/WORR/subprojects/ffmpeg/subprojects/nasm.wrap filename does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6906548d439c8328880a44361267fbaa