### PR TITLE
Fix include order and static declarations for client build

### DIFF
--- a/src/client/cgame_classic.cpp
+++ b/src/client/cgame_classic.cpp
@@ -39,6 +39,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define UI_RIGHT            BIT(1)
 #define UI_CENTER           (UI_LEFT | UI_RIGHT)
 
+static cgame_import_t cgi;
+static cgame_q2pro_extended_support_ext_t cgix;
+static const cs_remap_t *csr;
+static int max_stats;
+
 namespace
 {
 
@@ -81,11 +86,6 @@ float SCR_FadeAlpha(unsigned startTime, unsigned visTime, unsigned fadeTime);
 bool SCR_ParseColor(const char *s, color_t *color);
 
 // ==========================================================================
-
-static cgame_import_t cgi;
-static cgame_q2pro_extended_support_ext_t cgix;
-static const cs_remap_t *csr;
-static int max_stats;
 
 static cvar_t   *scr_centertime;
 static cvar_t   *scr_draw2d;

--- a/src/client/client.hpp
+++ b/src/client/client.hpp
@@ -47,11 +47,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "common/sizebuf.hpp"
 #include "common/zone.hpp"
 
+#include "client/client.hpp"
 #include "refresh/refresh.hpp"
 #include "server/server.hpp"
 #include "system/system.hpp"
-
-#include "client/client.hpp"
 #include "client/input.hpp"
 #include "client/keys.hpp"
 #include "client/sound/sound.hpp"


### PR DESCRIPTION
## Summary
- move cgame classic static imports before they are used so HUD helpers compile
- include the client API header before the refresh header so UI macros are available

## Testing
- ninja -C build *(fails: build.ninja: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6907621df9a083288b9dbf493185ed4e