### PR TITLE
Enable FreeType dependency by default

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -476,8 +476,18 @@ if sdl2.found()
   config.set('USE_SDL', 'USE_CLIENT')
 endif
 
+freetype = dependency('freetype2',
+  required:        get_option('freetype'),
+  default_options: fallback_opt,
+)
+
+config.set10('USE_FREETYPE', freetype.found())
+
 common_deps = [zlib]
 client_deps = [png, curl, sdl2]
+if freetype.found()
+  client_deps += freetype
+endif
 server_deps = []
 game_deps = [zlib]
 
@@ -876,6 +886,7 @@ summary({
   'debug'              : config.get('USE_DEBUG', 0) != 0,
   'game-abi-hack'      : config.get('USE_GAME_ABI_HACK', 0) != 0,
   'game-new-api'       : config.get('USE_NEW_GAME_API', 0) != 0,
+  'freetype'           : config.get('USE_FREETYPE', 0) != 0,
   'icmp-errors'        : config.get('USE_ICMP', 0) != 0,
   'libcurl'            : config.get('USE_CURL', 0) != 0,
   'libjpeg'            : config.get('USE_JPG', 0) != 0,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -30,7 +30,7 @@ option('client-ui',
 
 option('freetype',
   type: 'feature',
-  value: 'auto',
+  value: 'enabled',
   description: 'FreeType2 font rendering support')
 
 option('default-game',

--- a/src/common/features.hpp
+++ b/src/common/features.hpp
@@ -46,6 +46,9 @@ static const char *Com_GetFeatures(void)
 #if USE_CURL
     "libcurl "
 #endif
+#if USE_FREETYPE
+    "freetype "
+#endif
 #if USE_JPG
     "libjpeg "
 #endif


### PR DESCRIPTION
## Summary
- enable the FreeType build option by default
- wire the freetype2 dependency into the client build and expose a USE_FREETYPE config flag
- report the FreeType capability in the compiled feature list

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69069ea2a4a08328aa162ea837436df0