### PR TITLE
Add C linkage guards to q2proto headers

### DIFF
--- a/q2proto/inc/q2proto/q2proto_packing.h
+++ b/q2proto/inc/q2proto/q2proto_packing.h
@@ -26,6 +26,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "q2proto_game_api.h"
 #include "q2proto_limits.h" // for Q2PROTO_STATS
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /// Packed representation of entity state. Use with only server context used for packing!
 typedef struct q2proto_packed_entity_state_s {
     uint16_t modelindex;
@@ -147,5 +151,9 @@ typedef enum _q2proto_packing_flavor_e {
 Q2PROTO_PUBLIC_API _q2proto_packing_flavor_t _q2proto_get_packing_flavor(q2proto_servercontext_t *context,
                                                                          q2proto_game_api_t *game_api);
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // Q2PROTO_STRUCT_PACKING_H_

--- a/q2proto/inc/q2proto/q2proto_sound.h
+++ b/q2proto/inc/q2proto/q2proto_sound.h
@@ -27,6 +27,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**\name Sound messages
  * @{ */
 /// Sound parameters, as typically stored internally by engines
@@ -62,5 +66,9 @@ Q2PROTO_PUBLIC_API float q2proto_sound_decode_loop_attenuation(uint8_t protocol_
 /// Encode a loop attenuation for sending over network
 Q2PROTO_PUBLIC_API uint8_t q2proto_sound_encode_loop_attenuation(float loop_attenuation);
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // Q2PROTO_SOUND_H_


### PR DESCRIPTION
## Summary
- add extern "C" guards around the declarations in q2proto_sound.h
- add extern "C" guards around the declarations in q2proto_packing.h so internal helpers retain C linkage

## Testing
- not run (MSVC unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_6906548f86c08328ad79a600dc204649