### PR TITLE
Add FreeType-aware text backend selection

### DIFF
--- a/src/client/cgame.cpp
+++ b/src/client/cgame.cpp
@@ -370,7 +370,7 @@ static void CG_SCR_DrawFontString(const char *str, int x, int y, int scale, cons
 
     // TODO: 'str' may contain UTF-8, handle that.
     if (!scr.kfont.pic) {
-        SCR_DrawStringMultiStretch(draw_x, y, scale, draw_flags, strlen(str), str, draw_color, scr.font_pic);
+        SCR_DrawStringMultiStretch(draw_x, y, scale, draw_flags, strlen(str), str, draw_color, SCR_DefaultFontHandle());
     } else {
         SCR_DrawKStringMultiStretch(draw_x, y, scale, draw_flags, strlen(str), str, draw_color, &scr.kfont);
     }

--- a/src/client/client.hpp
+++ b/src/client/client.hpp
@@ -1203,6 +1203,7 @@ struct scr_freetype_cache_t {
     std::unordered_map<std::string, scr_freetype_font_entry_t> fonts;
     std::unordered_map<qhandle_t, std::string>                 handleLookup;
     std::string                                         activeFontKey;
+    qhandle_t                                           activeFontHandle { 0 };
 };
 #endif
 
@@ -1280,8 +1281,12 @@ int     SCR_DrawStringStretch(int x, int y, int scale, int flags, size_t maxlen,
 void    SCR_DrawStringMultiStretch(int x, int y, int scale, int flags, size_t maxlen, const char *s, color_t color, qhandle_t font);
 void    SCR_DrawKStringMultiStretch(int x, int y, int scale, int flags, size_t maxlen, const char *s, color_t color, const kfont_t *kfont);
 
+qhandle_t SCR_DefaultFontHandle(void);
+int     SCR_FontLineHeight(int scale, qhandle_t font);
+int     SCR_MeasureString(int scale, int flags, size_t maxlen, const char *s, qhandle_t font);
+
 #define SCR_DrawString(x, y, flags, color, string) \
-    SCR_DrawStringStretch(x, y, 1, flags, MAX_STRING_CHARS, string, color, scr.font_pic)
+    SCR_DrawStringStretch(x, y, 1, flags, MAX_STRING_CHARS, string, color, SCR_DefaultFontHandle())
 
 void    SCR_ClearChatHUD_f(void);
 void    SCR_AddToChatHUD(const char *text);

--- a/src/client/ui/menu.cpp
+++ b/src/client/ui/menu.cpp
@@ -2288,12 +2288,15 @@ static void Menu_DrawStatus(menuFrameWork_t *menu)
 
     lens[count++] = x;
 
-    R_DrawFill8(0, menu->y2 - count * CONCHAR_HEIGHT, uis.width, count * CONCHAR_HEIGHT, 4);
+    const int lineHeight = SCR_FontLineHeight(1, uis.fontHandle);
+
+    R_DrawFill8(0, menu->y2 - count * lineHeight, uis.width, count * lineHeight, 4);
 
     for (l = 0; l < count; l++) {
-        x = (uis.width - lens[l] * CONCHAR_WIDTH) / 2;
-        y = menu->y2 - (count - l) * CONCHAR_HEIGHT;
-        R_DrawString(x, y, 0, lens[l], ptrs[l], COLOR_WHITE, uis.fontHandle);
+        const int lineWidth = SCR_MeasureString(1, 0, lens[l], ptrs[l], uis.fontHandle);
+        x = (uis.width - lineWidth) / 2;
+        y = menu->y2 - (count - l) * lineHeight;
+        SCR_DrawStringStretch(x, y, 1, 0, lens[l], ptrs[l], COLOR_WHITE, uis.fontHandle);
     }
 }
 

--- a/src/client/ui/ui.cpp
+++ b/src/client/ui/ui.cpp
@@ -305,13 +305,8 @@ bool UI_CursorInRect(const vrect_t *rect)
 // nb: all UI strings are drawn at full alpha
 void UI_DrawString(int x, int y, int flags, color_t color, const char *string)
 {
-    if ((flags & UI_CENTER) == UI_CENTER) {
-        x -= strlen(string) * CONCHAR_WIDTH / 2;
-    } else if (flags & UI_RIGHT) {
-        x -= strlen(string) * CONCHAR_WIDTH;
-    }
-
-    R_DrawString(x, y, flags, MAX_STRING_CHARS, string, ColorSetAlpha(color, static_cast<uint8_t>(255)), uis.fontHandle);
+    SCR_DrawStringStretch(x, y, 1, flags, MAX_STRING_CHARS, string,
+                          ColorSetAlpha(color, static_cast<uint8_t>(255)), uis.fontHandle);
 }
 
 // nb: all UI chars are drawn at full alpha
@@ -322,8 +317,8 @@ void UI_DrawChar(int x, int y, int flags, color_t color, int ch)
 
 void UI_StringDimensions(vrect_t *rc, int flags, const char *string)
 {
-    rc->height = CONCHAR_HEIGHT;
-    rc->width = CONCHAR_WIDTH * strlen(string);
+    rc->height = SCR_FontLineHeight(1, uis.fontHandle);
+    rc->width = SCR_MeasureString(1, flags & ~UI_MULTILINE, MAX_STRING_CHARS, string, uis.fontHandle);
 
     if ((flags & UI_CENTER) == UI_CENTER) {
         rc->x -= rc->width / 2;


### PR DESCRIPTION
## Summary
- add a `scr_text_backend` runtime option and helper functions so HUD text chooses between bitmap and FreeType fonts at draw time
- update UI drawing and measurement helpers (including menu status text) to use the shared FreeType-aware routines
- route cgame multi-line string drawing through the default font selector so game text honors the backend choice

## Testing
- `meson compile -C build` *(fails: `/workspace/WORR/build` is not an initialized Meson build directory)*

------
https://chatgpt.com/codex/tasks/task_e_6906aa4003fc8328ac673ba52f6b5293