### PR TITLE
Improve player sound spatialization anchor and diagnostics

### DIFF
--- a/src/client/client.hpp
+++ b/src/client/client.hpp
@@ -908,7 +908,7 @@ void CL_CheckEntityPresent(int entnum, const char *what);
 
 // the sound code makes callbacks to the client for entity position
 // information, so entities can be dynamically re-spatialized
-void CL_GetEntitySoundOrigin(unsigned entnum, vec3_t org);
+bool CL_GetEntitySoundOrigin(unsigned entnum, vec3_t org, vec3_t offset);
 
 
 //

--- a/src/client/sound/main.cpp
+++ b/src/client/sound/main.cpp
@@ -64,6 +64,7 @@ cvar_t      *s_show;
 cvar_t      *s_underwater;
 cvar_t      *s_underwater_gain_hf;
 cvar_t      *s_num_channels;
+cvar_t      *s_debug_soundorigins;
 
 static cvar_t   *s_enable;
 static cvar_t   *s_auto_focus;
@@ -155,6 +156,7 @@ void S_Init(void)
     s_underwater = Cvar_Get("s_underwater", "1", 0);
     s_underwater_gain_hf = Cvar_Get("s_underwater_gain_hf", "0.25", 0);
     s_num_channels = Cvar_Get("s_num_channels", "64", CVAR_SOUND);
+    s_debug_soundorigins = Cvar_Get("s_debugSoundOrigins", "0", CVAR_DEVELOPER);
 
     s_maxchannels = Cvar_ClampInteger(s_num_channels, 16, 256);
     s_channels = Z_TagMalloc(sizeof(*s_channels) * s_maxchannels, TAG_SOUND);
@@ -575,6 +577,7 @@ channel_t *S_PickChannel(int entnum, int entchannel)
     if (s_api->stop_channel)
         s_api->stop_channel(ch);
     memset(ch, 0, sizeof(*ch));
+    ch->has_spatial_offset = false;
 
     return ch;
 }

--- a/src/client/sound/sound.hpp
+++ b/src/client/sound/sound.hpp
@@ -82,6 +82,8 @@ typedef struct {
     float       master_vol;     // 0.0-1.0 master volume
     bool        fixed_origin;   // use origin instead of fetching entnum's origin
     bool        autosound;      // from an entity->sound, cleared each frame
+    bool        has_spatial_offset;
+    vec3_t      spatial_offset;
 #if USE_OPENAL
     byte        fullvolume;
     unsigned    autoframe;
@@ -171,9 +173,10 @@ extern cvar_t       *s_show;
 extern cvar_t       *s_underwater;
 extern cvar_t       *s_underwater_gain_hf;
 extern cvar_t       *s_num_channels;
+extern cvar_t       *s_debug_soundorigins;
 
 #define S_IsFullVolume(ch) \
-    ((ch)->entnum == -1 || (ch)->entnum == listener_entnum || (ch)->dist_mult == 0)
+    ((ch)->entnum == -1 || ((ch)->entnum == listener_entnum && !cl.thirdPersonView) || (ch)->dist_mult == 0)
 
 #define S_IsUnderWater() \
     (cls.state == ca_active && (cl.frame.ps.rdflags | cl.predicted_rdflags) & RDF_UNDERWATER && s_underwater->integer)


### PR DESCRIPTION
## Summary
- anchor player sound origins using centity_t bounds and adjust listener handling for third-person
- track per-channel spatial offsets with an optional debug visualizer controlled by `s_debugSoundOrigins`
- update OpenAL and DMA spatialization paths to use the refined origins and propagate offset data

## Testing
- python3 -m mesonbuild.mesonmain setup build -Davcodec=disabled *(fails: wrap-redirect /workspace/WORR/subprojects/ffmpeg/subprojects/nasm.wrap filename does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_69073f2d5c4c83269c6a96630764f319