### PR TITLE
Wrap filesystem globals in extern C

### DIFF
--- a/src/common/files.cpp
+++ b/src/common/files.cpp
@@ -194,7 +194,10 @@ typedef struct {
 } symlink_t;
 
 // these point to user home directory
+extern "C" {
 char                fs_gamedir[MAX_OSPATH];
+cvar_t              *fs_game;
+}
 //static char       fs_basedir[MAX_OSPATH];
 
 static searchpath_t *fs_searchpaths;
@@ -229,8 +232,6 @@ static cvar_t       *fs_autoexec;
 #if USE_DEBUG
 static cvar_t       *fs_debug;
 #endif
-
-cvar_t              *fs_game;
 
 #if USE_ZLIB
 // local stream used for all file loads


### PR DESCRIPTION
## Summary
- wrap the fs_gamedir and fs_game definitions in an extern "C" block so they match the header declaration

## Testing
- meson setup builddir *(fails: wrap-redirect /workspace/WORR/subprojects/ffmpeg/subprojects/nasm.wrap filename does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_69065491cb088328ac0df6ce9829de62