### PR TITLE
Add FreeType rendering support for text

### DIFF
--- a/src/refresh/font_freetype.hpp
+++ b/src/refresh/font_freetype.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "images.hpp"
+
+#if USE_FREETYPE
+
+bool Draw_LoadFreeTypeFont(image_t *image, const char *filename);
+void Draw_FreeFreeTypeFont(image_t *image);
+void Draw_InitFreeTypeFonts(void);
+void Draw_ShutdownFreeTypeFonts(void);
+
+#else
+
+inline bool Draw_LoadFreeTypeFont(image_t *, const char *)
+{
+    return false;
+}
+
+inline void Draw_FreeFreeTypeFont(image_t *)
+{
+}
+
+inline void Draw_InitFreeTypeFonts(void)
+{
+}
+
+inline void Draw_ShutdownFreeTypeFonts(void)
+{
+}
+
+#endif

--- a/src/refresh/main.cpp
+++ b/src/refresh/main.cpp
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
  */
 
 #include "gl.hpp"
+#include "font_freetype.hpp"
 #include <array>
 
 glRefdef_t glr;
@@ -1458,6 +1459,8 @@ bool R_Init(bool total)
 
     GL_PostInit();
 
+    Draw_InitFreeTypeFonts();
+
     GL_ShowErrors(__func__);
 
     SCR_RegisterStat("refresh", Draw_Stats_s);
@@ -1486,10 +1489,13 @@ void R_Shutdown(bool total)
     GL_FreeWorld();
     GL_DeleteQueries();
     GL_ShutdownImages();
+
     MOD_Shutdown();
 
     if (!total)
         return;
+
+    Draw_ShutdownFreeTypeFonts();
 
     if (gl_static.sync) {
         qglDeleteSync(gl_static.sync);

--- a/src/refresh/texture.cpp
+++ b/src/refresh/texture.cpp
@@ -18,6 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "gl.hpp"
+#include "font_freetype.hpp"
 #include "common/prompt.hpp"
 #include <array>
 
@@ -906,6 +907,8 @@ void IMG_Load(image_t *image, byte *pic)
 
 void IMG_Unload(image_t *image)
 {
+    Draw_FreeFreeTypeFont(image);
+
     if (image->texnum && !(image->flags & IF_SCRAP)) {
         std::array<GLuint, 2> tex = { image->texnum, image->texnum2 };
 


### PR DESCRIPTION
## Summary
- add a FreeType-backed glyph cache and rendering path in the 2D draw routines
- detect .ttf/.otf fonts during image registration and initialize/shutdown the FreeType cache with the renderer
- ensure FreeType-managed textures are released when images unload

## Testing
- `meson setup build` *(fails: wrap-redirect /workspace/WORR/subprojects/ffmpeg/subprojects/nasm.wrap filename does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_69069fdcbf6c8328a27b97898073e60b