### PR TITLE
Fix Meson FFmpeg fallback archive conversion

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -672,7 +672,7 @@ if ffmpeg_all_found and cc.get_id() == 'msvc' and avcodec_opt.allowed()
             command: [coff_librarian, '/nologo', '/OUT:@OUTPUT@', '@INPUT@'],
             build_by_default: true,
           )
-          converted_archives[archive] = convert_target
+          converted_archives += { archive: convert_target }
         endif
 
         converted_paths += [convert_target.full_path()]


### PR DESCRIPTION
## Summary
- replace illegal dictionary indexing assignment with Meson's dictionary merge syntax when caching converted FFmpeg archives

## Testing
- meson compile -C builddir *(fails: /workspace/WORR/builddir is not a Meson build directory in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_69065ca71a508328b7d7deb0d5753261