### PR TITLE
Fix Meson dictionary assignment for FFmpeg deps

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -678,14 +678,16 @@ if ffmpeg_all_found and cc.get_id() == 'msvc' and avcodec_opt.allowed()
         converted_paths += [convert_target.full_path()]
       endforeach
 
-      converted_ffmpeg_deps[dep_name] = declare_dependency(
-        include_directories: dep_obj.get_include_directories(),
-        compile_args: dep_obj.get_compile_args(),
-        sources: dep_obj.get_sources(),
-        dependencies: dep_obj.get_dependencies(),
-        link_whole: dep_obj.get_link_whole(),
-        link_args: preserved_link_args + converted_paths,
-      )
+      converted_ffmpeg_deps += {
+        dep_name: declare_dependency(
+          include_directories: dep_obj.get_include_directories(),
+          compile_args: dep_obj.get_compile_args(),
+          sources: dep_obj.get_sources(),
+          dependencies: dep_obj.get_dependencies(),
+          link_whole: dep_obj.get_link_whole(),
+          link_args: preserved_link_args + converted_paths,
+        ),
+      }
     endif
   endforeach
 endif


### PR DESCRIPTION
## Summary
- replace invalid dictionary index assignment with dictionary merge when recording converted FFmpeg dependencies
- ensure Meson evaluates the dependency creation without triggering "Assignment target must be an id" errors on newer releases

## Testing
- meson compile -C builddir (fails: builddir not configured in container)

------
https://chatgpt.com/codex/tasks/task_e_69065d3ae0e88328bb57a26592cfe45b