### PR TITLE
Make freetype feature optional by default

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -30,7 +30,7 @@ option('client-ui',
 
 option('freetype',
   type: 'feature',
-  value: 'enabled',
+  value: 'auto',
   description: 'FreeType2 font rendering support')
 
 option('default-game',


### PR DESCRIPTION
## Summary
- change the freetype feature option default from enabled to auto so the build does not fail when the dependency is unavailable

## Testing
- Not run (meson is not available in the container image)


------
https://chatgpt.com/codex/tasks/task_e_69073e7141c083269875afcc9df8db1a