### PR TITLE
Ensure mmove definitions have external linkage in C++

### DIFF
--- a/src/game/g_local.hpp
+++ b/src/game/g_local.hpp
@@ -424,6 +424,12 @@ typedef struct {
     void        (*endfunc)(edict_t *self);
 } mmove_t;
 
+#ifdef __cplusplus
+#define DEFINE_MMOVE(name, ...) extern const mmove_t name = { __VA_ARGS__ }
+#else
+#define DEFINE_MMOVE(name, ...) const mmove_t name = { __VA_ARGS__ }
+#endif
+
 typedef struct {
     const mmove_t   *currentmove;
     int         aiflags;

--- a/src/game/m_actor.cpp
+++ b/src/game/m_actor.cpp
@@ -77,7 +77,7 @@ static const mframe_t actor_frames_stand[] = {
     { ai_stand, 0, NULL },
     { ai_stand, 0, NULL }
 };
-const mmove_t actor_move_stand = {FRAME_stand101, FRAME_stand140, actor_frames_stand, NULL};
+DEFINE_MMOVE(actor_move_stand, FRAME_stand101, FRAME_stand140, actor_frames_stand, NULL);
 
 void actor_stand(edict_t *self)
 {
@@ -101,7 +101,7 @@ static const mframe_t actor_frames_walk[] = {
     { ai_walk, 0,  NULL },
     { ai_walk, 0,  NULL }
 };
-const mmove_t actor_move_walk = {FRAME_walk01, FRAME_walk08, actor_frames_walk, NULL};
+DEFINE_MMOVE(actor_move_walk, FRAME_walk01, FRAME_walk08, actor_frames_walk, NULL);
 
 void actor_walk(edict_t *self)
 {
@@ -122,7 +122,7 @@ static const mframe_t actor_frames_run[] = {
     { ai_run, -2, NULL },
     { ai_run, -1, NULL }
 };
-const mmove_t actor_move_run = {FRAME_run02, FRAME_run07, actor_frames_run, NULL};
+DEFINE_MMOVE(actor_move_run, FRAME_run02, FRAME_run07, actor_frames_run, NULL);
 
 void actor_run(edict_t *self)
 {
@@ -147,21 +147,21 @@ static const mframe_t actor_frames_pain1[] = {
     { ai_move, 4,  NULL },
     { ai_move, 1,  NULL }
 };
-const mmove_t actor_move_pain1 = {FRAME_pain101, FRAME_pain103, actor_frames_pain1, actor_run};
+DEFINE_MMOVE(actor_move_pain1, FRAME_pain101, FRAME_pain103, actor_frames_pain1, actor_run);
 
 static const mframe_t actor_frames_pain2[] = {
     { ai_move, -4, NULL },
     { ai_move, 4,  NULL },
     { ai_move, 0,  NULL }
 };
-const mmove_t actor_move_pain2 = {FRAME_pain201, FRAME_pain203, actor_frames_pain2, actor_run};
+DEFINE_MMOVE(actor_move_pain2, FRAME_pain201, FRAME_pain203, actor_frames_pain2, actor_run);
 
 static const mframe_t actor_frames_pain3[] = {
     { ai_move, -1, NULL },
     { ai_move, 1,  NULL },
     { ai_move, 0,  NULL }
 };
-const mmove_t actor_move_pain3 = {FRAME_pain301, FRAME_pain303, actor_frames_pain3, actor_run};
+DEFINE_MMOVE(actor_move_pain3, FRAME_pain301, FRAME_pain303, actor_frames_pain3, actor_run);
 
 static const mframe_t actor_frames_flipoff[] = {
     { ai_turn, 0,  NULL },
@@ -179,7 +179,7 @@ static const mframe_t actor_frames_flipoff[] = {
     { ai_turn, 0,  NULL },
     { ai_turn, 0,  NULL }
 };
-const mmove_t actor_move_flipoff = {FRAME_flip01, FRAME_flip14, actor_frames_flipoff, actor_run};
+DEFINE_MMOVE(actor_move_flipoff, FRAME_flip01, FRAME_flip14, actor_frames_flipoff, actor_run);
 
 static const mframe_t actor_frames_taunt[] = {
     { ai_turn, 0,  NULL },
@@ -200,7 +200,7 @@ static const mframe_t actor_frames_taunt[] = {
     { ai_turn, 0,  NULL },
     { ai_turn, 0,  NULL }
 };
-const mmove_t actor_move_taunt = {FRAME_taunt01, FRAME_taunt17, actor_frames_taunt, actor_run};
+DEFINE_MMOVE(actor_move_taunt, FRAME_taunt01, FRAME_taunt17, actor_frames_taunt, actor_run);
 
 static const char *const messages[] = {
     "Watch it",
@@ -288,7 +288,7 @@ static const mframe_t actor_frames_death1[] = {
     { ai_move, -2,  NULL },
     { ai_move, 1,   NULL }
 };
-const mmove_t actor_move_death1 = {FRAME_death101, FRAME_death107, actor_frames_death1, actor_dead};
+DEFINE_MMOVE(actor_move_death1, FRAME_death101, FRAME_death107, actor_frames_death1, actor_dead);
 
 static const mframe_t actor_frames_death2[] = {
     { ai_move, 0,   NULL },
@@ -305,7 +305,7 @@ static const mframe_t actor_frames_death2[] = {
     { ai_move, -13, NULL },
     { ai_move, 0,   NULL }
 };
-const mmove_t actor_move_death2 = {FRAME_death201, FRAME_death213, actor_frames_death2, actor_dead};
+DEFINE_MMOVE(actor_move_death2, FRAME_death201, FRAME_death213, actor_frames_death2, actor_dead);
 
 void actor_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage, vec3_t point)
 {
@@ -354,7 +354,7 @@ static const mframe_t actor_frames_attack[] = {
     { ai_charge, 3,   NULL },
     { ai_charge, 2,   NULL }
 };
-const mmove_t actor_move_attack = {FRAME_attak01, FRAME_attak04, actor_frames_attack, actor_run};
+DEFINE_MMOVE(actor_move_attack, FRAME_attak01, FRAME_attak04, actor_frames_attack, actor_run);
 
 void actor_attack(edict_t *self)
 {

--- a/src/game/m_berserk.cpp
+++ b/src/game/m_berserk.cpp
@@ -52,7 +52,7 @@ static const mframe_t berserk_frames_stand[] = {
     { ai_stand, 0, NULL },
     { ai_stand, 0, NULL }
 };
-const mmove_t berserk_move_stand = {FRAME_stand1, FRAME_stand5, berserk_frames_stand, NULL};
+DEFINE_MMOVE(berserk_move_stand, FRAME_stand1, FRAME_stand5, berserk_frames_stand, NULL);
 
 void berserk_stand(edict_t *self)
 {
@@ -81,7 +81,7 @@ static const mframe_t berserk_frames_stand_fidget[] = {
     { ai_stand, 0, NULL },
     { ai_stand, 0, NULL }
 };
-const mmove_t berserk_move_stand_fidget = {FRAME_standb1, FRAME_standb20, berserk_frames_stand_fidget, berserk_stand};
+DEFINE_MMOVE(berserk_move_stand_fidget, FRAME_standb1, FRAME_standb20, berserk_frames_stand_fidget, berserk_stand);
 
 static void berserk_fidget(edict_t *self)
 {
@@ -108,7 +108,7 @@ static const mframe_t berserk_frames_walk[] = {
     { ai_walk, 4.7, NULL },
     { ai_walk, 4.8, NULL }
 };
-const mmove_t berserk_move_walk = {FRAME_walkc1, FRAME_walkc11, berserk_frames_walk, NULL};
+DEFINE_MMOVE(berserk_move_walk, FRAME_walkc1, FRAME_walkc11, berserk_frames_walk, NULL);
 
 void berserk_walk(edict_t *self)
 {
@@ -147,7 +147,7 @@ static const mframe_t berserk_frames_run1[] = {
     { ai_run, 18, NULL },
     { ai_run, 19, NULL }
 };
-const mmove_t berserk_move_run1 = {FRAME_run1, FRAME_run6, berserk_frames_run1, NULL};
+DEFINE_MMOVE(berserk_move_run1, FRAME_run1, FRAME_run6, berserk_frames_run1, NULL);
 
 void berserk_run(edict_t *self)
 {
@@ -179,7 +179,7 @@ static const mframe_t berserk_frames_attack_spike[] = {
     { ai_charge, 0, NULL },
     { ai_charge, 0, NULL }
 };
-const mmove_t berserk_move_attack_spike = {FRAME_att_c1, FRAME_att_c8, berserk_frames_attack_spike, berserk_run};
+DEFINE_MMOVE(berserk_move_attack_spike, FRAME_att_c1, FRAME_att_c8, berserk_frames_attack_spike, berserk_run);
 
 static void berserk_attack_club(edict_t *self)
 {
@@ -202,7 +202,7 @@ static const mframe_t berserk_frames_attack_club[] = {
     { ai_charge, 0, NULL },
     { ai_charge, 0, NULL }
 };
-const mmove_t berserk_move_attack_club = {FRAME_att_c9, FRAME_att_c20, berserk_frames_attack_club, berserk_run};
+DEFINE_MMOVE(berserk_move_attack_club, FRAME_att_c9, FRAME_att_c20, berserk_frames_attack_club, berserk_run);
 
 static void berserk_strike(edict_t *self)
 {
@@ -226,7 +226,7 @@ static const mframe_t berserk_frames_attack_strike[] = {
     { ai_move, 13.6, NULL }
 };
 
-const mmove_t berserk_move_attack_strike = {FRAME_att_c21, FRAME_att_c34, berserk_frames_attack_strike, berserk_run};
+DEFINE_MMOVE(berserk_move_attack_strike, FRAME_att_c21, FRAME_att_c34, berserk_frames_attack_strike, berserk_run);
 
 void berserk_melee(edict_t *self)
 {
@@ -263,7 +263,7 @@ static const mframe_t berserk_frames_pain1[] = {
     { ai_move, 0, NULL },
     { ai_move, 0, NULL }
 };
-const mmove_t berserk_move_pain1 = {FRAME_painc1, FRAME_painc4, berserk_frames_pain1, berserk_run};
+DEFINE_MMOVE(berserk_move_pain1, FRAME_painc1, FRAME_painc4, berserk_frames_pain1, berserk_run);
 
 static const mframe_t berserk_frames_pain2[] = {
     { ai_move, 0, NULL },
@@ -287,7 +287,7 @@ static const mframe_t berserk_frames_pain2[] = {
     { ai_move, 0, NULL },
     { ai_move, 0, NULL }
 };
-const mmove_t berserk_move_pain2 = {FRAME_painb1, FRAME_painb20, berserk_frames_pain2, berserk_run};
+DEFINE_MMOVE(berserk_move_pain2, FRAME_painb1, FRAME_painb20, berserk_frames_pain2, berserk_run);
 
 void berserk_pain(edict_t *self, edict_t *other, float kick, int damage)
 {
@@ -335,7 +335,7 @@ static const mframe_t berserk_frames_death1[] = {
     { ai_move, 0, NULL }
 
 };
-const mmove_t berserk_move_death1 = {FRAME_death1, FRAME_death13, berserk_frames_death1, berserk_dead};
+DEFINE_MMOVE(berserk_move_death1, FRAME_death1, FRAME_death13, berserk_frames_death1, berserk_dead);
 
 static const mframe_t berserk_frames_death2[] = {
     { ai_move, 0, NULL },
@@ -347,7 +347,7 @@ static const mframe_t berserk_frames_death2[] = {
     { ai_move, 0, NULL },
     { ai_move, 0, NULL }
 };
-const mmove_t berserk_move_death2 = {FRAME_deathc1, FRAME_deathc8, berserk_frames_death2, berserk_dead};
+DEFINE_MMOVE(berserk_move_death2, FRAME_deathc1, FRAME_deathc8, berserk_frames_death2, berserk_dead);
 
 void berserk_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage, vec3_t point)
 {

--- a/src/game/m_boss2.cpp
+++ b/src/game/m_boss2.cpp
@@ -155,7 +155,7 @@ static const mframe_t boss2_frames_stand[] = {
     { ai_stand, 0, NULL },
     { ai_stand, 0, NULL }
 };
-const mmove_t boss2_move_stand = {FRAME_stand30, FRAME_stand50, boss2_frames_stand, NULL};
+DEFINE_MMOVE(boss2_move_stand, FRAME_stand30, FRAME_stand50, boss2_frames_stand, NULL);
 
 static const mframe_t boss2_frames_fidget[] = {
     { ai_stand, 0, NULL },
@@ -189,7 +189,7 @@ static const mframe_t boss2_frames_fidget[] = {
     { ai_stand, 0, NULL },
     { ai_stand, 0, NULL }
 };
-const mmove_t boss2_move_fidget = {FRAME_stand1, FRAME_stand30, boss2_frames_fidget, NULL};
+DEFINE_MMOVE(boss2_move_fidget, FRAME_stand1, FRAME_stand30, boss2_frames_fidget, NULL);
 
 static const mframe_t boss2_frames_walk[] = {
     { ai_walk,    8,  NULL },
@@ -213,7 +213,7 @@ static const mframe_t boss2_frames_walk[] = {
     { ai_walk,    8,  NULL },
     { ai_walk,    8,  NULL }
 };
-const mmove_t boss2_move_walk = {FRAME_walk1, FRAME_walk20, boss2_frames_walk, NULL};
+DEFINE_MMOVE(boss2_move_walk, FRAME_walk1, FRAME_walk20, boss2_frames_walk, NULL);
 
 static const mframe_t boss2_frames_run[] = {
     { ai_run, 8,  NULL },
@@ -237,7 +237,7 @@ static const mframe_t boss2_frames_run[] = {
     { ai_run, 8,  NULL },
     { ai_run, 8,  NULL }
 };
-const mmove_t boss2_move_run = {FRAME_walk1, FRAME_walk20, boss2_frames_run, NULL};
+DEFINE_MMOVE(boss2_move_run, FRAME_walk1, FRAME_walk20, boss2_frames_run, NULL);
 
 static const mframe_t boss2_frames_attack_pre_mg[] = {
     { ai_charge,  1,  NULL },
@@ -250,7 +250,7 @@ static const mframe_t boss2_frames_attack_pre_mg[] = {
     { ai_charge,  1,  NULL },
     { ai_charge,  1,  boss2_attack_mg }
 };
-const mmove_t boss2_move_attack_pre_mg = {FRAME_attack1, FRAME_attack9, boss2_frames_attack_pre_mg, NULL};
+DEFINE_MMOVE(boss2_move_attack_pre_mg, FRAME_attack1, FRAME_attack9, boss2_frames_attack_pre_mg, NULL);
 
 // Loop this
 static const mframe_t boss2_frames_attack_mg[] = {
@@ -261,7 +261,7 @@ static const mframe_t boss2_frames_attack_mg[] = {
     { ai_charge,  1,  Boss2MachineGun },
     { ai_charge,  1,  boss2_reattack_mg }
 };
-const mmove_t boss2_move_attack_mg = {FRAME_attack10, FRAME_attack15, boss2_frames_attack_mg, NULL};
+DEFINE_MMOVE(boss2_move_attack_mg, FRAME_attack10, FRAME_attack15, boss2_frames_attack_mg, NULL);
 
 static const mframe_t boss2_frames_attack_post_mg[] = {
     { ai_charge,  1,  NULL },
@@ -269,7 +269,7 @@ static const mframe_t boss2_frames_attack_post_mg[] = {
     { ai_charge,  1,  NULL },
     { ai_charge,  1,  NULL }
 };
-const mmove_t boss2_move_attack_post_mg = {FRAME_attack16, FRAME_attack19, boss2_frames_attack_post_mg, boss2_run};
+DEFINE_MMOVE(boss2_move_attack_post_mg, FRAME_attack16, FRAME_attack19, boss2_frames_attack_post_mg, boss2_run);
 
 static const mframe_t boss2_frames_attack_rocket[] = {
     { ai_charge,  1,  NULL },
@@ -294,7 +294,7 @@ static const mframe_t boss2_frames_attack_rocket[] = {
     { ai_charge,  1,  NULL },
     { ai_charge,  1,  NULL }
 };
-const mmove_t boss2_move_attack_rocket = {FRAME_attack20, FRAME_attack40, boss2_frames_attack_rocket, boss2_run};
+DEFINE_MMOVE(boss2_move_attack_rocket, FRAME_attack20, FRAME_attack40, boss2_frames_attack_rocket, boss2_run);
 
 static const mframe_t boss2_frames_pain_heavy[] = {
     { ai_move,    0,  NULL },
@@ -316,7 +316,7 @@ static const mframe_t boss2_frames_pain_heavy[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t boss2_move_pain_heavy = {FRAME_pain2, FRAME_pain19, boss2_frames_pain_heavy, boss2_run};
+DEFINE_MMOVE(boss2_move_pain_heavy, FRAME_pain2, FRAME_pain19, boss2_frames_pain_heavy, boss2_run);
 
 static const mframe_t boss2_frames_pain_light[] = {
     { ai_move,    0,  NULL },
@@ -324,7 +324,7 @@ static const mframe_t boss2_frames_pain_light[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t boss2_move_pain_light = {FRAME_pain20, FRAME_pain23, boss2_frames_pain_light, boss2_run};
+DEFINE_MMOVE(boss2_move_pain_light, FRAME_pain20, FRAME_pain23, boss2_frames_pain_light, boss2_run);
 
 static const mframe_t boss2_frames_death[] = {
     { ai_move,    0,  NULL },
@@ -377,7 +377,7 @@ static const mframe_t boss2_frames_death[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  BossExplode }
 };
-const mmove_t boss2_move_death = {FRAME_death2, FRAME_death50, boss2_frames_death, boss2_dead};
+DEFINE_MMOVE(boss2_move_death, FRAME_death2, FRAME_death50, boss2_frames_death, boss2_dead);
 
 void boss2_stand(edict_t *self)
 {

--- a/src/game/m_boss31.cpp
+++ b/src/game/m_boss31.cpp
@@ -125,7 +125,7 @@ static const mframe_t jorg_frames_stand[] = {
     { ai_stand, -12, NULL },        // 50
     { ai_stand, -14, jorg_step_right }  // 51
 };
-const mmove_t jorg_move_stand = {FRAME_stand01, FRAME_stand51, jorg_frames_stand, NULL};
+DEFINE_MMOVE(jorg_move_stand, FRAME_stand01, FRAME_stand51, jorg_frames_stand, NULL);
 
 static void jorg_idle(edict_t *self)
 {
@@ -163,7 +163,7 @@ static const mframe_t jorg_frames_run[] = {
     { ai_run, 9,  NULL },
     { ai_run, 9,  NULL }
 };
-const mmove_t jorg_move_run = {FRAME_walk06, FRAME_walk19, jorg_frames_run, NULL};
+DEFINE_MMOVE(jorg_move_run, FRAME_walk06, FRAME_walk19, jorg_frames_run, NULL);
 
 //
 // walk
@@ -176,7 +176,7 @@ static const mframe_t jorg_frames_start_walk[] = {
     { ai_walk,    9,  NULL },
     { ai_walk,    15, NULL }
 };
-const mmove_t jorg_move_start_walk = {FRAME_walk01, FRAME_walk05, jorg_frames_start_walk, NULL};
+DEFINE_MMOVE(jorg_move_start_walk, FRAME_walk01, FRAME_walk05, jorg_frames_start_walk, NULL);
 
 static const mframe_t jorg_frames_walk[] = {
     { ai_walk, 17,    NULL },
@@ -194,7 +194,7 @@ static const mframe_t jorg_frames_walk[] = {
     { ai_walk, 9, NULL },
     { ai_walk, 9, NULL }
 };
-const mmove_t jorg_move_walk = {FRAME_walk06, FRAME_walk19, jorg_frames_walk, NULL};
+DEFINE_MMOVE(jorg_move_walk, FRAME_walk06, FRAME_walk19, jorg_frames_walk, NULL);
 
 static const mframe_t jorg_frames_end_walk[] = {
     { ai_walk,    11, NULL },
@@ -204,7 +204,7 @@ static const mframe_t jorg_frames_end_walk[] = {
     { ai_walk,    8,  NULL },
     { ai_walk,    -8, NULL }
 };
-const mmove_t jorg_move_end_walk = {FRAME_walk20, FRAME_walk25, jorg_frames_end_walk, NULL};
+DEFINE_MMOVE(jorg_move_end_walk, FRAME_walk20, FRAME_walk25, jorg_frames_end_walk, NULL);
 
 void jorg_walk(edict_t *self)
 {
@@ -246,21 +246,21 @@ static const mframe_t jorg_frames_pain3[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  jorg_step_right }
 };
-const mmove_t jorg_move_pain3 = {FRAME_pain301, FRAME_pain325, jorg_frames_pain3, jorg_run};
+DEFINE_MMOVE(jorg_move_pain3, FRAME_pain301, FRAME_pain325, jorg_frames_pain3, jorg_run);
 
 static const mframe_t jorg_frames_pain2[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t jorg_move_pain2 = {FRAME_pain201, FRAME_pain203, jorg_frames_pain2, jorg_run};
+DEFINE_MMOVE(jorg_move_pain2, FRAME_pain201, FRAME_pain203, jorg_frames_pain2, jorg_run);
 
 static const mframe_t jorg_frames_pain1[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t jorg_move_pain1 = {FRAME_pain101, FRAME_pain103, jorg_frames_pain1, jorg_run};
+DEFINE_MMOVE(jorg_move_pain1, FRAME_pain101, FRAME_pain103, jorg_frames_pain1, jorg_run);
 
 static const mframe_t jorg_frames_death1[] = {
     { ai_move,    0,  NULL },
@@ -314,7 +314,7 @@ static const mframe_t jorg_frames_death1[] = {
     { ai_move,    0,  MakronToss },
     { ai_move,    0,  BossExplode }     // 50
 };
-const mmove_t jorg_move_death = {FRAME_death01, FRAME_death50, jorg_frames_death1, jorg_dead};
+DEFINE_MMOVE(jorg_move_death, FRAME_death01, FRAME_death50, jorg_frames_death1, jorg_dead);
 
 static const mframe_t jorg_frames_attack2[] = {
     { ai_charge,  0,  NULL },
@@ -331,7 +331,7 @@ static const mframe_t jorg_frames_attack2[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t jorg_move_attack2 = {FRAME_attak201, FRAME_attak213, jorg_frames_attack2, jorg_run};
+DEFINE_MMOVE(jorg_move_attack2, FRAME_attak201, FRAME_attak213, jorg_frames_attack2, jorg_run);
 
 static const mframe_t jorg_frames_start_attack1[] = {
     { ai_charge,  0,  NULL },
@@ -343,7 +343,7 @@ static const mframe_t jorg_frames_start_attack1[] = {
     { ai_charge,  0,  NULL },
     { ai_charge,  0,  NULL }
 };
-const mmove_t jorg_move_start_attack1 = {FRAME_attak101, FRAME_attak108, jorg_frames_start_attack1, jorg_attack1};
+DEFINE_MMOVE(jorg_move_start_attack1, FRAME_attak101, FRAME_attak108, jorg_frames_start_attack1, jorg_attack1);
 
 static const mframe_t jorg_frames_attack1[] = {
     { ai_charge,  0,  jorg_firebullet },
@@ -353,7 +353,7 @@ static const mframe_t jorg_frames_attack1[] = {
     { ai_charge,  0,  jorg_firebullet },
     { ai_charge,  0,  jorg_firebullet }
 };
-const mmove_t jorg_move_attack1 = {FRAME_attak109, FRAME_attak114, jorg_frames_attack1, jorg_reattack1};
+DEFINE_MMOVE(jorg_move_attack1, FRAME_attak109, FRAME_attak114, jorg_frames_attack1, jorg_reattack1);
 
 static const mframe_t jorg_frames_end_attack1[] = {
     { ai_move,    0,  NULL },
@@ -361,7 +361,7 @@ static const mframe_t jorg_frames_end_attack1[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t jorg_move_end_attack1 = {FRAME_attak115, FRAME_attak118, jorg_frames_end_attack1, jorg_run};
+DEFINE_MMOVE(jorg_move_end_attack1, FRAME_attak115, FRAME_attak118, jorg_frames_end_attack1, jorg_run);
 
 static void jorg_reattack1(edict_t *self)
 {

--- a/src/game/m_boss32.cpp
+++ b/src/game/m_boss32.cpp
@@ -128,7 +128,7 @@ static const mframe_t makron_frames_stand[] = {
     { ai_stand, 0, NULL },
     { ai_stand, 0, NULL }       // 60
 };
-const mmove_t makron_move_stand = {FRAME_stand201, FRAME_stand260, makron_frames_stand, NULL};
+DEFINE_MMOVE(makron_move_stand, FRAME_stand201, FRAME_stand260, makron_frames_stand, NULL);
 
 void makron_stand(edict_t *self)
 {
@@ -147,7 +147,7 @@ static const mframe_t makron_frames_run[] = {
     { ai_run, 6,  NULL },
     { ai_run, 12, NULL }
 };
-const mmove_t makron_move_run = {FRAME_walk204, FRAME_walk213, makron_frames_run, NULL};
+DEFINE_MMOVE(makron_move_run, FRAME_walk204, FRAME_walk213, makron_frames_run, NULL);
 
 static void makron_hit(edict_t *self)
 {
@@ -179,7 +179,7 @@ static void makron_prerailgun(edict_t *self)
     gi.sound(self, CHAN_WEAPON, sound_prerailgun, 1, ATTN_NORM, 0);
 }
 
-const mmove_t makron_move_walk = {FRAME_walk204, FRAME_walk213, makron_frames_run, NULL};
+DEFINE_MMOVE(makron_move_walk, FRAME_walk204, FRAME_walk213, makron_frames_run, NULL);
 
 void makron_walk(edict_t *self)
 {
@@ -223,7 +223,7 @@ static const mframe_t makron_frames_pain6[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t makron_move_pain6 = {FRAME_pain601, FRAME_pain627, makron_frames_pain6, makron_run};
+DEFINE_MMOVE(makron_move_pain6, FRAME_pain601, FRAME_pain627, makron_frames_pain6, makron_run);
 
 static const mframe_t makron_frames_pain5[] = {
     { ai_move,    0,  NULL },
@@ -231,7 +231,7 @@ static const mframe_t makron_frames_pain5[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t makron_move_pain5 = {FRAME_pain501, FRAME_pain504, makron_frames_pain5, makron_run};
+DEFINE_MMOVE(makron_move_pain5, FRAME_pain501, FRAME_pain504, makron_frames_pain5, makron_run);
 
 static const mframe_t makron_frames_pain4[] = {
     { ai_move,    0,  NULL },
@@ -239,7 +239,7 @@ static const mframe_t makron_frames_pain4[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t makron_move_pain4 = {FRAME_pain401, FRAME_pain404, makron_frames_pain4, makron_run};
+DEFINE_MMOVE(makron_move_pain4, FRAME_pain401, FRAME_pain404, makron_frames_pain4, makron_run);
 
 static const mframe_t makron_frames_death2[] = {
     { ai_move,    -15,    NULL },
@@ -338,7 +338,7 @@ static const mframe_t makron_frames_death2[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }            // 95
 };
-const mmove_t makron_move_death2 = {FRAME_death201, FRAME_death295, makron_frames_death2, makron_dead};
+DEFINE_MMOVE(makron_move_death2, FRAME_death201, FRAME_death295, makron_frames_death2, makron_dead);
 
 static const mframe_t makron_frames_death3[] = {
     { ai_move,    0,  NULL },
@@ -362,7 +362,7 @@ static const mframe_t makron_frames_death3[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t makron_move_death3 = {FRAME_death301, FRAME_death320, makron_frames_death3, NULL};
+DEFINE_MMOVE(makron_move_death3, FRAME_death301, FRAME_death320, makron_frames_death3, NULL);
 
 static const mframe_t makron_frames_sight[] = {
     { ai_move,    0,  NULL },
@@ -379,7 +379,7 @@ static const mframe_t makron_frames_sight[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t makron_move_sight = {FRAME_active01, FRAME_active13, makron_frames_sight, makron_run};
+DEFINE_MMOVE(makron_move_sight, FRAME_active01, FRAME_active13, makron_frames_sight, makron_run);
 
 static void makronBFG(edict_t *self)
 {
@@ -409,7 +409,7 @@ static const mframe_t makron_frames_attack3[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t makron_move_attack3 = {FRAME_attak301, FRAME_attak308, makron_frames_attack3, makron_run};
+DEFINE_MMOVE(makron_move_attack3, FRAME_attak301, FRAME_attak308, makron_frames_attack3, makron_run);
 
 static const mframe_t makron_frames_attack4[] = {
     { ai_charge,  0,  NULL },
@@ -439,7 +439,7 @@ static const mframe_t makron_frames_attack4[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t makron_move_attack4 = {FRAME_attak401, FRAME_attak426, makron_frames_attack4, makron_run};
+DEFINE_MMOVE(makron_move_attack4, FRAME_attak401, FRAME_attak426, makron_frames_attack4, makron_run);
 
 static const mframe_t makron_frames_attack5[] = {
     { ai_charge,  0,  makron_prerailgun },
@@ -459,7 +459,7 @@ static const mframe_t makron_frames_attack5[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t makron_move_attack5 = {FRAME_attak501, FRAME_attak516, makron_frames_attack5, makron_run};
+DEFINE_MMOVE(makron_move_attack5, FRAME_attak501, FRAME_attak516, makron_frames_attack5, makron_run);
 
 static void MakronSaveloc(edict_t *self)
 {

--- a/src/game/m_brain.cpp
+++ b/src/game/m_brain.cpp
@@ -92,7 +92,7 @@ static const mframe_t brain_frames_stand[] = {
     { ai_stand,   0,  NULL },
     { ai_stand,   0,  NULL }
 };
-const mmove_t brain_move_stand = {FRAME_stand01, FRAME_stand30, brain_frames_stand, NULL};
+DEFINE_MMOVE(brain_move_stand, FRAME_stand01, FRAME_stand30, brain_frames_stand, NULL);
 
 void brain_stand(edict_t *self)
 {
@@ -137,7 +137,7 @@ static const mframe_t brain_frames_idle[] = {
     { ai_stand,   0,  NULL },
     { ai_stand,   0,  NULL }
 };
-const mmove_t brain_move_idle = {FRAME_stand31, FRAME_stand60, brain_frames_idle, brain_stand};
+DEFINE_MMOVE(brain_move_idle, FRAME_stand31, FRAME_stand60, brain_frames_idle, brain_stand);
 
 void brain_idle(edict_t *self)
 {
@@ -161,7 +161,7 @@ static const mframe_t brain_frames_walk1[] = {
     { ai_walk,    -1, NULL },
     { ai_walk,    2,  NULL }
 };
-const mmove_t brain_move_walk1 = {FRAME_walk101, FRAME_walk111, brain_frames_walk1, NULL};
+DEFINE_MMOVE(brain_move_walk1, FRAME_walk101, FRAME_walk111, brain_frames_walk1, NULL);
 
 void brain_walk(edict_t *self)
 {
@@ -179,7 +179,7 @@ static const mframe_t brain_frames_defense[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t brain_move_defense = {FRAME_defens01, FRAME_defens08, brain_frames_defense, NULL};
+DEFINE_MMOVE(brain_move_defense, FRAME_defens01, FRAME_defens08, brain_frames_defense, NULL);
 
 static const mframe_t brain_frames_pain3[] = {
     { ai_move,    -2, NULL },
@@ -189,7 +189,7 @@ static const mframe_t brain_frames_pain3[] = {
     { ai_move,    0,  NULL },
     { ai_move,    -4, NULL }
 };
-const mmove_t brain_move_pain3 = {FRAME_pain301, FRAME_pain306, brain_frames_pain3, brain_run};
+DEFINE_MMOVE(brain_move_pain3, FRAME_pain301, FRAME_pain306, brain_frames_pain3, brain_run);
 
 static const mframe_t brain_frames_pain2[] = {
     { ai_move,    -2, NULL },
@@ -201,7 +201,7 @@ static const mframe_t brain_frames_pain2[] = {
     { ai_move,    1,  NULL },
     { ai_move,    -2, NULL }
 };
-const mmove_t brain_move_pain2 = {FRAME_pain201, FRAME_pain208, brain_frames_pain2, brain_run};
+DEFINE_MMOVE(brain_move_pain2, FRAME_pain201, FRAME_pain208, brain_frames_pain2, brain_run);
 
 static const mframe_t brain_frames_pain1[] = {
     { ai_move,    -6, NULL },
@@ -226,7 +226,7 @@ static const mframe_t brain_frames_pain1[] = {
     { ai_move,    3,  NULL },
     { ai_move,    -1, NULL }
 };
-const mmove_t brain_move_pain1 = {FRAME_pain101, FRAME_pain121, brain_frames_pain1, brain_run};
+DEFINE_MMOVE(brain_move_pain1, FRAME_pain101, FRAME_pain121, brain_frames_pain1, brain_run);
 
 //
 // DUCK
@@ -268,7 +268,7 @@ static const mframe_t brain_frames_duck[] = {
     { ai_move,    -6, NULL },
     { ai_move,    -6, NULL }
 };
-const mmove_t brain_move_duck = {FRAME_duck01, FRAME_duck08, brain_frames_duck, brain_run};
+DEFINE_MMOVE(brain_move_duck, FRAME_duck01, FRAME_duck08, brain_frames_duck, brain_run);
 
 void brain_dodge(edict_t *self, edict_t *attacker, float eta)
 {
@@ -289,7 +289,7 @@ static const mframe_t brain_frames_death2[] = {
     { ai_move,    9,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t brain_move_death2 = {FRAME_death201, FRAME_death205, brain_frames_death2, brain_dead};
+DEFINE_MMOVE(brain_move_death2, FRAME_death201, FRAME_death205, brain_frames_death2, brain_dead);
 
 static const mframe_t brain_frames_death1[] = {
     { ai_move,    0,  NULL },
@@ -311,7 +311,7 @@ static const mframe_t brain_frames_death1[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t brain_move_death1 = {FRAME_death101, FRAME_death118, brain_frames_death1, brain_dead};
+DEFINE_MMOVE(brain_move_death1, FRAME_death101, FRAME_death118, brain_frames_death1, brain_dead);
 
 //
 // MELEE
@@ -363,7 +363,7 @@ static const mframe_t brain_frames_attack1[] = {
     { ai_charge,  2,  NULL },
     { ai_charge,  -11, NULL }
 };
-const mmove_t brain_move_attack1 = {FRAME_attak101, FRAME_attak118, brain_frames_attack1, brain_run};
+DEFINE_MMOVE(brain_move_attack1, FRAME_attak101, FRAME_attak118, brain_frames_attack1, brain_run);
 
 static void brain_chest_open(edict_t *self)
 {
@@ -409,7 +409,7 @@ static const mframe_t brain_frames_attack2[] = {
     { ai_charge,  -3, NULL },
     { ai_charge,  -6, NULL }
 };
-const mmove_t brain_move_attack2 = {FRAME_attak201, FRAME_attak217, brain_frames_attack2, brain_run};
+DEFINE_MMOVE(brain_move_attack2, FRAME_attak201, FRAME_attak217, brain_frames_attack2, brain_run);
 
 void brain_melee(edict_t *self)
 {
@@ -436,7 +436,7 @@ static const mframe_t brain_frames_run[] = {
     { ai_run, -1, NULL },
     { ai_run, 2,  NULL }
 };
-const mmove_t brain_move_run = {FRAME_walk101, FRAME_walk111, brain_frames_run, NULL};
+DEFINE_MMOVE(brain_move_run, FRAME_walk101, FRAME_walk111, brain_frames_run, NULL);
 
 void brain_run(edict_t *self)
 {

--- a/src/game/m_chick.cpp
+++ b/src/game/m_chick.cpp
@@ -89,7 +89,7 @@ static const mframe_t chick_frames_fidget[] = {
     { ai_stand, 0,  NULL },
     { ai_stand, 0,  NULL }
 };
-const mmove_t chick_move_fidget = {FRAME_stand201, FRAME_stand230, chick_frames_fidget, chick_stand};
+DEFINE_MMOVE(chick_move_fidget, FRAME_stand201, FRAME_stand230, chick_frames_fidget, chick_stand);
 
 static void chick_fidget(edict_t *self)
 {
@@ -132,7 +132,7 @@ static const mframe_t chick_frames_stand[] = {
     { ai_stand, 0, chick_fidget },
 
 };
-const mmove_t chick_move_stand = {FRAME_stand101, FRAME_stand130, chick_frames_stand, NULL};
+DEFINE_MMOVE(chick_move_stand, FRAME_stand101, FRAME_stand130, chick_frames_stand, NULL);
 
 void chick_stand(edict_t *self)
 {
@@ -151,7 +151,7 @@ static const mframe_t chick_frames_start_run[] = {
     { ai_run, 6,   NULL },
     { ai_run, 3,   NULL }
 };
-const mmove_t chick_move_start_run = {FRAME_walk01, FRAME_walk10, chick_frames_start_run, chick_run};
+DEFINE_MMOVE(chick_move_start_run, FRAME_walk01, FRAME_walk10, chick_frames_start_run, chick_run);
 
 static const mframe_t chick_frames_run[] = {
     { ai_run, 6,  NULL },
@@ -167,7 +167,7 @@ static const mframe_t chick_frames_run[] = {
 
 };
 
-const mmove_t chick_move_run = {FRAME_walk11, FRAME_walk20, chick_frames_run, NULL};
+DEFINE_MMOVE(chick_move_run, FRAME_walk11, FRAME_walk20, chick_frames_run, NULL);
 
 static const mframe_t chick_frames_walk[] = {
     { ai_walk, 6,  NULL },
@@ -182,7 +182,7 @@ static const mframe_t chick_frames_walk[] = {
     { ai_walk, 7,  NULL }
 };
 
-const mmove_t chick_move_walk = {FRAME_walk11, FRAME_walk20, chick_frames_walk, NULL};
+DEFINE_MMOVE(chick_move_walk, FRAME_walk11, FRAME_walk20, chick_frames_walk, NULL);
 
 void chick_walk(edict_t *self)
 {
@@ -211,7 +211,7 @@ static const mframe_t chick_frames_pain1[] = {
     { ai_move, 0, NULL },
     { ai_move, 0, NULL }
 };
-const mmove_t chick_move_pain1 = {FRAME_pain101, FRAME_pain105, chick_frames_pain1, chick_run};
+DEFINE_MMOVE(chick_move_pain1, FRAME_pain101, FRAME_pain105, chick_frames_pain1, chick_run);
 
 static const mframe_t chick_frames_pain2[] = {
     { ai_move, 0, NULL },
@@ -220,7 +220,7 @@ static const mframe_t chick_frames_pain2[] = {
     { ai_move, 0, NULL },
     { ai_move, 0, NULL }
 };
-const mmove_t chick_move_pain2 = {FRAME_pain201, FRAME_pain205, chick_frames_pain2, chick_run};
+DEFINE_MMOVE(chick_move_pain2, FRAME_pain201, FRAME_pain205, chick_frames_pain2, chick_run);
 
 static const mframe_t chick_frames_pain3[] = {
     { ai_move, 0,     NULL },
@@ -245,7 +245,7 @@ static const mframe_t chick_frames_pain3[] = {
     { ai_move, -8,    NULL },
     { ai_move, 2,     NULL }
 };
-const mmove_t chick_move_pain3 = {FRAME_pain301, FRAME_pain321, chick_frames_pain3, chick_run};
+DEFINE_MMOVE(chick_move_pain3, FRAME_pain301, FRAME_pain321, chick_frames_pain3, chick_run);
 
 void chick_pain(edict_t *self, edict_t *other, float kick, int damage)
 {
@@ -313,7 +313,7 @@ static const mframe_t chick_frames_death2[] = {
     { ai_move, 14, NULL },
     { ai_move, 1, NULL }
 };
-const mmove_t chick_move_death2 = {FRAME_death201, FRAME_death223, chick_frames_death2, chick_dead};
+DEFINE_MMOVE(chick_move_death2, FRAME_death201, FRAME_death223, chick_frames_death2, chick_dead);
 
 static const mframe_t chick_frames_death1[] = {
     { ai_move, 0,  NULL },
@@ -330,7 +330,7 @@ static const mframe_t chick_frames_death1[] = {
     { ai_move, 0,  NULL }
 
 };
-const mmove_t chick_move_death1 = {FRAME_death101, FRAME_death112, chick_frames_death1, chick_dead};
+DEFINE_MMOVE(chick_move_death1, FRAME_death101, FRAME_death112, chick_frames_death1, chick_dead);
 
 void chick_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage, vec3_t point)
 {
@@ -401,7 +401,7 @@ static const mframe_t chick_frames_duck[] = {
     { ai_move, 3, NULL },
     { ai_move, 1,  NULL }
 };
-const mmove_t chick_move_duck = {FRAME_duck01, FRAME_duck07, chick_frames_duck, chick_run};
+DEFINE_MMOVE(chick_move_duck, FRAME_duck01, FRAME_duck07, chick_frames_duck, chick_run);
 
 void chick_dodge(edict_t *self, edict_t *attacker, float eta)
 {
@@ -465,7 +465,7 @@ static const mframe_t chick_frames_start_attack1[] = {
     { ai_charge, 0,   NULL },
     { ai_charge, 0,   chick_attack1 }
 };
-const mmove_t chick_move_start_attack1 = {FRAME_attak101, FRAME_attak113, chick_frames_start_attack1, NULL};
+DEFINE_MMOVE(chick_move_start_attack1, FRAME_attak101, FRAME_attak113, chick_frames_start_attack1, NULL);
 
 static const mframe_t chick_frames_attack1[] = {
     { ai_charge, 19,  ChickRocket },
@@ -484,7 +484,7 @@ static const mframe_t chick_frames_attack1[] = {
     { ai_charge, 3,   chick_rerocket }
 
 };
-const mmove_t chick_move_attack1 = {FRAME_attak114, FRAME_attak127, chick_frames_attack1, NULL};
+DEFINE_MMOVE(chick_move_attack1, FRAME_attak114, FRAME_attak127, chick_frames_attack1, NULL);
 
 static const mframe_t chick_frames_end_attack1[] = {
     { ai_charge, -3,  NULL },
@@ -493,7 +493,7 @@ static const mframe_t chick_frames_end_attack1[] = {
     { ai_charge, -4,  NULL },
     { ai_charge, -2,  NULL }
 };
-const mmove_t chick_move_end_attack1 = {FRAME_attak128, FRAME_attak132, chick_frames_end_attack1, chick_run};
+DEFINE_MMOVE(chick_move_end_attack1, FRAME_attak128, FRAME_attak132, chick_frames_end_attack1, chick_run);
 
 static void chick_rerocket(edict_t *self)
 {
@@ -524,7 +524,7 @@ static const mframe_t chick_frames_slash[] = {
     { ai_charge, 1,   NULL },
     { ai_charge, -2,  chick_reslash }
 };
-const mmove_t chick_move_slash = {FRAME_attak204, FRAME_attak212, chick_frames_slash, NULL};
+DEFINE_MMOVE(chick_move_slash, FRAME_attak204, FRAME_attak212, chick_frames_slash, NULL);
 
 static const mframe_t chick_frames_end_slash[] = {
     { ai_charge, -6,  NULL },
@@ -532,7 +532,7 @@ static const mframe_t chick_frames_end_slash[] = {
     { ai_charge, -6,  NULL },
     { ai_charge, 0,   NULL }
 };
-const mmove_t chick_move_end_slash = {FRAME_attak213, FRAME_attak216, chick_frames_end_slash, chick_run};
+DEFINE_MMOVE(chick_move_end_slash, FRAME_attak213, FRAME_attak216, chick_frames_end_slash, chick_run);
 
 static void chick_reslash(edict_t *self)
 {
@@ -560,7 +560,7 @@ static const mframe_t chick_frames_start_slash[] = {
     { ai_charge, 8,   NULL },
     { ai_charge, 3,   NULL }
 };
-const mmove_t chick_move_start_slash = {FRAME_attak201, FRAME_attak203, chick_frames_start_slash, chick_slash};
+DEFINE_MMOVE(chick_move_start_slash, FRAME_attak201, FRAME_attak203, chick_frames_start_slash, chick_slash);
 
 void chick_melee(edict_t *self)
 {

--- a/src/game/m_flipper.cpp
+++ b/src/game/m_flipper.cpp
@@ -39,7 +39,7 @@ static const mframe_t flipper_frames_stand[] = {
     { ai_stand, 0, NULL }
 };
 
-const mmove_t flipper_move_stand = {FRAME_flphor01, FRAME_flphor01, flipper_frames_stand, NULL};
+DEFINE_MMOVE(flipper_move_stand, FRAME_flphor01, FRAME_flphor01, flipper_frames_stand, NULL);
 
 void flipper_stand(edict_t *self)
 {
@@ -76,7 +76,7 @@ static const mframe_t flipper_frames_run[] = {
     { ai_run, FLIPPER_RUN_SPEED, NULL },
     { ai_run, FLIPPER_RUN_SPEED, NULL }     // 29
 };
-const mmove_t flipper_move_run_loop = {FRAME_flpver06, FRAME_flpver29, flipper_frames_run, NULL};
+DEFINE_MMOVE(flipper_move_run_loop, FRAME_flpver06, FRAME_flpver29, flipper_frames_run, NULL);
 
 static void flipper_run_loop(edict_t *self)
 {
@@ -91,7 +91,7 @@ static const mframe_t flipper_frames_run_start[] = {
     { ai_run, 8, NULL },
     { ai_run, 8, NULL }
 };
-const mmove_t flipper_move_run_start = {FRAME_flpver01, FRAME_flpver06, flipper_frames_run_start, flipper_run_loop};
+DEFINE_MMOVE(flipper_move_run_start, FRAME_flpver01, FRAME_flpver06, flipper_frames_run_start, flipper_run_loop);
 
 static void flipper_run(edict_t *self)
 {
@@ -125,7 +125,7 @@ static const mframe_t flipper_frames_walk[] = {
     { ai_walk, 4, NULL },
     { ai_walk, 4, NULL }
 };
-const mmove_t flipper_move_walk = {FRAME_flphor01, FRAME_flphor24, flipper_frames_walk, NULL};
+DEFINE_MMOVE(flipper_move_walk, FRAME_flphor01, FRAME_flphor24, flipper_frames_walk, NULL);
 
 void flipper_walk(edict_t *self)
 {
@@ -139,7 +139,7 @@ static const mframe_t flipper_frames_start_run[] = {
     { ai_run, 8, NULL },
     { ai_run, 8, flipper_run }
 };
-const mmove_t flipper_move_start_run = {FRAME_flphor01, FRAME_flphor05, flipper_frames_start_run, NULL};
+DEFINE_MMOVE(flipper_move_start_run, FRAME_flphor01, FRAME_flphor05, flipper_frames_start_run, NULL);
 
 void flipper_start_run(edict_t *self)
 {
@@ -153,7 +153,7 @@ static const mframe_t flipper_frames_pain2[] = {
     { ai_move, 0, NULL },
     { ai_move, 0, NULL }
 };
-const mmove_t flipper_move_pain2 = {FRAME_flppn101, FRAME_flppn105, flipper_frames_pain2, flipper_run};
+DEFINE_MMOVE(flipper_move_pain2, FRAME_flppn101, FRAME_flppn105, flipper_frames_pain2, flipper_run);
 
 static const mframe_t flipper_frames_pain1[] = {
     { ai_move, 0, NULL },
@@ -162,7 +162,7 @@ static const mframe_t flipper_frames_pain1[] = {
     { ai_move, 0, NULL },
     { ai_move, 0, NULL }
 };
-const mmove_t flipper_move_pain1 = {FRAME_flppn201, FRAME_flppn205, flipper_frames_pain1, flipper_run};
+DEFINE_MMOVE(flipper_move_pain1, FRAME_flppn201, FRAME_flppn205, flipper_frames_pain1, flipper_run);
 
 static void flipper_bite(edict_t *self)
 {
@@ -198,7 +198,7 @@ static const mframe_t flipper_frames_attack[] = {
     { ai_charge, 0,   flipper_bite },
     { ai_charge, 0,   NULL }
 };
-const mmove_t flipper_move_attack = {FRAME_flpbit01, FRAME_flpbit20, flipper_frames_attack, flipper_run};
+DEFINE_MMOVE(flipper_move_attack, FRAME_flpbit01, FRAME_flpbit20, flipper_frames_attack, flipper_run);
 
 void flipper_melee(edict_t *self)
 {
@@ -303,7 +303,7 @@ static const mframe_t flipper_frames_death[] = {
     { ai_move, 0,  NULL },
     { ai_move, 0,  NULL }
 };
-const mmove_t flipper_move_death = {FRAME_flpdth01, FRAME_flpdth56, flipper_frames_death, flipper_dead};
+DEFINE_MMOVE(flipper_move_death, FRAME_flpdth01, FRAME_flpdth56, flipper_frames_death, flipper_dead);
 
 void flipper_sight(edict_t *self, edict_t *other)
 {

--- a/src/game/m_float.cpp
+++ b/src/game/m_float.cpp
@@ -127,7 +127,7 @@ static const mframe_t floater_frames_stand1[] = {
     { ai_stand, 0, NULL },
     { ai_stand, 0, NULL }
 };
-const mmove_t floater_move_stand1 = {FRAME_stand101, FRAME_stand152, floater_frames_stand1, NULL};
+DEFINE_MMOVE(floater_move_stand1, FRAME_stand101, FRAME_stand152, floater_frames_stand1, NULL);
 
 static const mframe_t floater_frames_stand2[] = {
     { ai_stand, 0, NULL },
@@ -183,7 +183,7 @@ static const mframe_t floater_frames_stand2[] = {
     { ai_stand, 0, NULL },
     { ai_stand, 0, NULL }
 };
-const mmove_t floater_move_stand2 = {FRAME_stand201, FRAME_stand252, floater_frames_stand2, NULL};
+DEFINE_MMOVE(floater_move_stand2, FRAME_stand201, FRAME_stand252, floater_frames_stand2, NULL);
 
 void floater_stand(edict_t *self)
 {
@@ -225,7 +225,7 @@ static const mframe_t floater_frames_activate[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t floater_move_activate = {FRAME_actvat01, FRAME_actvat31, floater_frames_activate, NULL};
+DEFINE_MMOVE(floater_move_activate, FRAME_actvat01, FRAME_actvat31, floater_frames_activate, NULL);
 
 static const mframe_t floater_frames_attack1[] = {
     { ai_charge,  0,  NULL },           // Blaster attack
@@ -243,7 +243,7 @@ static const mframe_t floater_frames_attack1[] = {
     { ai_charge,  0,  NULL },
     { ai_charge,  0,  NULL }            //                          -- LOOP Ends
 };
-const mmove_t floater_move_attack1 = {FRAME_attak101, FRAME_attak114, floater_frames_attack1, floater_run};
+DEFINE_MMOVE(floater_move_attack1, FRAME_attak101, FRAME_attak114, floater_frames_attack1, floater_run);
 
 static const mframe_t floater_frames_attack2[] = {
     { ai_charge,  0,  NULL },           // Claws
@@ -272,7 +272,7 @@ static const mframe_t floater_frames_attack2[] = {
     { ai_charge,  0,  NULL },
     { ai_charge,  0,  NULL }
 };
-const mmove_t floater_move_attack2 = {FRAME_attak201, FRAME_attak225, floater_frames_attack2, floater_run};
+DEFINE_MMOVE(floater_move_attack2, FRAME_attak201, FRAME_attak225, floater_frames_attack2, floater_run);
 
 static const mframe_t floater_frames_attack3[] = {
     { ai_charge,  0,  NULL },
@@ -310,7 +310,7 @@ static const mframe_t floater_frames_attack3[] = {
     { ai_charge,  0,  NULL },
     { ai_charge,  0,  NULL }
 };
-const mmove_t floater_move_attack3 = {FRAME_attak301, FRAME_attak334, floater_frames_attack3, floater_run};
+DEFINE_MMOVE(floater_move_attack3, FRAME_attak301, FRAME_attak334, floater_frames_attack3, floater_run);
 
 static const mframe_t floater_frames_death[] = {
     { ai_move,    0,  NULL },
@@ -327,7 +327,7 @@ static const mframe_t floater_frames_death[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t floater_move_death = {FRAME_death01, FRAME_death13, floater_frames_death, floater_dead};
+DEFINE_MMOVE(floater_move_death, FRAME_death01, FRAME_death13, floater_frames_death, floater_dead);
 
 static const mframe_t floater_frames_pain1[] = {
     { ai_move,    0,  NULL },
@@ -338,7 +338,7 @@ static const mframe_t floater_frames_pain1[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t floater_move_pain1 = {FRAME_pain101, FRAME_pain107, floater_frames_pain1, floater_run};
+DEFINE_MMOVE(floater_move_pain1, FRAME_pain101, FRAME_pain107, floater_frames_pain1, floater_run);
 
 static const mframe_t floater_frames_pain2[] = {
     { ai_move,    0,  NULL },
@@ -350,7 +350,7 @@ static const mframe_t floater_frames_pain2[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t floater_move_pain2 = {FRAME_pain201, FRAME_pain208, floater_frames_pain2, floater_run};
+DEFINE_MMOVE(floater_move_pain2, FRAME_pain201, FRAME_pain208, floater_frames_pain2, floater_run);
 
 static const mframe_t floater_frames_pain3[] = {
     { ai_move,    0,  NULL },
@@ -366,7 +366,7 @@ static const mframe_t floater_frames_pain3[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t floater_move_pain3 = {FRAME_pain301, FRAME_pain312, floater_frames_pain3, floater_run};
+DEFINE_MMOVE(floater_move_pain3, FRAME_pain301, FRAME_pain312, floater_frames_pain3, floater_run);
 
 static const mframe_t floater_frames_walk[] = {
     { ai_walk, 5, NULL },
@@ -422,7 +422,7 @@ static const mframe_t floater_frames_walk[] = {
     { ai_walk, 5, NULL },
     { ai_walk, 5, NULL }
 };
-const mmove_t floater_move_walk = {FRAME_stand101, FRAME_stand152, floater_frames_walk, NULL};
+DEFINE_MMOVE(floater_move_walk, FRAME_stand101, FRAME_stand152, floater_frames_walk, NULL);
 
 static const mframe_t floater_frames_run[] = {
     { ai_run, 13, NULL },
@@ -478,7 +478,7 @@ static const mframe_t floater_frames_run[] = {
     { ai_run, 13, NULL },
     { ai_run, 13, NULL }
 };
-const mmove_t floater_move_run = {FRAME_stand101, FRAME_stand152, floater_frames_run, NULL};
+DEFINE_MMOVE(floater_move_run, FRAME_stand101, FRAME_stand152, floater_frames_run, NULL);
 
 void floater_run(edict_t *self)
 {

--- a/src/game/m_flyer.cpp
+++ b/src/game/m_flyer.cpp
@@ -102,7 +102,7 @@ static const mframe_t flyer_frames_stand[] = {
     { ai_stand, 0, NULL },
     { ai_stand, 0, NULL }
 };
-const mmove_t flyer_move_stand = {FRAME_stand01, FRAME_stand45, flyer_frames_stand, NULL};
+DEFINE_MMOVE(flyer_move_stand, FRAME_stand01, FRAME_stand45, flyer_frames_stand, NULL);
 
 static const mframe_t flyer_frames_walk[] = {
     { ai_walk, 5, NULL },
@@ -151,7 +151,7 @@ static const mframe_t flyer_frames_walk[] = {
     { ai_walk, 5, NULL },
     { ai_walk, 5, NULL }
 };
-const mmove_t flyer_move_walk = {FRAME_stand01, FRAME_stand45, flyer_frames_walk, NULL};
+DEFINE_MMOVE(flyer_move_walk, FRAME_stand01, FRAME_stand45, flyer_frames_walk, NULL);
 
 static const mframe_t flyer_frames_run[] = {
     { ai_run, 10, NULL },
@@ -200,7 +200,7 @@ static const mframe_t flyer_frames_run[] = {
     { ai_run, 10, NULL },
     { ai_run, 10, NULL }
 };
-const mmove_t flyer_move_run = {FRAME_stand01, FRAME_stand45, flyer_frames_run, NULL};
+DEFINE_MMOVE(flyer_move_run, FRAME_stand01, FRAME_stand45, flyer_frames_run, NULL);
 
 void flyer_run(edict_t *self)
 {
@@ -231,7 +231,7 @@ static const mframe_t flyer_frames_rollright[] = {
     { ai_move, 0, NULL },
     { ai_move, 0, NULL }
 };
-const mmove_t flyer_move_rollright = {FRAME_rollr01, FRAME_rollr09, flyer_frames_rollright, NULL};
+DEFINE_MMOVE(flyer_move_rollright, FRAME_rollr01, FRAME_rollr09, flyer_frames_rollright, NULL);
 
 static const mframe_t flyer_frames_rollleft[] = {
     { ai_move, 0, NULL },
@@ -244,7 +244,7 @@ static const mframe_t flyer_frames_rollleft[] = {
     { ai_move, 0, NULL },
     { ai_move, 0, NULL }
 };
-const mmove_t flyer_move_rollleft = {FRAME_rollf01, FRAME_rollf09, flyer_frames_rollleft, NULL};
+DEFINE_MMOVE(flyer_move_rollleft, FRAME_rollf01, FRAME_rollf09, flyer_frames_rollleft, NULL);
 
 static const mframe_t flyer_frames_pain3[] = {
     { ai_move, 0, NULL },
@@ -252,7 +252,7 @@ static const mframe_t flyer_frames_pain3[] = {
     { ai_move, 0, NULL },
     { ai_move, 0, NULL }
 };
-const mmove_t flyer_move_pain3 = {FRAME_pain301, FRAME_pain304, flyer_frames_pain3, flyer_run};
+DEFINE_MMOVE(flyer_move_pain3, FRAME_pain301, FRAME_pain304, flyer_frames_pain3, flyer_run);
 
 static const mframe_t flyer_frames_pain2[] = {
     { ai_move, 0, NULL },
@@ -260,7 +260,7 @@ static const mframe_t flyer_frames_pain2[] = {
     { ai_move, 0, NULL },
     { ai_move, 0, NULL }
 };
-const mmove_t flyer_move_pain2 = {FRAME_pain201, FRAME_pain204, flyer_frames_pain2, flyer_run};
+DEFINE_MMOVE(flyer_move_pain2, FRAME_pain201, FRAME_pain204, flyer_frames_pain2, flyer_run);
 
 static const mframe_t flyer_frames_pain1[] = {
     { ai_move, 0, NULL },
@@ -273,7 +273,7 @@ static const mframe_t flyer_frames_pain1[] = {
     { ai_move, 0, NULL },
     { ai_move, 0, NULL }
 };
-const mmove_t flyer_move_pain1 = {FRAME_pain101, FRAME_pain109, flyer_frames_pain1, flyer_run};
+DEFINE_MMOVE(flyer_move_pain1, FRAME_pain101, FRAME_pain109, flyer_frames_pain1, flyer_run);
 
 static const mframe_t flyer_frames_defense[] = {
     { ai_move, 0, NULL },
@@ -283,7 +283,7 @@ static const mframe_t flyer_frames_defense[] = {
     { ai_move, 0, NULL },
     { ai_move, 0, NULL }
 };
-const mmove_t flyer_move_defense = {FRAME_defens01, FRAME_defens06, flyer_frames_defense, NULL};
+DEFINE_MMOVE(flyer_move_defense, FRAME_defens01, FRAME_defens06, flyer_frames_defense, NULL);
 
 static const mframe_t flyer_frames_bankright[] = {
     { ai_move, 0, NULL },
@@ -294,7 +294,7 @@ static const mframe_t flyer_frames_bankright[] = {
     { ai_move, 0, NULL },
     { ai_move, 0, NULL }
 };
-const mmove_t flyer_move_bankright = {FRAME_bankr01, FRAME_bankr07, flyer_frames_bankright, NULL};
+DEFINE_MMOVE(flyer_move_bankright, FRAME_bankr01, FRAME_bankr07, flyer_frames_bankright, NULL);
 
 static const mframe_t flyer_frames_bankleft[] = {
     { ai_move, 0, NULL },
@@ -305,7 +305,7 @@ static const mframe_t flyer_frames_bankleft[] = {
     { ai_move, 0, NULL },
     { ai_move, 0, NULL }
 };
-const mmove_t flyer_move_bankleft = {FRAME_bankl01, FRAME_bankl07, flyer_frames_bankleft, NULL};
+DEFINE_MMOVE(flyer_move_bankleft, FRAME_bankl01, FRAME_bankl07, flyer_frames_bankleft, NULL);
 
 static void flyer_fire(edict_t *self, int flash_number)
 {
@@ -358,7 +358,7 @@ static const mframe_t flyer_frames_attack2[] = {
     { ai_charge, 0, NULL },
     { ai_charge, 0, NULL }
 };
-const mmove_t flyer_move_attack2 = {FRAME_attak201, FRAME_attak217, flyer_frames_attack2, flyer_run};
+DEFINE_MMOVE(flyer_move_attack2, FRAME_attak201, FRAME_attak217, flyer_frames_attack2, flyer_run);
 
 static void flyer_slash_left(edict_t *self)
 {
@@ -384,14 +384,14 @@ static const mframe_t flyer_frames_start_melee[] = {
     { ai_charge, 0, NULL },
     { ai_charge, 0, NULL }
 };
-const mmove_t flyer_move_start_melee = {FRAME_attak101, FRAME_attak106, flyer_frames_start_melee, flyer_loop_melee};
+DEFINE_MMOVE(flyer_move_start_melee, FRAME_attak101, FRAME_attak106, flyer_frames_start_melee, flyer_loop_melee);
 
 static const mframe_t flyer_frames_end_melee[] = {
     { ai_charge, 0, NULL },
     { ai_charge, 0, NULL },
     { ai_charge, 0, NULL }
 };
-const mmove_t flyer_move_end_melee = {FRAME_attak119, FRAME_attak121, flyer_frames_end_melee, flyer_run};
+DEFINE_MMOVE(flyer_move_end_melee, FRAME_attak119, FRAME_attak121, flyer_frames_end_melee, flyer_run);
 
 static const mframe_t flyer_frames_loop_melee[] = {
     { ai_charge, 0, NULL },     // Loop Start
@@ -408,7 +408,7 @@ static const mframe_t flyer_frames_loop_melee[] = {
     { ai_charge, 0, NULL }      // Loop Ends
 
 };
-const mmove_t flyer_move_loop_melee = {FRAME_attak107, FRAME_attak118, flyer_frames_loop_melee, flyer_check_melee};
+DEFINE_MMOVE(flyer_move_loop_melee, FRAME_attak107, FRAME_attak118, flyer_frames_loop_melee, flyer_check_melee);
 
 static void flyer_loop_melee(edict_t *self)
 {

--- a/src/game/m_gladiator.cpp
+++ b/src/game/m_gladiator.cpp
@@ -66,7 +66,7 @@ static const mframe_t gladiator_frames_stand[] = {
     { ai_stand, 0, NULL },
     { ai_stand, 0, NULL }
 };
-const mmove_t gladiator_move_stand = {FRAME_stand1, FRAME_stand7, gladiator_frames_stand, NULL};
+DEFINE_MMOVE(gladiator_move_stand, FRAME_stand1, FRAME_stand7, gladiator_frames_stand, NULL);
 
 void gladiator_stand(edict_t *self)
 {
@@ -91,7 +91,7 @@ static const mframe_t gladiator_frames_walk[] = {
     { ai_walk, 1,  NULL },
     { ai_walk, 8,  NULL }
 };
-const mmove_t gladiator_move_walk = {FRAME_walk1, FRAME_walk16, gladiator_frames_walk, NULL};
+DEFINE_MMOVE(gladiator_move_walk, FRAME_walk1, FRAME_walk16, gladiator_frames_walk, NULL);
 
 void gladiator_walk(edict_t *self)
 {
@@ -106,7 +106,7 @@ static const mframe_t gladiator_frames_run[] = {
     { ai_run, 12, NULL },
     { ai_run, 13, NULL }
 };
-const mmove_t gladiator_move_run = {FRAME_run1, FRAME_run6, gladiator_frames_run, NULL};
+DEFINE_MMOVE(gladiator_move_run, FRAME_run1, FRAME_run6, gladiator_frames_run, NULL);
 
 void gladiator_run(edict_t *self)
 {
@@ -145,7 +145,7 @@ static const mframe_t gladiator_frames_attack_melee[] = {
     { ai_charge, 0, NULL },
     { ai_charge, 0, NULL }
 };
-const mmove_t gladiator_move_attack_melee = {FRAME_melee1, FRAME_melee17, gladiator_frames_attack_melee, gladiator_run};
+DEFINE_MMOVE(gladiator_move_attack_melee, FRAME_melee1, FRAME_melee17, gladiator_frames_attack_melee, gladiator_run);
 
 void gladiator_melee(edict_t *self)
 {
@@ -179,7 +179,7 @@ static const mframe_t gladiator_frames_attack_gun[] = {
     { ai_charge, 0, NULL },
     { ai_charge, 0, NULL }
 };
-const mmove_t gladiator_move_attack_gun = {FRAME_attack1, FRAME_attack9, gladiator_frames_attack_gun, gladiator_run};
+DEFINE_MMOVE(gladiator_move_attack_gun, FRAME_attack1, FRAME_attack9, gladiator_frames_attack_gun, gladiator_run);
 
 void gladiator_attack(edict_t *self)
 {
@@ -207,7 +207,7 @@ static const mframe_t gladiator_frames_pain[] = {
     { ai_move, 0, NULL },
     { ai_move, 0, NULL }
 };
-const mmove_t gladiator_move_pain = {FRAME_pain1, FRAME_pain6, gladiator_frames_pain, gladiator_run};
+DEFINE_MMOVE(gladiator_move_pain, FRAME_pain1, FRAME_pain6, gladiator_frames_pain, gladiator_run);
 
 static const mframe_t gladiator_frames_pain_air[] = {
     { ai_move, 0, NULL },
@@ -218,7 +218,7 @@ static const mframe_t gladiator_frames_pain_air[] = {
     { ai_move, 0, NULL },
     { ai_move, 0, NULL }
 };
-const mmove_t gladiator_move_pain_air = {FRAME_painup1, FRAME_painup7, gladiator_frames_pain_air, gladiator_run};
+DEFINE_MMOVE(gladiator_move_pain_air, FRAME_painup1, FRAME_painup7, gladiator_frames_pain_air, gladiator_run);
 
 void gladiator_pain(edict_t *self, edict_t *other, float kick, int damage)
 {
@@ -281,7 +281,7 @@ static const mframe_t gladiator_frames_death[] = {
     { ai_move, 0, NULL },
     { ai_move, 0, NULL }
 };
-const mmove_t gladiator_move_death = {FRAME_death1, FRAME_death22, gladiator_frames_death, gladiator_dead};
+DEFINE_MMOVE(gladiator_move_death, FRAME_death1, FRAME_death22, gladiator_frames_death, gladiator_dead);
 
 void gladiator_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage, vec3_t point)
 {

--- a/src/game/m_gunner.cpp
+++ b/src/game/m_gunner.cpp
@@ -111,7 +111,7 @@ static const mframe_t gunner_frames_fidget[] = {
     { ai_stand, 0, NULL },
     { ai_stand, 0, NULL }
 };
-const mmove_t gunner_move_fidget = {FRAME_stand31, FRAME_stand70, gunner_frames_fidget, gunner_stand};
+DEFINE_MMOVE(gunner_move_fidget, FRAME_stand31, FRAME_stand70, gunner_frames_fidget, gunner_stand);
 
 static void gunner_fidget(edict_t *self)
 {
@@ -155,7 +155,7 @@ static const mframe_t gunner_frames_stand[] = {
     { ai_stand, 0, NULL },
     { ai_stand, 0, gunner_fidget }
 };
-const mmove_t gunner_move_stand = {FRAME_stand01, FRAME_stand30, gunner_frames_stand, NULL};
+DEFINE_MMOVE(gunner_move_stand, FRAME_stand01, FRAME_stand30, gunner_frames_stand, NULL);
 
 void gunner_stand(edict_t *self)
 {
@@ -177,7 +177,7 @@ static const mframe_t gunner_frames_walk[] = {
     { ai_walk, 7, NULL },
     { ai_walk, 4, NULL }
 };
-const mmove_t gunner_move_walk = {FRAME_walk07, FRAME_walk19, gunner_frames_walk, NULL};
+DEFINE_MMOVE(gunner_move_walk, FRAME_walk07, FRAME_walk19, gunner_frames_walk, NULL);
 
 void gunner_walk(edict_t *self)
 {
@@ -195,7 +195,7 @@ static const mframe_t gunner_frames_run[] = {
     { ai_run, 6,  NULL }
 };
 
-const mmove_t gunner_move_run = {FRAME_run01, FRAME_run08, gunner_frames_run, NULL};
+DEFINE_MMOVE(gunner_move_run, FRAME_run01, FRAME_run08, gunner_frames_run, NULL);
 
 void gunner_run(edict_t *self)
 {
@@ -214,7 +214,7 @@ static const mframe_t gunner_frames_runandshoot[] = {
     { ai_run, 20, NULL }
 };
 
-const mmove_t gunner_move_runandshoot = {FRAME_runs01, FRAME_runs06, gunner_frames_runandshoot, NULL};
+DEFINE_MMOVE(gunner_move_runandshoot, FRAME_runs01, FRAME_runs06, gunner_frames_runandshoot, NULL);
 
 static const mframe_t gunner_frames_pain3[] = {
     { ai_move, -3, NULL },
@@ -223,7 +223,7 @@ static const mframe_t gunner_frames_pain3[] = {
     { ai_move, 0,  NULL },
     { ai_move, 1,  NULL }
 };
-const mmove_t gunner_move_pain3 = {FRAME_pain301, FRAME_pain305, gunner_frames_pain3, gunner_run};
+DEFINE_MMOVE(gunner_move_pain3, FRAME_pain301, FRAME_pain305, gunner_frames_pain3, gunner_run);
 
 static const mframe_t gunner_frames_pain2[] = {
     { ai_move, -2, NULL },
@@ -235,7 +235,7 @@ static const mframe_t gunner_frames_pain2[] = {
     { ai_move, -2, NULL },
     { ai_move, -7, NULL }
 };
-const mmove_t gunner_move_pain2 = {FRAME_pain201, FRAME_pain208, gunner_frames_pain2, gunner_run};
+DEFINE_MMOVE(gunner_move_pain2, FRAME_pain201, FRAME_pain208, gunner_frames_pain2, gunner_run);
 
 static const mframe_t gunner_frames_pain1[] = {
     { ai_move, 2,  NULL },
@@ -257,7 +257,7 @@ static const mframe_t gunner_frames_pain1[] = {
     { ai_move, 0,  NULL },
     { ai_move, 0,  NULL }
 };
-const mmove_t gunner_move_pain1 = {FRAME_pain101, FRAME_pain118, gunner_frames_pain1, gunner_run};
+DEFINE_MMOVE(gunner_move_pain1, FRAME_pain101, FRAME_pain118, gunner_frames_pain1, gunner_run);
 
 void gunner_pain(edict_t *self, edict_t *other, float kick, int damage)
 {
@@ -308,7 +308,7 @@ static const mframe_t gunner_frames_death[] = {
     { ai_move, 0,  NULL },
     { ai_move, 0,  NULL }
 };
-const mmove_t gunner_move_death = {FRAME_death01, FRAME_death11, gunner_frames_death, gunner_dead};
+DEFINE_MMOVE(gunner_move_death, FRAME_death01, FRAME_death11, gunner_frames_death, gunner_dead);
 
 void gunner_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage, vec3_t point)
 {
@@ -378,7 +378,7 @@ static const mframe_t gunner_frames_duck[] = {
     { ai_move, 0,  gunner_duck_up },
     { ai_move, -1, NULL }
 };
-const mmove_t gunner_move_duck = {FRAME_duck01, FRAME_duck08, gunner_frames_duck, gunner_run};
+DEFINE_MMOVE(gunner_move_duck, FRAME_duck01, FRAME_duck08, gunner_frames_duck, gunner_run);
 
 void gunner_dodge(edict_t *self, edict_t *attacker, float eta)
 {
@@ -453,7 +453,7 @@ static const mframe_t gunner_frames_attack_chain[] = {
     { ai_charge, 0, NULL },
     { ai_charge, 0, NULL }
 };
-const mmove_t gunner_move_attack_chain = {FRAME_attak209, FRAME_attak215, gunner_frames_attack_chain, gunner_fire_chain};
+DEFINE_MMOVE(gunner_move_attack_chain, FRAME_attak209, FRAME_attak215, gunner_frames_attack_chain, gunner_fire_chain);
 
 static const mframe_t gunner_frames_fire_chain[] = {
     { ai_charge,   0, GunnerFire },
@@ -465,7 +465,7 @@ static const mframe_t gunner_frames_fire_chain[] = {
     { ai_charge,   0, GunnerFire },
     { ai_charge,   0, GunnerFire }
 };
-const mmove_t gunner_move_fire_chain = {FRAME_attak216, FRAME_attak223, gunner_frames_fire_chain, gunner_refire_chain};
+DEFINE_MMOVE(gunner_move_fire_chain, FRAME_attak216, FRAME_attak223, gunner_frames_fire_chain, gunner_refire_chain);
 
 static const mframe_t gunner_frames_endfire_chain[] = {
     { ai_charge, 0, NULL },
@@ -476,7 +476,7 @@ static const mframe_t gunner_frames_endfire_chain[] = {
     { ai_charge, 0, NULL },
     { ai_charge, 0, NULL }
 };
-const mmove_t gunner_move_endfire_chain = {FRAME_attak224, FRAME_attak230, gunner_frames_endfire_chain, gunner_run};
+DEFINE_MMOVE(gunner_move_endfire_chain, FRAME_attak224, FRAME_attak230, gunner_frames_endfire_chain, gunner_run);
 
 static const mframe_t gunner_frames_attack_grenade[] = {
     { ai_charge, 0, NULL },
@@ -501,7 +501,7 @@ static const mframe_t gunner_frames_attack_grenade[] = {
     { ai_charge, 0, NULL },
     { ai_charge, 0, NULL }
 };
-const mmove_t gunner_move_attack_grenade = {FRAME_attak101, FRAME_attak121, gunner_frames_attack_grenade, gunner_run};
+DEFINE_MMOVE(gunner_move_attack_grenade, FRAME_attak101, FRAME_attak121, gunner_frames_attack_grenade, gunner_run);
 
 void gunner_attack(edict_t *self)
 {

--- a/src/game/m_hover.cpp
+++ b/src/game/m_hover.cpp
@@ -88,7 +88,7 @@ static const mframe_t hover_frames_stand[] = {
     { ai_stand, 0, NULL },
     { ai_stand, 0, NULL }
 };
-const mmove_t hover_move_stand = {FRAME_stand01, FRAME_stand30, hover_frames_stand, NULL};
+DEFINE_MMOVE(hover_move_stand, FRAME_stand01, FRAME_stand30, hover_frames_stand, NULL);
 
 static const mframe_t hover_frames_stop1[] = {
     { ai_move,    0,  NULL },
@@ -101,7 +101,7 @@ static const mframe_t hover_frames_stop1[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t hover_move_stop1 = {FRAME_stop101, FRAME_stop109, hover_frames_stop1, NULL};
+DEFINE_MMOVE(hover_move_stop1, FRAME_stop101, FRAME_stop109, hover_frames_stop1, NULL);
 
 static const mframe_t hover_frames_stop2[] = {
     { ai_move,    0,  NULL },
@@ -113,7 +113,7 @@ static const mframe_t hover_frames_stop2[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t hover_move_stop2 = {FRAME_stop201, FRAME_stop208, hover_frames_stop2, NULL};
+DEFINE_MMOVE(hover_move_stop2, FRAME_stop201, FRAME_stop208, hover_frames_stop2, NULL);
 
 static const mframe_t hover_frames_takeoff[] = {
     { ai_move,    0,  NULL },
@@ -147,7 +147,7 @@ static const mframe_t hover_frames_takeoff[] = {
     { ai_move,    2,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t hover_move_takeoff = {FRAME_takeof01, FRAME_takeof30, hover_frames_takeoff, NULL};
+DEFINE_MMOVE(hover_move_takeoff, FRAME_takeof01, FRAME_takeof30, hover_frames_takeoff, NULL);
 
 static const mframe_t hover_frames_pain3[] = {
     { ai_move,    0,  NULL },
@@ -160,7 +160,7 @@ static const mframe_t hover_frames_pain3[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t hover_move_pain3 = {FRAME_pain301, FRAME_pain309, hover_frames_pain3, hover_run};
+DEFINE_MMOVE(hover_move_pain3, FRAME_pain301, FRAME_pain309, hover_frames_pain3, hover_run);
 
 static const mframe_t hover_frames_pain2[] = {
     { ai_move,    0,  NULL },
@@ -176,7 +176,7 @@ static const mframe_t hover_frames_pain2[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t hover_move_pain2 = {FRAME_pain201, FRAME_pain212, hover_frames_pain2, hover_run};
+DEFINE_MMOVE(hover_move_pain2, FRAME_pain201, FRAME_pain212, hover_frames_pain2, hover_run);
 
 static const mframe_t hover_frames_pain1[] = {
     { ai_move,    0,  NULL },
@@ -208,12 +208,12 @@ static const mframe_t hover_frames_pain1[] = {
     { ai_move,    3,  NULL },
     { ai_move,    4,  NULL }
 };
-const mmove_t hover_move_pain1 = {FRAME_pain101, FRAME_pain128, hover_frames_pain1, hover_run};
+DEFINE_MMOVE(hover_move_pain1, FRAME_pain101, FRAME_pain128, hover_frames_pain1, hover_run);
 
 static const mframe_t hover_frames_land[] = {
     { ai_move,    0,  NULL }
 };
-const mmove_t hover_move_land = {FRAME_land01, FRAME_land01, hover_frames_land, NULL};
+DEFINE_MMOVE(hover_move_land, FRAME_land01, FRAME_land01, hover_frames_land, NULL);
 
 static const mframe_t hover_frames_forward[] = {
     { ai_move,    0,  NULL },
@@ -252,7 +252,7 @@ static const mframe_t hover_frames_forward[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t hover_move_forward = {FRAME_forwrd01, FRAME_forwrd35, hover_frames_forward, NULL};
+DEFINE_MMOVE(hover_move_forward, FRAME_forwrd01, FRAME_forwrd35, hover_frames_forward, NULL);
 
 static const mframe_t hover_frames_walk[] = {
     { ai_walk,    4,  NULL },
@@ -291,7 +291,7 @@ static const mframe_t hover_frames_walk[] = {
     { ai_walk,    4,  NULL },
     { ai_walk,    4,  NULL }
 };
-const mmove_t hover_move_walk = {FRAME_forwrd01, FRAME_forwrd35, hover_frames_walk, NULL};
+DEFINE_MMOVE(hover_move_walk, FRAME_forwrd01, FRAME_forwrd35, hover_frames_walk, NULL);
 
 static const mframe_t hover_frames_run[] = {
     { ai_run, 10, NULL },
@@ -330,7 +330,7 @@ static const mframe_t hover_frames_run[] = {
     { ai_run, 10, NULL },
     { ai_run, 10, NULL }
 };
-const mmove_t hover_move_run = {FRAME_forwrd01, FRAME_forwrd35, hover_frames_run, NULL};
+DEFINE_MMOVE(hover_move_run, FRAME_forwrd01, FRAME_forwrd35, hover_frames_run, NULL);
 
 static const mframe_t hover_frames_death1[] = {
     { ai_move,    0,  NULL },
@@ -345,7 +345,7 @@ static const mframe_t hover_frames_death1[] = {
     { ai_move,    4,  NULL },
     { ai_move,    7,  NULL }
 };
-const mmove_t hover_move_death1 = {FRAME_death101, FRAME_death111, hover_frames_death1, hover_dead};
+DEFINE_MMOVE(hover_move_death1, FRAME_death101, FRAME_death111, hover_frames_death1, hover_dead);
 
 static const mframe_t hover_frames_backward[] = {
     { ai_move,    0,  NULL },
@@ -373,27 +373,27 @@ static const mframe_t hover_frames_backward[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t hover_move_backward = {FRAME_backwd01, FRAME_backwd24, hover_frames_backward, NULL};
+DEFINE_MMOVE(hover_move_backward, FRAME_backwd01, FRAME_backwd24, hover_frames_backward, NULL);
 
 static const mframe_t hover_frames_start_attack[] = {
     { ai_charge,  1,  NULL },
     { ai_charge,  1,  NULL },
     { ai_charge,  1,  NULL }
 };
-const mmove_t hover_move_start_attack = {FRAME_attak101, FRAME_attak103, hover_frames_start_attack, hover_attack};
+DEFINE_MMOVE(hover_move_start_attack, FRAME_attak101, FRAME_attak103, hover_frames_start_attack, hover_attack);
 
 static const mframe_t hover_frames_attack1[] = {
     { ai_charge,  -10,    hover_fire_blaster },
     { ai_charge,  -10,    hover_fire_blaster },
     { ai_charge,  0,      hover_reattack },
 };
-const mmove_t hover_move_attack1 = {FRAME_attak104, FRAME_attak106, hover_frames_attack1, NULL};
+DEFINE_MMOVE(hover_move_attack1, FRAME_attak104, FRAME_attak106, hover_frames_attack1, NULL);
 
 static const mframe_t hover_frames_end_attack[] = {
     { ai_charge,  1,  NULL },
     { ai_charge,  1,  NULL }
 };
-const mmove_t hover_move_end_attack = {FRAME_attak107, FRAME_attak108, hover_frames_end_attack, hover_run};
+DEFINE_MMOVE(hover_move_end_attack, FRAME_attak107, FRAME_attak108, hover_frames_end_attack, hover_run);
 
 static void hover_reattack(edict_t *self)
 {

--- a/src/game/m_infantry.cpp
+++ b/src/game/m_infantry.cpp
@@ -65,7 +65,7 @@ static const mframe_t infantry_frames_stand[] = {
     { ai_stand, 0, NULL },
     { ai_stand, 0, NULL }
 };
-const mmove_t infantry_move_stand = {FRAME_stand50, FRAME_stand71, infantry_frames_stand, NULL};
+DEFINE_MMOVE(infantry_move_stand, FRAME_stand50, FRAME_stand71, infantry_frames_stand, NULL);
 
 void infantry_stand(edict_t *self)
 {
@@ -123,7 +123,7 @@ static const mframe_t infantry_frames_fidget[] = {
     { ai_stand, -3, NULL },
     { ai_stand, -2, NULL }
 };
-const mmove_t infantry_move_fidget = {FRAME_stand01, FRAME_stand49, infantry_frames_fidget, infantry_stand};
+DEFINE_MMOVE(infantry_move_fidget, FRAME_stand01, FRAME_stand49, infantry_frames_fidget, infantry_stand);
 
 void infantry_fidget(edict_t *self)
 {
@@ -145,7 +145,7 @@ static const mframe_t infantry_frames_walk[] = {
     { ai_walk, 4,  NULL },
     { ai_walk, 5,  NULL }
 };
-const mmove_t infantry_move_walk = {FRAME_walk03, FRAME_walk14, infantry_frames_walk, NULL};
+DEFINE_MMOVE(infantry_move_walk, FRAME_walk03, FRAME_walk14, infantry_frames_walk, NULL);
 
 void infantry_walk(edict_t *self)
 {
@@ -162,7 +162,7 @@ static const mframe_t infantry_frames_run[] = {
     { ai_run, 2,  NULL },
     { ai_run, 6,  NULL }
 };
-const mmove_t infantry_move_run = {FRAME_run01, FRAME_run08, infantry_frames_run, NULL};
+DEFINE_MMOVE(infantry_move_run, FRAME_run01, FRAME_run08, infantry_frames_run, NULL);
 
 void infantry_run(edict_t *self)
 {
@@ -184,7 +184,7 @@ static const mframe_t infantry_frames_pain1[] = {
     { ai_move, 6,  NULL },
     { ai_move, 2,  NULL }
 };
-const mmove_t infantry_move_pain1 = {FRAME_pain101, FRAME_pain110, infantry_frames_pain1, infantry_run};
+DEFINE_MMOVE(infantry_move_pain1, FRAME_pain101, FRAME_pain110, infantry_frames_pain1, infantry_run);
 
 static const mframe_t infantry_frames_pain2[] = {
     { ai_move, -3, NULL },
@@ -198,7 +198,7 @@ static const mframe_t infantry_frames_pain2[] = {
     { ai_move, 5,  NULL },
     { ai_move, 2,  NULL }
 };
-const mmove_t infantry_move_pain2 = {FRAME_pain201, FRAME_pain210, infantry_frames_pain2, infantry_run};
+DEFINE_MMOVE(infantry_move_pain2, FRAME_pain201, FRAME_pain210, infantry_frames_pain2, infantry_run);
 
 void infantry_pain(edict_t *self, edict_t *other, float kick, int damage)
 {
@@ -311,7 +311,7 @@ static const mframe_t infantry_frames_death1[] = {
     { ai_move, -3, NULL },
     { ai_move, -3, NULL }
 };
-const mmove_t infantry_move_death1 = {FRAME_death101, FRAME_death120, infantry_frames_death1, infantry_dead};
+DEFINE_MMOVE(infantry_move_death1, FRAME_death101, FRAME_death120, infantry_frames_death1, infantry_dead);
 
 // Off with his head
 static const mframe_t infantry_frames_death2[] = {
@@ -341,7 +341,7 @@ static const mframe_t infantry_frames_death2[] = {
     { ai_move, 4,   NULL },
     { ai_move, 0,   NULL }
 };
-const mmove_t infantry_move_death2 = {FRAME_death201, FRAME_death225, infantry_frames_death2, infantry_dead};
+DEFINE_MMOVE(infantry_move_death2, FRAME_death201, FRAME_death225, infantry_frames_death2, infantry_dead);
 
 static const mframe_t infantry_frames_death3[] = {
     { ai_move, 0,   NULL },
@@ -354,7 +354,7 @@ static const mframe_t infantry_frames_death3[] = {
     { ai_move, 0,   NULL },
     { ai_move, 0,   NULL }
 };
-const mmove_t infantry_move_death3 = {FRAME_death301, FRAME_death309, infantry_frames_death3, infantry_dead};
+DEFINE_MMOVE(infantry_move_death3, FRAME_death301, FRAME_death309, infantry_frames_death3, infantry_dead);
 
 void infantry_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage, vec3_t point)
 {
@@ -426,7 +426,7 @@ static const mframe_t infantry_frames_duck[] = {
     { ai_move, 4,  infantry_duck_up },
     { ai_move, 0,  NULL }
 };
-const mmove_t infantry_move_duck = {FRAME_duck01, FRAME_duck05, infantry_frames_duck, infantry_run};
+DEFINE_MMOVE(infantry_move_duck, FRAME_duck01, FRAME_duck05, infantry_frames_duck, infantry_run);
 
 void infantry_dodge(edict_t *self, edict_t *attacker, float eta)
 {
@@ -475,7 +475,7 @@ static const mframe_t infantry_frames_attack1[] = {
     { ai_charge, -2, NULL },
     { ai_charge, -3, NULL }
 };
-const mmove_t infantry_move_attack1 = {FRAME_attak101, FRAME_attak115, infantry_frames_attack1, infantry_run};
+DEFINE_MMOVE(infantry_move_attack1, FRAME_attak101, FRAME_attak115, infantry_frames_attack1, infantry_run);
 
 static void infantry_swing(edict_t *self)
 {
@@ -500,7 +500,7 @@ static const mframe_t infantry_frames_attack2[] = {
     { ai_charge, 6, NULL },
     { ai_charge, 3, NULL },
 };
-const mmove_t infantry_move_attack2 = {FRAME_attak201, FRAME_attak208, infantry_frames_attack2, infantry_run};
+DEFINE_MMOVE(infantry_move_attack2, FRAME_attak201, FRAME_attak208, infantry_frames_attack2, infantry_run);
 
 void infantry_attack(edict_t *self)
 {

--- a/src/game/m_insane.cpp
+++ b/src/game/m_insane.cpp
@@ -69,7 +69,7 @@ static const mframe_t insane_frames_stand_normal[] = {
     { ai_stand, 0, NULL },
     { ai_stand, 0, insane_checkdown }
 };
-const mmove_t insane_move_stand_normal = {FRAME_stand60, FRAME_stand65, insane_frames_stand_normal, insane_stand};
+DEFINE_MMOVE(insane_move_stand_normal, FRAME_stand60, FRAME_stand65, insane_frames_stand_normal, insane_stand);
 
 static const mframe_t insane_frames_stand_insane[] = {
     { ai_stand,   0,  insane_shake },
@@ -103,7 +103,7 @@ static const mframe_t insane_frames_stand_insane[] = {
     { ai_stand,   0,  NULL },
     { ai_stand,   0,  insane_checkdown }
 };
-const mmove_t insane_move_stand_insane = {FRAME_stand65, FRAME_stand94, insane_frames_stand_insane, insane_stand};
+DEFINE_MMOVE(insane_move_stand_insane, FRAME_stand65, FRAME_stand94, insane_frames_stand_insane, insane_stand);
 
 static const mframe_t insane_frames_uptodown[] = {
     { ai_move,    0,  NULL },
@@ -150,7 +150,7 @@ static const mframe_t insane_frames_uptodown[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t insane_move_uptodown = {FRAME_stand1, FRAME_stand40, insane_frames_uptodown, insane_onground};
+DEFINE_MMOVE(insane_move_uptodown, FRAME_stand1, FRAME_stand40, insane_frames_uptodown, insane_onground);
 
 static const mframe_t insane_frames_downtoup[] = {
     { ai_move,    -0.7,   NULL },           // 41
@@ -173,7 +173,7 @@ static const mframe_t insane_frames_downtoup[] = {
     { ai_move,    0,  NULL },               // 58
     { ai_move,    0,  NULL }                // 59
 };
-const mmove_t insane_move_downtoup = {FRAME_stand41, FRAME_stand59, insane_frames_downtoup, insane_stand};
+DEFINE_MMOVE(insane_move_downtoup, FRAME_stand41, FRAME_stand59, insane_frames_downtoup, insane_stand);
 
 static const mframe_t insane_frames_jumpdown[] = {
     { ai_move,    0.2,    NULL },
@@ -182,7 +182,7 @@ static const mframe_t insane_frames_jumpdown[] = {
     { ai_move,    7.1,    NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t insane_move_jumpdown = {FRAME_stand96, FRAME_stand100, insane_frames_jumpdown, insane_onground};
+DEFINE_MMOVE(insane_move_jumpdown, FRAME_stand96, FRAME_stand100, insane_frames_jumpdown, insane_onground);
 
 static const mframe_t insane_frames_down[] = {
     { ai_move,    0,      NULL },       // 100
@@ -247,7 +247,7 @@ static const mframe_t insane_frames_down[] = {
     { ai_move,    0.7,        NULL },
     { ai_move,    0,      insane_checkup }      // 160
 };
-const mmove_t insane_move_down = {FRAME_stand100, FRAME_stand160, insane_frames_down, insane_onground};
+DEFINE_MMOVE(insane_move_down, FRAME_stand100, FRAME_stand160, insane_frames_down, insane_onground);
 
 static const mframe_t insane_frames_walk_normal[] = {
     { ai_walk,    0,      insane_scream },
@@ -264,8 +264,8 @@ static const mframe_t insane_frames_walk_normal[] = {
     { ai_walk,    0.9,    NULL },
     { ai_walk,    0,      NULL }
 };
-const mmove_t insane_move_walk_normal = {FRAME_walk27, FRAME_walk39, insane_frames_walk_normal, insane_walk};
-const mmove_t insane_move_run_normal = {FRAME_walk27, FRAME_walk39, insane_frames_walk_normal, insane_run};
+DEFINE_MMOVE(insane_move_walk_normal, FRAME_walk27, FRAME_walk39, insane_frames_walk_normal, insane_walk);
+DEFINE_MMOVE(insane_move_run_normal, FRAME_walk27, FRAME_walk39, insane_frames_walk_normal, insane_run);
 
 static const mframe_t insane_frames_walk_insane[] = {
     { ai_walk,    0,      insane_scream },      // walk 1
@@ -295,8 +295,8 @@ static const mframe_t insane_frames_walk_insane[] = {
     { ai_walk,    1.8,    NULL },       // 25
     { ai_walk,    0,      NULL }        // 26
 };
-const mmove_t insane_move_walk_insane = {FRAME_walk1, FRAME_walk26, insane_frames_walk_insane, insane_walk};
-const mmove_t insane_move_run_insane = {FRAME_walk1, FRAME_walk26, insane_frames_walk_insane, insane_run};
+DEFINE_MMOVE(insane_move_walk_insane, FRAME_walk1, FRAME_walk26, insane_frames_walk_insane, insane_walk);
+DEFINE_MMOVE(insane_move_run_insane, FRAME_walk1, FRAME_walk26, insane_frames_walk_insane, insane_run);
 
 static const mframe_t insane_frames_stand_pain[] = {
     { ai_move,    0,      NULL },
@@ -311,7 +311,7 @@ static const mframe_t insane_frames_stand_pain[] = {
     { ai_move,    0,      NULL },
     { ai_move,    0,      NULL }
 };
-const mmove_t insane_move_stand_pain = {FRAME_st_pain2, FRAME_st_pain12, insane_frames_stand_pain, insane_run};
+DEFINE_MMOVE(insane_move_stand_pain, FRAME_st_pain2, FRAME_st_pain12, insane_frames_stand_pain, insane_run);
 
 static const mframe_t insane_frames_stand_death[] = {
     { ai_move,    0,      NULL },
@@ -332,7 +332,7 @@ static const mframe_t insane_frames_stand_death[] = {
     { ai_move,    0,      NULL },
     { ai_move,    0,      NULL }
 };
-const mmove_t insane_move_stand_death = {FRAME_st_death2, FRAME_st_death18, insane_frames_stand_death, insane_dead};
+DEFINE_MMOVE(insane_move_stand_death, FRAME_st_death2, FRAME_st_death18, insane_frames_stand_death, insane_dead);
 
 static const mframe_t insane_frames_crawl[] = {
     { ai_walk,    0,      insane_scream },
@@ -345,8 +345,8 @@ static const mframe_t insane_frames_crawl[] = {
     { ai_walk,    3.4,    NULL },
     { ai_walk,    2.4,    NULL }
 };
-const mmove_t insane_move_crawl = {FRAME_crawl1, FRAME_crawl9, insane_frames_crawl, NULL};
-const mmove_t insane_move_runcrawl = {FRAME_crawl1, FRAME_crawl9, insane_frames_crawl, NULL};
+DEFINE_MMOVE(insane_move_crawl, FRAME_crawl1, FRAME_crawl9, insane_frames_crawl, NULL);
+DEFINE_MMOVE(insane_move_runcrawl, FRAME_crawl1, FRAME_crawl9, insane_frames_crawl, NULL);
 
 static const mframe_t insane_frames_crawl_pain[] = {
     { ai_move,    0,      NULL },
@@ -359,7 +359,7 @@ static const mframe_t insane_frames_crawl_pain[] = {
     { ai_move,    0,      NULL },
     { ai_move,    0,      NULL }
 };
-const mmove_t insane_move_crawl_pain = {FRAME_cr_pain2, FRAME_cr_pain10, insane_frames_crawl_pain, insane_run};
+DEFINE_MMOVE(insane_move_crawl_pain, FRAME_cr_pain2, FRAME_cr_pain10, insane_frames_crawl_pain, insane_run);
 
 static const mframe_t insane_frames_crawl_death[] = {
     { ai_move,    0,      NULL },
@@ -370,7 +370,7 @@ static const mframe_t insane_frames_crawl_death[] = {
     { ai_move,    0,      NULL },
     { ai_move,    0,      NULL }
 };
-const mmove_t insane_move_crawl_death = {FRAME_cr_death10, FRAME_cr_death16, insane_frames_crawl_death, insane_dead};
+DEFINE_MMOVE(insane_move_crawl_death, FRAME_cr_death10, FRAME_cr_death16, insane_frames_crawl_death, insane_dead);
 
 static const mframe_t insane_frames_cross[] = {
     { ai_move,    0,      insane_moan },
@@ -389,7 +389,7 @@ static const mframe_t insane_frames_cross[] = {
     { ai_move,    0,      NULL },
     { ai_move,    0,      NULL }
 };
-const mmove_t insane_move_cross = {FRAME_cross1, FRAME_cross15, insane_frames_cross, insane_cross};
+DEFINE_MMOVE(insane_move_cross, FRAME_cross1, FRAME_cross15, insane_frames_cross, insane_cross);
 
 static const mframe_t insane_frames_struggle_cross[] = {
     { ai_move,    0,      insane_scream },
@@ -408,7 +408,7 @@ static const mframe_t insane_frames_struggle_cross[] = {
     { ai_move,    0,      NULL },
     { ai_move,    0,      NULL }
 };
-const mmove_t insane_move_struggle_cross = {FRAME_cross16, FRAME_cross30, insane_frames_struggle_cross, insane_cross};
+DEFINE_MMOVE(insane_move_struggle_cross, FRAME_cross16, FRAME_cross30, insane_frames_struggle_cross, insane_cross);
 
 static void insane_cross(edict_t *self)
 {

--- a/src/game/m_medic.cpp
+++ b/src/game/m_medic.cpp
@@ -200,7 +200,7 @@ static const mframe_t medic_frames_stand[] = {
     { ai_stand, 0, NULL },
 
 };
-const mmove_t medic_move_stand = {FRAME_wait1, FRAME_wait90, medic_frames_stand, NULL};
+DEFINE_MMOVE(medic_move_stand, FRAME_wait1, FRAME_wait90, medic_frames_stand, NULL);
 
 void medic_stand(edict_t *self)
 {
@@ -221,7 +221,7 @@ static const mframe_t medic_frames_walk[] = {
     { ai_walk, 14,    NULL },
     { ai_walk, 9.3,   NULL }
 };
-const mmove_t medic_move_walk = {FRAME_walk1, FRAME_walk12, medic_frames_walk, NULL};
+DEFINE_MMOVE(medic_move_walk, FRAME_walk1, FRAME_walk12, medic_frames_walk, NULL);
 
 void medic_walk(edict_t *self)
 {
@@ -237,7 +237,7 @@ static const mframe_t medic_frames_run[] = {
     { ai_run, 35.6,   NULL }
 
 };
-const mmove_t medic_move_run = {FRAME_run1, FRAME_run6, medic_frames_run, NULL};
+DEFINE_MMOVE(medic_move_run, FRAME_run1, FRAME_run6, medic_frames_run, NULL);
 
 void medic_run(edict_t *self)
 {
@@ -271,7 +271,7 @@ static const mframe_t medic_frames_pain1[] = {
     { ai_move, 0, NULL },
     { ai_move, 0, NULL }
 };
-const mmove_t medic_move_pain1 = {FRAME_paina1, FRAME_paina8, medic_frames_pain1, medic_run};
+DEFINE_MMOVE(medic_move_pain1, FRAME_paina1, FRAME_paina8, medic_frames_pain1, medic_run);
 
 static const mframe_t medic_frames_pain2[] = {
     { ai_move, 0, NULL },
@@ -290,7 +290,7 @@ static const mframe_t medic_frames_pain2[] = {
     { ai_move, 0, NULL },
     { ai_move, 0, NULL }
 };
-const mmove_t medic_move_pain2 = {FRAME_painb1, FRAME_painb15, medic_frames_pain2, medic_run};
+DEFINE_MMOVE(medic_move_pain2, FRAME_painb1, FRAME_painb15, medic_frames_pain2, medic_run);
 
 void medic_pain(edict_t *self, edict_t *other, float kick, int damage)
 {
@@ -381,7 +381,7 @@ static const mframe_t medic_frames_death[] = {
     { ai_move, 0, NULL },
     { ai_move, 0, NULL }
 };
-const mmove_t medic_move_death = {FRAME_death1, FRAME_death30, medic_frames_death, medic_dead};
+DEFINE_MMOVE(medic_move_death, FRAME_death1, FRAME_death30, medic_frames_death, medic_dead);
 
 void medic_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage, vec3_t point)
 {
@@ -459,7 +459,7 @@ static const mframe_t medic_frames_duck[] = {
     { ai_move, -1,    NULL },
     { ai_move, -1,    NULL }
 };
-const mmove_t medic_move_duck = {FRAME_duck1, FRAME_duck16, medic_frames_duck, medic_run};
+DEFINE_MMOVE(medic_move_duck, FRAME_duck1, FRAME_duck16, medic_frames_duck, medic_run);
 
 void medic_dodge(edict_t *self, edict_t *attacker, float eta)
 {
@@ -490,7 +490,7 @@ static const mframe_t medic_frames_attackHyperBlaster[] = {
     { ai_charge, 0,   medic_fire_blaster },
     { ai_charge, 0,   medic_fire_blaster }
 };
-const mmove_t medic_move_attackHyperBlaster = {FRAME_attack15, FRAME_attack30, medic_frames_attackHyperBlaster, medic_run};
+DEFINE_MMOVE(medic_move_attackHyperBlaster, FRAME_attack15, FRAME_attack30, medic_frames_attackHyperBlaster, medic_run);
 
 static void medic_continue(edict_t *self)
 {
@@ -515,7 +515,7 @@ static const mframe_t medic_frames_attackBlaster[] = {
     { ai_charge, 0,   NULL },
     { ai_charge, 0,   medic_continue }  // Change to medic_continue... Else, go to frame 32
 };
-const mmove_t medic_move_attackBlaster = {FRAME_attack1, FRAME_attack14, medic_frames_attackBlaster, medic_run};
+DEFINE_MMOVE(medic_move_attackBlaster, FRAME_attack1, FRAME_attack14, medic_frames_attackBlaster, medic_run);
 
 static void medic_hook_launch(edict_t *self)
 {
@@ -644,7 +644,7 @@ static const mframe_t medic_frames_attackCable[] = {
     { ai_move, 1.2,   NULL },
     { ai_move, 1.3,   NULL }
 };
-const mmove_t medic_move_attackCable = {FRAME_attack33, FRAME_attack60, medic_frames_attackCable, medic_run};
+DEFINE_MMOVE(medic_move_attackCable, FRAME_attack33, FRAME_attack60, medic_frames_attackCable, medic_run);
 
 void medic_attack(edict_t *self)
 {

--- a/src/game/m_mutant.cpp
+++ b/src/game/m_mutant.cpp
@@ -128,7 +128,7 @@ static const mframe_t mutant_frames_stand[] = {
 
     { ai_stand, 0, NULL }
 };
-const mmove_t mutant_move_stand = {FRAME_stand101, FRAME_stand151, mutant_frames_stand, NULL};
+DEFINE_MMOVE(mutant_move_stand, FRAME_stand101, FRAME_stand151, mutant_frames_stand, NULL);
 
 void mutant_stand(edict_t *self)
 {
@@ -160,7 +160,7 @@ static const mframe_t mutant_frames_idle[] = {
     { ai_stand, 0, NULL },
     { ai_stand, 0, NULL }
 };
-const mmove_t mutant_move_idle = {FRAME_stand152, FRAME_stand164, mutant_frames_idle, mutant_stand};
+DEFINE_MMOVE(mutant_move_idle, FRAME_stand152, FRAME_stand164, mutant_frames_idle, mutant_stand);
 
 void mutant_idle(edict_t *self)
 {
@@ -188,7 +188,7 @@ static const mframe_t mutant_frames_walk[] = {
     { ai_walk,    15,     NULL },
     { ai_walk,    6,      NULL }
 };
-const mmove_t mutant_move_walk = {FRAME_walk05, FRAME_walk16, mutant_frames_walk, NULL};
+DEFINE_MMOVE(mutant_move_walk, FRAME_walk05, FRAME_walk16, mutant_frames_walk, NULL);
 
 static void mutant_walk_loop(edict_t *self)
 {
@@ -201,7 +201,7 @@ static const mframe_t mutant_frames_start_walk[] = {
     { ai_walk,    -2,     NULL },
     { ai_walk,    1,      NULL }
 };
-const mmove_t mutant_move_start_walk = {FRAME_walk01, FRAME_walk04, mutant_frames_start_walk, mutant_walk_loop};
+DEFINE_MMOVE(mutant_move_start_walk, FRAME_walk01, FRAME_walk04, mutant_frames_start_walk, mutant_walk_loop);
 
 void mutant_walk(edict_t *self)
 {
@@ -220,7 +220,7 @@ static const mframe_t mutant_frames_run[] = {
     { ai_run, 17,     NULL },
     { ai_run, 10,     NULL }
 };
-const mmove_t mutant_move_run = {FRAME_run03, FRAME_run08, mutant_frames_run, NULL};
+DEFINE_MMOVE(mutant_move_run, FRAME_run03, FRAME_run08, mutant_frames_run, NULL);
 
 void mutant_run(edict_t *self)
 {
@@ -272,7 +272,7 @@ static const mframe_t mutant_frames_attack[] = {
     { ai_charge,  0,  mutant_hit_right },
     { ai_charge,  0,  mutant_check_refire }
 };
-const mmove_t mutant_move_attack = {FRAME_attack09, FRAME_attack15, mutant_frames_attack, mutant_run};
+DEFINE_MMOVE(mutant_move_attack, FRAME_attack09, FRAME_attack15, mutant_frames_attack, mutant_run);
 
 void mutant_melee(edict_t *self)
 {
@@ -355,7 +355,7 @@ static const mframe_t mutant_frames_jump[] = {
     { ai_charge,   3, NULL },
     { ai_charge,   0, NULL }
 };
-const mmove_t mutant_move_jump = {FRAME_attack01, FRAME_attack08, mutant_frames_jump, mutant_run};
+DEFINE_MMOVE(mutant_move_jump, FRAME_attack01, FRAME_attack08, mutant_frames_jump, mutant_run);
 
 void mutant_jump(edict_t *self)
 {
@@ -429,7 +429,7 @@ static const mframe_t mutant_frames_pain1[] = {
     { ai_move,    2,  NULL },
     { ai_move,    5,  NULL }
 };
-const mmove_t mutant_move_pain1 = {FRAME_pain101, FRAME_pain105, mutant_frames_pain1, mutant_run};
+DEFINE_MMOVE(mutant_move_pain1, FRAME_pain101, FRAME_pain105, mutant_frames_pain1, mutant_run);
 
 static const mframe_t mutant_frames_pain2[] = {
     { ai_move,    -24, NULL },
@@ -439,7 +439,7 @@ static const mframe_t mutant_frames_pain2[] = {
     { ai_move,    6,  NULL },
     { ai_move,    4,  NULL }
 };
-const mmove_t mutant_move_pain2 = {FRAME_pain201, FRAME_pain206, mutant_frames_pain2, mutant_run};
+DEFINE_MMOVE(mutant_move_pain2, FRAME_pain201, FRAME_pain206, mutant_frames_pain2, mutant_run);
 
 static const mframe_t mutant_frames_pain3[] = {
     { ai_move,    -22, NULL },
@@ -454,7 +454,7 @@ static const mframe_t mutant_frames_pain3[] = {
     { ai_move,    0,  NULL },
     { ai_move,    1,  NULL }
 };
-const mmove_t mutant_move_pain3 = {FRAME_pain301, FRAME_pain311, mutant_frames_pain3, mutant_run};
+DEFINE_MMOVE(mutant_move_pain3, FRAME_pain301, FRAME_pain311, mutant_frames_pain3, mutant_run);
 
 void mutant_pain(edict_t *self, edict_t *other, float kick, int damage)
 {
@@ -510,7 +510,7 @@ static const mframe_t mutant_frames_death1[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t mutant_move_death1 = {FRAME_death101, FRAME_death109, mutant_frames_death1, mutant_dead};
+DEFINE_MMOVE(mutant_move_death1, FRAME_death101, FRAME_death109, mutant_frames_death1, mutant_dead);
 
 static const mframe_t mutant_frames_death2[] = {
     { ai_move,    0,  NULL },
@@ -524,7 +524,7 @@ static const mframe_t mutant_frames_death2[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t mutant_move_death2 = {FRAME_death201, FRAME_death210, mutant_frames_death2, mutant_dead};
+DEFINE_MMOVE(mutant_move_death2, FRAME_death201, FRAME_death210, mutant_frames_death2, mutant_dead);
 
 void mutant_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage, vec3_t point)
 {

--- a/src/game/m_parasite.cpp
+++ b/src/game/m_parasite.cpp
@@ -77,7 +77,7 @@ static const mframe_t parasite_frames_start_fidget[] = {
     { ai_stand, 0, NULL },
     { ai_stand, 0, NULL }
 };
-const mmove_t parasite_move_start_fidget = {FRAME_stand18, FRAME_stand21, parasite_frames_start_fidget, parasite_do_fidget};
+DEFINE_MMOVE(parasite_move_start_fidget, FRAME_stand18, FRAME_stand21, parasite_frames_start_fidget, parasite_do_fidget);
 
 static const mframe_t parasite_frames_fidget[] = {
     { ai_stand, 0, parasite_scratch },
@@ -87,7 +87,7 @@ static const mframe_t parasite_frames_fidget[] = {
     { ai_stand, 0, NULL },
     { ai_stand, 0, NULL }
 };
-const mmove_t parasite_move_fidget = {FRAME_stand22, FRAME_stand27, parasite_frames_fidget, parasite_refidget};
+DEFINE_MMOVE(parasite_move_fidget, FRAME_stand22, FRAME_stand27, parasite_frames_fidget, parasite_refidget);
 
 static const mframe_t parasite_frames_end_fidget[] = {
     { ai_stand, 0, parasite_scratch },
@@ -99,7 +99,7 @@ static const mframe_t parasite_frames_end_fidget[] = {
     { ai_stand, 0, NULL },
     { ai_stand, 0, NULL }
 };
-const mmove_t parasite_move_end_fidget = {FRAME_stand28, FRAME_stand35, parasite_frames_end_fidget, parasite_stand};
+DEFINE_MMOVE(parasite_move_end_fidget, FRAME_stand28, FRAME_stand35, parasite_frames_end_fidget, parasite_stand);
 
 static void parasite_do_fidget(edict_t *self)
 {
@@ -138,7 +138,7 @@ static const mframe_t parasite_frames_stand[] = {
     { ai_stand, 0, NULL },
     { ai_stand, 0, parasite_tap }
 };
-const mmove_t parasite_move_stand = {FRAME_stand01, FRAME_stand17, parasite_frames_stand, parasite_stand};
+DEFINE_MMOVE(parasite_move_stand, FRAME_stand01, FRAME_stand17, parasite_frames_stand, parasite_stand);
 
 void parasite_stand(edict_t *self)
 {
@@ -154,13 +154,13 @@ static const mframe_t parasite_frames_run[] = {
     { ai_run, 28, NULL },
     { ai_run, 25, NULL }
 };
-const mmove_t parasite_move_run = {FRAME_run03, FRAME_run09, parasite_frames_run, NULL};
+DEFINE_MMOVE(parasite_move_run, FRAME_run03, FRAME_run09, parasite_frames_run, NULL);
 
 static const mframe_t parasite_frames_start_run[] = {
     { ai_run, 0,  NULL },
     { ai_run, 30, NULL },
 };
-const mmove_t parasite_move_start_run = {FRAME_run01, FRAME_run02, parasite_frames_start_run, parasite_run};
+DEFINE_MMOVE(parasite_move_start_run, FRAME_run01, FRAME_run02, parasite_frames_start_run, parasite_run);
 
 static const mframe_t parasite_frames_stop_run[] = {
     { ai_run, 20, NULL },
@@ -170,7 +170,7 @@ static const mframe_t parasite_frames_stop_run[] = {
     { ai_run, 0,  NULL },
     { ai_run, 0,  NULL }
 };
-const mmove_t parasite_move_stop_run = {FRAME_run10, FRAME_run15, parasite_frames_stop_run, NULL};
+DEFINE_MMOVE(parasite_move_stop_run, FRAME_run10, FRAME_run15, parasite_frames_stop_run, NULL);
 
 void parasite_start_run(edict_t *self)
 {
@@ -197,13 +197,13 @@ static const mframe_t parasite_frames_walk[] = {
     { ai_walk, 28, NULL },
     { ai_walk, 25, NULL }
 };
-const mmove_t parasite_move_walk = {FRAME_run03, FRAME_run09, parasite_frames_walk, parasite_walk};
+DEFINE_MMOVE(parasite_move_walk, FRAME_run03, FRAME_run09, parasite_frames_walk, parasite_walk);
 
 static const mframe_t parasite_frames_start_walk[] = {
     { ai_walk, 0, NULL },
     { ai_walk, 30, parasite_walk }
 };
-const mmove_t parasite_move_start_walk = {FRAME_run01, FRAME_run02, parasite_frames_start_walk, NULL};
+DEFINE_MMOVE(parasite_move_start_walk, FRAME_run01, FRAME_run02, parasite_frames_start_walk, NULL);
 
 static const mframe_t parasite_frames_stop_walk[] = {
     { ai_walk, 20, NULL },
@@ -213,7 +213,7 @@ static const mframe_t parasite_frames_stop_walk[] = {
     { ai_walk, 0,  NULL },
     { ai_walk, 0,  NULL }
 };
-const mmove_t parasite_move_stop_walk = {FRAME_run10, FRAME_run15, parasite_frames_stop_walk, NULL};
+DEFINE_MMOVE(parasite_move_stop_walk, FRAME_run10, FRAME_run15, parasite_frames_stop_walk, NULL);
 
 void parasite_start_walk(edict_t *self)
 {
@@ -238,7 +238,7 @@ static const mframe_t parasite_frames_pain1[] = {
     { ai_move, -7, NULL },
     { ai_move, 0, NULL }
 };
-const mmove_t parasite_move_pain1 = {FRAME_pain101, FRAME_pain111, parasite_frames_pain1, parasite_start_run};
+DEFINE_MMOVE(parasite_move_pain1, FRAME_pain101, FRAME_pain111, parasite_frames_pain1, parasite_start_run);
 
 void parasite_pain(edict_t *self, edict_t *other, float kick, int damage)
 {
@@ -345,7 +345,7 @@ static const mframe_t parasite_frames_drain[] = {
     { ai_charge, -3,  NULL },
     { ai_charge, 0,   NULL }
 };
-const mmove_t parasite_move_drain = {FRAME_drain01, FRAME_drain18, parasite_frames_drain, parasite_start_run};
+DEFINE_MMOVE(parasite_move_drain, FRAME_drain01, FRAME_drain18, parasite_frames_drain, parasite_start_run);
 
 void parasite_attack(edict_t *self)
 {
@@ -377,7 +377,7 @@ static const mframe_t parasite_frames_death[] = {
     { ai_move, 0,  NULL },
     { ai_move, 0,  NULL }
 };
-const mmove_t parasite_move_death = {FRAME_death101, FRAME_death107, parasite_frames_death, parasite_dead};
+DEFINE_MMOVE(parasite_move_death, FRAME_death101, FRAME_death107, parasite_frames_death, parasite_dead);
 
 void parasite_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage, vec3_t point)
 {

--- a/src/game/m_soldier.cpp
+++ b/src/game/m_soldier.cpp
@@ -89,7 +89,7 @@ static const mframe_t soldier_frames_stand1[] = {
     { ai_stand, 0, NULL },
     { ai_stand, 0, NULL }
 };
-const mmove_t soldier_move_stand1 = {FRAME_stand101, FRAME_stand130, soldier_frames_stand1, soldier_stand};
+DEFINE_MMOVE(soldier_move_stand1, FRAME_stand101, FRAME_stand130, soldier_frames_stand1, soldier_stand);
 
 static const mframe_t soldier_frames_stand3[] = {
     { ai_stand, 0, NULL },
@@ -135,7 +135,7 @@ static const mframe_t soldier_frames_stand3[] = {
     { ai_stand, 0, NULL },
     { ai_stand, 0, NULL }
 };
-const mmove_t soldier_move_stand3 = {FRAME_stand301, FRAME_stand339, soldier_frames_stand3, soldier_stand};
+DEFINE_MMOVE(soldier_move_stand3, FRAME_stand301, FRAME_stand339, soldier_frames_stand3, soldier_stand);
 
 void soldier_stand(edict_t *self)
 {
@@ -190,7 +190,7 @@ static const mframe_t soldier_frames_walk1[] = {
     { ai_walk, 0,  NULL },
     { ai_walk, 0,  NULL }
 };
-const mmove_t soldier_move_walk1 = {FRAME_walk101, FRAME_walk133, soldier_frames_walk1, NULL};
+DEFINE_MMOVE(soldier_move_walk1, FRAME_walk101, FRAME_walk133, soldier_frames_walk1, NULL);
 
 static const mframe_t soldier_frames_walk2[] = {
     { ai_walk, 4,  NULL },
@@ -204,7 +204,7 @@ static const mframe_t soldier_frames_walk2[] = {
     { ai_walk, 6,  NULL },
     { ai_walk, 7,  NULL }
 };
-const mmove_t soldier_move_walk2 = {FRAME_walk209, FRAME_walk218, soldier_frames_walk2, NULL};
+DEFINE_MMOVE(soldier_move_walk2, FRAME_walk209, FRAME_walk218, soldier_frames_walk2, NULL);
 
 void soldier_walk(edict_t *self)
 {
@@ -224,7 +224,7 @@ static const mframe_t soldier_frames_start_run[] = {
     { ai_run, 7,  NULL },
     { ai_run, 5,  NULL }
 };
-const mmove_t soldier_move_start_run = {FRAME_run01, FRAME_run02, soldier_frames_start_run, soldier_run};
+DEFINE_MMOVE(soldier_move_start_run, FRAME_run01, FRAME_run02, soldier_frames_start_run, soldier_run);
 
 static const mframe_t soldier_frames_run[] = {
     { ai_run, 10, NULL },
@@ -234,7 +234,7 @@ static const mframe_t soldier_frames_run[] = {
     { ai_run, 10, NULL },
     { ai_run, 15, NULL }
 };
-const mmove_t soldier_move_run = {FRAME_run03, FRAME_run08, soldier_frames_run, NULL};
+DEFINE_MMOVE(soldier_move_run, FRAME_run03, FRAME_run08, soldier_frames_run, NULL);
 
 void soldier_run(edict_t *self)
 {
@@ -263,7 +263,7 @@ static const mframe_t soldier_frames_pain1[] = {
     { ai_move, 1,  NULL },
     { ai_move, 0,  NULL }
 };
-const mmove_t soldier_move_pain1 = {FRAME_pain101, FRAME_pain105, soldier_frames_pain1, soldier_run};
+DEFINE_MMOVE(soldier_move_pain1, FRAME_pain101, FRAME_pain105, soldier_frames_pain1, soldier_run);
 
 static const mframe_t soldier_frames_pain2[] = {
     { ai_move, -13, NULL },
@@ -274,7 +274,7 @@ static const mframe_t soldier_frames_pain2[] = {
     { ai_move, 3,   NULL },
     { ai_move, 2,   NULL }
 };
-const mmove_t soldier_move_pain2 = {FRAME_pain201, FRAME_pain207, soldier_frames_pain2, soldier_run};
+DEFINE_MMOVE(soldier_move_pain2, FRAME_pain201, FRAME_pain207, soldier_frames_pain2, soldier_run);
 
 static const mframe_t soldier_frames_pain3[] = {
     { ai_move, -8, NULL },
@@ -296,7 +296,7 @@ static const mframe_t soldier_frames_pain3[] = {
     { ai_move, 3,  NULL },
     { ai_move, 2,  NULL }
 };
-const mmove_t soldier_move_pain3 = {FRAME_pain301, FRAME_pain318, soldier_frames_pain3, soldier_run};
+DEFINE_MMOVE(soldier_move_pain3, FRAME_pain301, FRAME_pain318, soldier_frames_pain3, soldier_run);
 
 static const mframe_t soldier_frames_pain4[] = {
     { ai_move, 0,   NULL },
@@ -317,7 +317,7 @@ static const mframe_t soldier_frames_pain4[] = {
     { ai_move, 2,   NULL },
     { ai_move, 0,   NULL }
 };
-const mmove_t soldier_move_pain4 = {FRAME_pain401, FRAME_pain417, soldier_frames_pain4, soldier_run};
+DEFINE_MMOVE(soldier_move_pain4, FRAME_pain401, FRAME_pain417, soldier_frames_pain4, soldier_run);
 
 void soldier_pain(edict_t *self, edict_t *other, float kick, int damage)
 {
@@ -501,7 +501,7 @@ static const mframe_t soldier_frames_attack1[] = {
     { ai_charge, 0,  NULL },
     { ai_charge, 0,  NULL }
 };
-const mmove_t soldier_move_attack1 = {FRAME_attak101, FRAME_attak112, soldier_frames_attack1, soldier_run};
+DEFINE_MMOVE(soldier_move_attack1, FRAME_attak101, FRAME_attak112, soldier_frames_attack1, soldier_run);
 
 // ATTACK2 (blaster/shotgun)
 
@@ -556,7 +556,7 @@ static const mframe_t soldier_frames_attack2[] = {
     { ai_charge, 0, NULL },
     { ai_charge, 0, NULL }
 };
-const mmove_t soldier_move_attack2 = {FRAME_attak201, FRAME_attak218, soldier_frames_attack2, soldier_run};
+DEFINE_MMOVE(soldier_move_attack2, FRAME_attak201, FRAME_attak218, soldier_frames_attack2, soldier_run);
 
 // ATTACK3 (duck and shoot)
 
@@ -602,7 +602,7 @@ static const mframe_t soldier_frames_attack3[] = {
     { ai_charge, 0, NULL },
     { ai_charge, 0, NULL }
 };
-const mmove_t soldier_move_attack3 = {FRAME_attak301, FRAME_attak309, soldier_frames_attack3, soldier_run};
+DEFINE_MMOVE(soldier_move_attack3, FRAME_attak301, FRAME_attak309, soldier_frames_attack3, soldier_run);
 
 // ATTACK4 (machinegun)
 
@@ -619,7 +619,7 @@ static const mframe_t soldier_frames_attack4[] = {
     { ai_charge, 0, NULL },
     { ai_charge, 0, NULL }
 };
-const mmove_t soldier_move_attack4 = {FRAME_attak401, FRAME_attak406, soldier_frames_attack4, soldier_run};
+DEFINE_MMOVE(soldier_move_attack4, FRAME_attak401, FRAME_attak406, soldier_frames_attack4, soldier_run);
 
 // ATTACK6 (run & shoot)
 
@@ -656,7 +656,7 @@ static const mframe_t soldier_frames_attack6[] = {
     { ai_charge, 12, NULL },
     { ai_charge, 17, soldier_attack6_refire }
 };
-const mmove_t soldier_move_attack6 = {FRAME_runs01, FRAME_runs14, soldier_frames_attack6, soldier_run};
+DEFINE_MMOVE(soldier_move_attack6, FRAME_runs01, FRAME_runs14, soldier_frames_attack6, soldier_run);
 
 void soldier_attack(edict_t *self)
 {
@@ -706,7 +706,7 @@ static const mframe_t soldier_frames_duck[] = {
     { ai_move, 0,  soldier_duck_up },
     { ai_move, 5,  NULL }
 };
-const mmove_t soldier_move_duck = {FRAME_duck01, FRAME_duck05, soldier_frames_duck, soldier_run};
+DEFINE_MMOVE(soldier_move_duck, FRAME_duck01, FRAME_duck05, soldier_frames_duck, soldier_run);
 
 void soldier_dodge(edict_t *self, edict_t *attacker, float eta)
 {
@@ -811,7 +811,7 @@ static const mframe_t soldier_frames_death1[] = {
     { ai_move, 0,   NULL },
     { ai_move, 0,   NULL }
 };
-const mmove_t soldier_move_death1 = {FRAME_death101, FRAME_death136, soldier_frames_death1, soldier_dead};
+DEFINE_MMOVE(soldier_move_death1, FRAME_death101, FRAME_death136, soldier_frames_death1, soldier_dead);
 
 static const mframe_t soldier_frames_death2[] = {
     { ai_move, -5,  NULL },
@@ -853,7 +853,7 @@ static const mframe_t soldier_frames_death2[] = {
     { ai_move, 0,   NULL },
     { ai_move, 0,   NULL }
 };
-const mmove_t soldier_move_death2 = {FRAME_death201, FRAME_death235, soldier_frames_death2, soldier_dead};
+DEFINE_MMOVE(soldier_move_death2, FRAME_death201, FRAME_death235, soldier_frames_death2, soldier_dead);
 
 static const mframe_t soldier_frames_death3[] = {
     { ai_move, -5,  NULL },
@@ -906,7 +906,7 @@ static const mframe_t soldier_frames_death3[] = {
     { ai_move, 0,   NULL },
     { ai_move, 0,   NULL },
 };
-const mmove_t soldier_move_death3 = {FRAME_death301, FRAME_death345, soldier_frames_death3, soldier_dead};
+DEFINE_MMOVE(soldier_move_death3, FRAME_death301, FRAME_death345, soldier_frames_death3, soldier_dead);
 
 static const mframe_t soldier_frames_death4[] = {
     { ai_move, 0,   NULL },
@@ -968,7 +968,7 @@ static const mframe_t soldier_frames_death4[] = {
     { ai_move, 0,   NULL },
     { ai_move, 0,   NULL }
 };
-const mmove_t soldier_move_death4 = {FRAME_death401, FRAME_death453, soldier_frames_death4, soldier_dead};
+DEFINE_MMOVE(soldier_move_death4, FRAME_death401, FRAME_death453, soldier_frames_death4, soldier_dead);
 
 static const mframe_t soldier_frames_death5[] = {
     { ai_move, -5,  NULL },
@@ -998,7 +998,7 @@ static const mframe_t soldier_frames_death5[] = {
     { ai_move, 0,   NULL },
     { ai_move, 0,   NULL }
 };
-const mmove_t soldier_move_death5 = {FRAME_death501, FRAME_death524, soldier_frames_death5, soldier_dead};
+DEFINE_MMOVE(soldier_move_death5, FRAME_death501, FRAME_death524, soldier_frames_death5, soldier_dead);
 
 static const mframe_t soldier_frames_death6[] = {
     { ai_move, 0,   NULL },
@@ -1012,7 +1012,7 @@ static const mframe_t soldier_frames_death6[] = {
     { ai_move, 0,   NULL },
     { ai_move, 0,   NULL }
 };
-const mmove_t soldier_move_death6 = {FRAME_death601, FRAME_death610, soldier_frames_death6, soldier_dead};
+DEFINE_MMOVE(soldier_move_death6, FRAME_death601, FRAME_death610, soldier_frames_death6, soldier_dead);
 
 void soldier_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage, vec3_t point)
 {

--- a/src/game/m_supertank.cpp
+++ b/src/game/m_supertank.cpp
@@ -121,7 +121,7 @@ static const mframe_t supertank_frames_stand[] = {
     { ai_stand, 0, NULL },
     { ai_stand, 0, NULL }
 };
-const mmove_t supertank_move_stand = {FRAME_stand_1, FRAME_stand_60, supertank_frames_stand, NULL};
+DEFINE_MMOVE(supertank_move_stand, FRAME_stand_1, FRAME_stand_60, supertank_frames_stand, NULL);
 
 void supertank_stand(edict_t *self)
 {
@@ -148,7 +148,7 @@ static const mframe_t supertank_frames_run[] = {
     { ai_run, 12, NULL },
     { ai_run, 12, NULL }
 };
-const mmove_t supertank_move_run = {FRAME_forwrd_1, FRAME_forwrd_18, supertank_frames_run, NULL};
+DEFINE_MMOVE(supertank_move_run, FRAME_forwrd_1, FRAME_forwrd_18, supertank_frames_run, NULL);
 
 //
 // walk
@@ -174,7 +174,7 @@ static const mframe_t supertank_frames_forward[] = {
     { ai_walk, 4, NULL },
     { ai_walk, 4, NULL }
 };
-const mmove_t supertank_move_forward = {FRAME_forwrd_1, FRAME_forwrd_18, supertank_frames_forward, NULL};
+DEFINE_MMOVE(supertank_move_forward, FRAME_forwrd_1, FRAME_forwrd_18, supertank_frames_forward, NULL);
 
 void supertank_walk(edict_t *self)
 {
@@ -209,7 +209,7 @@ static const mframe_t supertank_frames_turn_right[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t supertank_move_turn_right = {FRAME_right_1, FRAME_right_18, supertank_frames_turn_right, supertank_run};
+DEFINE_MMOVE(supertank_move_turn_right, FRAME_right_1, FRAME_right_18, supertank_frames_turn_right, supertank_run);
 
 static const mframe_t supertank_frames_turn_left[] = {
     { ai_move,    0,  TreadSound },
@@ -231,7 +231,7 @@ static const mframe_t supertank_frames_turn_left[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t supertank_move_turn_left = {FRAME_left_1, FRAME_left_18, supertank_frames_turn_left, supertank_run};
+DEFINE_MMOVE(supertank_move_turn_left, FRAME_left_1, FRAME_left_18, supertank_frames_turn_left, supertank_run);
 
 static const mframe_t supertank_frames_pain3[] = {
     { ai_move,    0,  NULL },
@@ -239,7 +239,7 @@ static const mframe_t supertank_frames_pain3[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t supertank_move_pain3 = {FRAME_pain3_9, FRAME_pain3_12, supertank_frames_pain3, supertank_run};
+DEFINE_MMOVE(supertank_move_pain3, FRAME_pain3_9, FRAME_pain3_12, supertank_frames_pain3, supertank_run);
 
 static const mframe_t supertank_frames_pain2[] = {
     { ai_move,    0,  NULL },
@@ -247,7 +247,7 @@ static const mframe_t supertank_frames_pain2[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t supertank_move_pain2 = {FRAME_pain2_5, FRAME_pain2_8, supertank_frames_pain2, supertank_run};
+DEFINE_MMOVE(supertank_move_pain2, FRAME_pain2_5, FRAME_pain2_8, supertank_frames_pain2, supertank_run);
 
 static const mframe_t supertank_frames_pain1[] = {
     { ai_move,    0,  NULL },
@@ -255,7 +255,7 @@ static const mframe_t supertank_frames_pain1[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t supertank_move_pain1 = {FRAME_pain1_1, FRAME_pain1_4, supertank_frames_pain1, supertank_run};
+DEFINE_MMOVE(supertank_move_pain1, FRAME_pain1_1, FRAME_pain1_4, supertank_frames_pain1, supertank_run);
 
 static const mframe_t supertank_frames_death1[] = {
     { ai_move,    0,  NULL },
@@ -283,7 +283,7 @@ static const mframe_t supertank_frames_death1[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  BossExplode }
 };
-const mmove_t supertank_move_death = {FRAME_death_1, FRAME_death_24, supertank_frames_death1, supertank_dead};
+DEFINE_MMOVE(supertank_move_death, FRAME_death_1, FRAME_death_24, supertank_frames_death1, supertank_dead);
 
 static const mframe_t supertank_frames_backward[] = {
     { ai_walk, 0, TreadSound },
@@ -305,7 +305,7 @@ static const mframe_t supertank_frames_backward[] = {
     { ai_walk, 0, NULL },
     { ai_walk, 0, NULL }
 };
-const mmove_t supertank_move_backward = {FRAME_backwd_1, FRAME_backwd_18, supertank_frames_backward, NULL};
+DEFINE_MMOVE(supertank_move_backward, FRAME_backwd_1, FRAME_backwd_18, supertank_frames_backward, NULL);
 
 static const mframe_t supertank_frames_attack4[] = {
     { ai_move,    0,  NULL },
@@ -315,7 +315,7 @@ static const mframe_t supertank_frames_attack4[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t supertank_move_attack4 = {FRAME_attak4_1, FRAME_attak4_6, supertank_frames_attack4, supertank_run};
+DEFINE_MMOVE(supertank_move_attack4, FRAME_attak4_1, FRAME_attak4_6, supertank_frames_attack4, supertank_run);
 
 static const mframe_t supertank_frames_attack3[] = {
     { ai_move,    0,  NULL },
@@ -346,7 +346,7 @@ static const mframe_t supertank_frames_attack3[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t supertank_move_attack3 = {FRAME_attak3_1, FRAME_attak3_27, supertank_frames_attack3, supertank_run};
+DEFINE_MMOVE(supertank_move_attack3, FRAME_attak3_1, FRAME_attak3_27, supertank_frames_attack3, supertank_run);
 
 static const mframe_t supertank_frames_attack2[] = {
     { ai_charge,  0,  NULL },
@@ -377,7 +377,7 @@ static const mframe_t supertank_frames_attack2[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t supertank_move_attack2 = {FRAME_attak2_1, FRAME_attak2_27, supertank_frames_attack2, supertank_run};
+DEFINE_MMOVE(supertank_move_attack2, FRAME_attak2_1, FRAME_attak2_27, supertank_frames_attack2, supertank_run);
 
 static const mframe_t supertank_frames_attack1[] = {
     { ai_charge,  0,  supertankMachineGun },
@@ -388,7 +388,7 @@ static const mframe_t supertank_frames_attack1[] = {
     { ai_charge,  0,  supertankMachineGun },
 
 };
-const mmove_t supertank_move_attack1 = {FRAME_attak1_1, FRAME_attak1_6, supertank_frames_attack1, supertank_reattack1};
+DEFINE_MMOVE(supertank_move_attack1, FRAME_attak1_1, FRAME_attak1_6, supertank_frames_attack1, supertank_reattack1);
 
 static const mframe_t supertank_frames_end_attack1[] = {
     { ai_move,    0,  NULL },
@@ -406,7 +406,7 @@ static const mframe_t supertank_frames_end_attack1[] = {
     { ai_move,    0,  NULL },
     { ai_move,    0,  NULL }
 };
-const mmove_t supertank_move_end_attack1 = {FRAME_attak1_7, FRAME_attak1_20, supertank_frames_end_attack1, supertank_run};
+DEFINE_MMOVE(supertank_move_end_attack1, FRAME_attak1_7, FRAME_attak1_20, supertank_frames_end_attack1, supertank_run);
 
 static void supertank_reattack1(edict_t *self)
 {

--- a/src/game/m_tank.cpp
+++ b/src/game/m_tank.cpp
@@ -104,7 +104,7 @@ static const mframe_t tank_frames_stand[] = {
     { ai_stand, 0, NULL },
     { ai_stand, 0, NULL }
 };
-const mmove_t tank_move_stand = {FRAME_stand01, FRAME_stand30, tank_frames_stand, NULL};
+DEFINE_MMOVE(tank_move_stand, FRAME_stand01, FRAME_stand30, tank_frames_stand, NULL);
 
 void tank_stand(edict_t *self)
 {
@@ -123,7 +123,7 @@ static const mframe_t tank_frames_start_walk[] = {
     { ai_walk,  6, NULL },
     { ai_walk, 11, tank_footstep }
 };
-const mmove_t tank_move_start_walk = {FRAME_walk01, FRAME_walk04, tank_frames_start_walk, tank_walk};
+DEFINE_MMOVE(tank_move_start_walk, FRAME_walk01, FRAME_walk04, tank_frames_start_walk, tank_walk);
 
 static const mframe_t tank_frames_walk[] = {
     { ai_walk, 4, NULL },
@@ -143,7 +143,7 @@ static const mframe_t tank_frames_walk[] = {
     { ai_walk, 6, NULL },
     { ai_walk, 6, tank_footstep }
 };
-const mmove_t tank_move_walk = {FRAME_walk05, FRAME_walk20, tank_frames_walk, NULL};
+DEFINE_MMOVE(tank_move_walk, FRAME_walk05, FRAME_walk20, tank_frames_walk, NULL);
 
 static const mframe_t tank_frames_stop_walk[] = {
     { ai_walk,  3, NULL },
@@ -152,7 +152,7 @@ static const mframe_t tank_frames_stop_walk[] = {
     { ai_walk,  2, NULL },
     { ai_walk,  4, tank_footstep }
 };
-const mmove_t tank_move_stop_walk = {FRAME_walk21, FRAME_walk25, tank_frames_stop_walk, tank_stand};
+DEFINE_MMOVE(tank_move_stop_walk, FRAME_walk21, FRAME_walk25, tank_frames_stop_walk, tank_stand);
 
 void tank_walk(edict_t *self)
 {
@@ -171,7 +171,7 @@ static const mframe_t tank_frames_start_run[] = {
     { ai_run,  6, NULL },
     { ai_run, 11, tank_footstep }
 };
-const mmove_t tank_move_start_run = {FRAME_walk01, FRAME_walk04, tank_frames_start_run, tank_run};
+DEFINE_MMOVE(tank_move_start_run, FRAME_walk01, FRAME_walk04, tank_frames_start_run, tank_run);
 
 static const mframe_t tank_frames_run[] = {
     { ai_run, 4,  NULL },
@@ -191,7 +191,7 @@ static const mframe_t tank_frames_run[] = {
     { ai_run, 6,  NULL },
     { ai_run, 6,  tank_footstep }
 };
-const mmove_t tank_move_run = {FRAME_walk05, FRAME_walk20, tank_frames_run, NULL};
+DEFINE_MMOVE(tank_move_run, FRAME_walk05, FRAME_walk20, tank_frames_run, NULL);
 
 static const mframe_t tank_frames_stop_run[] = {
     { ai_run,  3, NULL },
@@ -200,7 +200,7 @@ static const mframe_t tank_frames_stop_run[] = {
     { ai_run,  2, NULL },
     { ai_run,  4, tank_footstep }
 };
-const mmove_t tank_move_stop_run = {FRAME_walk21, FRAME_walk25, tank_frames_stop_run, tank_walk};
+DEFINE_MMOVE(tank_move_stop_run, FRAME_walk21, FRAME_walk25, tank_frames_stop_run, tank_walk);
 
 void tank_run(edict_t *self)
 {
@@ -232,7 +232,7 @@ static const mframe_t tank_frames_pain1[] = {
     { ai_move, 0, NULL },
     { ai_move, 0, NULL }
 };
-const mmove_t tank_move_pain1 = {FRAME_pain101, FRAME_pain104, tank_frames_pain1, tank_run};
+DEFINE_MMOVE(tank_move_pain1, FRAME_pain101, FRAME_pain104, tank_frames_pain1, tank_run);
 
 static const mframe_t tank_frames_pain2[] = {
     { ai_move, 0, NULL },
@@ -241,7 +241,7 @@ static const mframe_t tank_frames_pain2[] = {
     { ai_move, 0, NULL },
     { ai_move, 0, NULL }
 };
-const mmove_t tank_move_pain2 = {FRAME_pain201, FRAME_pain205, tank_frames_pain2, tank_run};
+DEFINE_MMOVE(tank_move_pain2, FRAME_pain201, FRAME_pain205, tank_frames_pain2, tank_run);
 
 static const mframe_t tank_frames_pain3[] = {
     { ai_move, -7, NULL },
@@ -261,7 +261,7 @@ static const mframe_t tank_frames_pain3[] = {
     { ai_move, 0,  NULL },
     { ai_move, 0,  tank_footstep }
 };
-const mmove_t tank_move_pain3 = {FRAME_pain301, FRAME_pain316, tank_frames_pain3, tank_run};
+DEFINE_MMOVE(tank_move_pain3, FRAME_pain301, FRAME_pain316, tank_frames_pain3, tank_run);
 
 void tank_pain(edict_t *self, edict_t *other, float kick, int damage)
 {
@@ -411,7 +411,7 @@ static const mframe_t tank_frames_attack_blast[] = {
     { ai_charge, 0,   NULL },
     { ai_charge, 0,   TankBlaster }     // 16
 };
-const mmove_t tank_move_attack_blast = {FRAME_attak101, FRAME_attak116, tank_frames_attack_blast, tank_reattack_blaster};
+DEFINE_MMOVE(tank_move_attack_blast, FRAME_attak101, FRAME_attak116, tank_frames_attack_blast, tank_reattack_blaster);
 
 static const mframe_t tank_frames_reattack_blast[] = {
     { ai_charge, 0,   NULL },
@@ -421,7 +421,7 @@ static const mframe_t tank_frames_reattack_blast[] = {
     { ai_charge, 0,   NULL },
     { ai_charge, 0,   TankBlaster }     // 16
 };
-const mmove_t tank_move_reattack_blast = {FRAME_attak111, FRAME_attak116, tank_frames_reattack_blast, tank_reattack_blaster};
+DEFINE_MMOVE(tank_move_reattack_blast, FRAME_attak111, FRAME_attak116, tank_frames_reattack_blast, tank_reattack_blaster);
 
 static const mframe_t tank_frames_attack_post_blast[] = {
     { ai_move, 0,     NULL },           // 17
@@ -431,7 +431,7 @@ static const mframe_t tank_frames_attack_post_blast[] = {
     { ai_move, 2,     NULL },
     { ai_move, -2,    tank_footstep }   // 22
 };
-const mmove_t tank_move_attack_post_blast = {FRAME_attak117, FRAME_attak122, tank_frames_attack_post_blast, tank_run};
+DEFINE_MMOVE(tank_move_attack_post_blast, FRAME_attak117, FRAME_attak122, tank_frames_attack_post_blast, tank_run);
 
 static void tank_reattack_blaster(edict_t *self)
 {
@@ -491,7 +491,7 @@ static const mframe_t tank_frames_attack_strike[] = {
     { ai_move, -3,  NULL },
     { ai_move, -2,  tank_footstep }
 };
-const mmove_t tank_move_attack_strike = {FRAME_attak201, FRAME_attak238, tank_frames_attack_strike, tank_poststrike};
+DEFINE_MMOVE(tank_move_attack_strike, FRAME_attak201, FRAME_attak238, tank_frames_attack_strike, tank_poststrike);
 
 static const mframe_t tank_frames_attack_pre_rocket[] = {
     { ai_charge, 0,  NULL },
@@ -518,7 +518,7 @@ static const mframe_t tank_frames_attack_pre_rocket[] = {
 
     { ai_charge, -3, NULL }
 };
-const mmove_t tank_move_attack_pre_rocket = {FRAME_attak301, FRAME_attak321, tank_frames_attack_pre_rocket, tank_doattack_rocket};
+DEFINE_MMOVE(tank_move_attack_pre_rocket, FRAME_attak301, FRAME_attak321, tank_frames_attack_pre_rocket, tank_doattack_rocket);
 
 static const mframe_t tank_frames_attack_fire_rocket[] = {
     { ai_charge, -3, NULL },            // Loop Start   22
@@ -531,7 +531,7 @@ static const mframe_t tank_frames_attack_fire_rocket[] = {
     { ai_charge, 0,  NULL },
     { ai_charge, -1, TankRocket }       // 30   Loop End
 };
-const mmove_t tank_move_attack_fire_rocket = {FRAME_attak322, FRAME_attak330, tank_frames_attack_fire_rocket, tank_refire_rocket};
+DEFINE_MMOVE(tank_move_attack_fire_rocket, FRAME_attak322, FRAME_attak330, tank_frames_attack_fire_rocket, tank_refire_rocket);
 
 static const mframe_t tank_frames_attack_post_rocket[] = {
     { ai_charge, 0,  NULL },            // 31
@@ -560,7 +560,7 @@ static const mframe_t tank_frames_attack_post_rocket[] = {
     { ai_charge, 0,  NULL },
     { ai_charge, 0,  NULL }
 };
-const mmove_t tank_move_attack_post_rocket = {FRAME_attak331, FRAME_attak353, tank_frames_attack_post_rocket, tank_run};
+DEFINE_MMOVE(tank_move_attack_post_rocket, FRAME_attak331, FRAME_attak353, tank_frames_attack_post_rocket, tank_run);
 
 static const mframe_t tank_frames_attack_chain[] = {
     { ai_charge, 0, NULL },
@@ -593,7 +593,7 @@ static const mframe_t tank_frames_attack_chain[] = {
     { ai_charge, 0, NULL },
     { ai_charge, 0, NULL }
 };
-const mmove_t tank_move_attack_chain = {FRAME_attak401, FRAME_attak429, tank_frames_attack_chain, tank_run};
+DEFINE_MMOVE(tank_move_attack_chain, FRAME_attak401, FRAME_attak429, tank_frames_attack_chain, tank_run);
 
 static void tank_refire_rocket(edict_t *self)
 {
@@ -699,7 +699,7 @@ static const mframe_t tank_frames_death1[] = {
     { ai_move, 0,   NULL },
     { ai_move, 0,   NULL }
 };
-const mmove_t tank_move_death = {FRAME_death101, FRAME_death132, tank_frames_death1, tank_dead};
+DEFINE_MMOVE(tank_move_death, FRAME_death101, FRAME_death132, tank_frames_death1, tank_dead);
 
 void tank_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage, vec3_t point)
 {


### PR DESCRIPTION
## Summary
- add a DEFINE_MMOVE helper that gives mmove_t definitions external linkage under C++ while keeping C builds unchanged
- switch all monster mmove_t definitions to use the new macro for consistency

## Testing
- ninja -C build *(fails: build.ninja not generated in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_69065b2528548328aa0bdd66d3ff2564