### PR TITLE
Guard FFmpeg helpers behind USE_AVCODEC

### DIFF
--- a/src/client/ffmpeg_utils.hpp
+++ b/src/client/ffmpeg_utils.hpp
@@ -18,10 +18,14 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
+#ifdef USE_AVCODEC
+
 #include <string>
 #include <type_traits>
 
+extern "C" {
 #include <libavutil/channel_layout.h>
+}
 
 static inline int Q_AVChannelLayoutDefault(AVChannelLayout *layout, int nb_channels)
 {
@@ -34,8 +38,6 @@ static inline int Q_AVChannelLayoutDefault(AVChannelLayout *layout, int nb_chann
     av_channel_layout_default(layout, nb_channels);
     return 0;
 }
-
-#ifdef USE_AVCODEC
 
 std::string AvErrorString(int err);
 


### PR DESCRIPTION
## Summary
- wrap ffmpeg helper declarations behind USE_AVCODEC so builds without FFmpeg headers succeed
- include libavutil/channel_layout.h via extern "C" only when FFmpeg support is enabled

## Testing
- ninja -C build worr.exe.p/src_client_ffmpeg_utils.cpp.obj *(fails: build directory not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_690670271de4832887a9d938e3c0f774