### PR TITLE
Ensure FreeType font images mark transparent

### DIFF
--- a/src/refresh/images.cpp
+++ b/src/refresh/images.cpp
@@ -2011,6 +2011,8 @@ static image_t *find_or_load_image(const char *name, size_t len,
         if (!Q_stricmp(ext, "ttf") || !Q_stricmp(ext, "otf")) {
             if (Draw_LoadFreeTypeFont(image, image->name)) {
                 freetype_font = true;
+                flags = enum_bit_or(flags, IF_TRANSPARENT);
+                image_set_flags(image, flags);
             } else {
                 ret = Q_ERR_LIBRARY_ERROR;
                 goto fail;


### PR DESCRIPTION
## Summary
- ensure FreeType font registrations set IF_TRANSPARENT when using FreeType glyphs so shader paths treat them as translucent

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6906ac7d9bd083288acbc091ac962e9e