### PR TITLE
Fix ffmpeg internal dependency link args for MSVC

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -643,7 +643,7 @@ if ffmpeg_all_found and cc.get_id() == 'msvc' and avcodec_opt.allowed()
       preserved_link_args = []
       fallback_archives = []
 
-      foreach link_arg : dep_obj.link_args()
+      foreach link_arg : dep_obj.get_link_args()
         if link_arg.endswith('.a')
           fallback_archives += [link_arg]
         else


### PR DESCRIPTION
## Summary
- replace use of the removed `link_args()` helper on internal dependencies with `get_link_args()` in the FFmpeg COFF conversion logic for MSVC

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69066aeb95d88328a9dbea5ef56ad45b