### PR TITLE
Give driver backends external linkage

### DIFF
--- a/src/refresh/legacy.cpp
+++ b/src/refresh/legacy.cpp
@@ -239,7 +239,7 @@ static bool legacy_use_per_pixel_lighting(void)
     return false;
 }
 
-const glbackend_t backend_legacy = {
+extern const glbackend_t backend_legacy = {
     .name = "legacy",
 
     .init = legacy_init,

--- a/src/refresh/shader.cpp
+++ b/src/refresh/shader.cpp
@@ -1285,7 +1285,7 @@ static bool shader_use_per_pixel_lighting(void)
     return !!gl_per_pixel_lighting->integer;
 }
 
-const glbackend_t backend_shader = {
+extern const glbackend_t backend_shader = {
     .name = "GLSL",
 
     .init = shader_init,

--- a/src/windows/dsound.cpp
+++ b/src/windows/dsound.cpp
@@ -396,7 +396,7 @@ static void DS_Activate(bool active)
     }
 }
 
-const snddma_driver_t snddma_dsound = {
+extern const snddma_driver_t snddma_dsound = {
     "dsound",
     DS_Init,
     DS_Shutdown,

--- a/src/windows/egl.cpp
+++ b/src/windows/egl.cpp
@@ -182,7 +182,7 @@ static bool egl_probe(void)
     return os_access("libEGL.dll", X_OK) == 0;
 }
 
-const vid_driver_t vid_win32egl = {
+extern const vid_driver_t vid_win32egl = {
     "win32egl",
     egl_probe,
     egl_init,

--- a/src/windows/wave.cpp
+++ b/src/windows/wave.cpp
@@ -322,4 +322,4 @@ static void WAVE_Activate(bool active)
 {
 }
 
-const snddma_driver_t snddma_wave{"wave", WAVE_Init, WAVE_Shutdown, WAVE_BeginPainting, WAVE_Submit, WAVE_Activate};
+extern const snddma_driver_t snddma_wave{"wave", WAVE_Init, WAVE_Shutdown, WAVE_BeginPainting, WAVE_Submit, WAVE_Activate};

--- a/src/windows/wgl.cpp
+++ b/src/windows/wgl.cpp
@@ -413,7 +413,7 @@ static bool wgl_probe(void)
     return true;
 }
 
-const vid_driver_t vid_win32wgl = {
+extern const vid_driver_t vid_win32wgl = {
     "win32wgl",
     wgl_probe,
     wgl_init,


### PR DESCRIPTION
## Summary
- add extern specifiers to the Windows video driver definitions so they export symbols expected by other translation units
- update Windows sound drivers and OpenGL backends to provide external linkage for their constant definitions

## Testing
- ninja -C build *(fails: build.ninja: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_690654952efc8328b3b06f2b8ba8529e