### PR TITLE
Fix Windows build issues for scoreboard and filesystem

### DIFF
--- a/src/common/gamedll.cpp
+++ b/src/common/gamedll.cpp
@@ -23,7 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include <errno.h>
 
-extern cvar_t   *fs_game;
+extern "C" cvar_t   *fs_game;
 
 #if defined(_WIN64)
 // Official remaster game DLL is named "game_x64.dll"

--- a/src/game/g_local.hpp
+++ b/src/game/g_local.hpp
@@ -326,7 +326,7 @@ typedef struct {
 
     // intermission state
     int         intermission_framenum;  // time the intermission was started
-    char        *changemap;
+    const char  *changemap;
     int         exitintermission;
     vec3_t      intermission_origin;
     vec3_t      intermission_angle;

--- a/src/game/p_hud.cpp
+++ b/src/game/p_hud.cpp
@@ -170,7 +170,7 @@ void DeathmatchScoreboardMessage(edict_t *ent, edict_t *killer)
     int     x, y;
     gclient_t   *cl;
     edict_t     *cl_ent;
-    char    *tag;
+    const char  *tag;
 
     // sort the clients by score
     total = 0;


### PR DESCRIPTION
## Summary
- mark level changemap pointer and scoreboard HUD tag pointers as const to satisfy MSVC's strict string handling
- declare the fs_game variable with C linkage in gamedll.cpp so the dedicated server links successfully on Windows

## Testing
- ninja -C build *(fails: build.ninja missing in repository checkout)*
- meson compile -C build *(fails: current directory is not a meson build directory)*

------
https://chatgpt.com/codex/tasks/task_e_6906562fb49c83289deae9f5eb1cb18c