### PR TITLE
Add extern linkage to embedded resource definitions

### DIFF
--- a/embed.py
+++ b/embed.py
@@ -29,7 +29,7 @@ var_name = sys.argv[3]
 
 converted = [
     '#include <stddef.h>',
-    f'const char {var_name}[] ='
+    f'extern const char {var_name}[] ='
 ]
 
 chunk_size = 16384
@@ -38,7 +38,7 @@ for i in range(0, len(in_contents), chunk_size):
     converted.append(f'"{chunk}"')
 
 converted.append(';')
-converted.append(f'const size_t {var_name}_size = {size};')
+converted.append(f'extern const size_t {var_name}_size = {size};')
 in_contents = '\n'.join(converted)
 
 # write


### PR DESCRIPTION
## Summary
- ensure the embed.py generator prefixes resource symbols with `extern` so they retain external linkage

## Testing
- meson setup build *(fails: wrap-redirect /workspace/WORR/subprojects/ffmpeg/subprojects/nasm.wrap filename does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_690654933c7c8328abff30cb2ca488ef