### PR TITLE
Fix missing virtual screen import in rerelease cgame

### DIFF
--- a/subprojects/rerelease-game/rerelease/game.h
+++ b/subprojects/rerelease-game/rerelease/game.h
@@ -2233,6 +2233,8 @@ struct cgame_import_t
     void (*SCR_DrawPic) (int x, int y, int w, int h, const char *name);
     void (*SCR_DrawColorPic)(int x, int y, int w, int h, const char* name, const rgba_t &color);
 
+    const vrect_t *(*SCR_GetVirtualScreen)(text_align_t align);
+
     // [Paril-KEX] kfont stuff
     void(*SCR_SetAltTypeface)(bool enabled);
     void (*SCR_DrawFontString)(const char *str, int x, int y, int scale, const rgba_t &color, bool shadow, text_align_t align);


### PR DESCRIPTION
## Summary
- add the SCR_GetVirtualScreen hook to the rerelease cgame import table so HUD helpers can link against it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690760c36b0c832881d734b3b685685c