### PR TITLE
Fix FFmpeg dependency link arg lookup for Meson 1.3

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -643,7 +643,7 @@ if ffmpeg_all_found and cc.get_id() == 'msvc' and avcodec_opt.allowed()
       preserved_link_args = []
       fallback_archives = []
 
-      foreach link_arg : dep_obj.get_link_args()
+      foreach link_arg : dep_obj.link_args()
         if link_arg.endswith('.a')
           fallback_archives += [link_arg]
         else


### PR DESCRIPTION
## Summary
- replace the deprecated get_link_args call with link_args so FFmpeg dependencies can be inspected under newer Meson releases

## Testing
- meson setup builddir *(fails: wrap-redirect /workspace/WORR/subprojects/ffmpeg/subprojects/nasm.wrap filename does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_69065edc6740832880602342ad8c246a