### PR TITLE
Refactor sound API into SoundSystem methods

### DIFF
--- a/inc/client/sound/sound.hpp
+++ b/inc/client/sound/sound.hpp
@@ -23,16 +23,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 void S_Init(void);
 void S_Shutdown(void);
 
-// if origin is NULL, the sound will be dynamically sourced from the entity
-void S_StartSound(const vec3_t origin, int entnum, int entchannel,
-                  qhandle_t sfx, float fvol, float attenuation, float timeofs);
 void S_ParseStartSound(void);
 void S_StartLocalSound(const char *s);
 void S_StartLocalSoundOnce(const char *s);
 
 void S_FreeAllSounds(void);
-void S_StopAllSounds(void);
-void S_Update(void);
 
 void S_Activate(void);
 

--- a/src/client/client.hpp
+++ b/src/client/client.hpp
@@ -54,6 +54,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "client/client.hpp"
 #include "client/input.hpp"
 #include "client/keys.hpp"
+#include "client/sound/SoundSystem.hpp"
 #include "client/sound/sound.hpp"
 #include "client/ui.hpp"
 #include "client/video.hpp"

--- a/src/client/console.cpp
+++ b/src/client/console.cpp
@@ -572,7 +572,7 @@ void CL_LoadState(load_state_t state)
     SCR_UpdateScreen();
     if (vid)
         vid->pump_events();
-    S_Update();
+    S_GetSoundSystem().Update();
 }
 
 /*

--- a/src/client/demo.cpp
+++ b/src/client/demo.cpp
@@ -1243,7 +1243,7 @@ static void CL_Seek_f(void)
     memset(cl.dcs, 0, sizeof(cl.dcs));
 
     // stop sounds
-    S_StopAllSounds();
+    S_GetSoundSystem().StopAllSounds();
 
     // save previous server frame number
     prev = cl.frame.number;

--- a/src/client/effects.cpp
+++ b/src/client/effects.cpp
@@ -239,18 +239,18 @@ void CL_MuzzleFlash(void)
     switch (mz.weapon) {
     case MZ_BLASTER: {
         VectorSet(dl->color, 1, 1, 0);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/blastf1a.wav"), volume, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/blastf1a.wav"), volume, ATTN_NORM, 0);
         const vec3_t offset = { 27.0f, 7.4f, -6.6f };
         CL_AddWeaponMuzzleFX(MFLASH_BLAST, offset, 8.0f);
         break;
     }
     case MZ_BLUEHYPERBLASTER:
         VectorSet(dl->color, 0, 0, 1);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/hyprbf1a.wav"), volume, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/hyprbf1a.wav"), volume, ATTN_NORM, 0);
         break;
     case MZ_HYPERBLASTER: {
         VectorSet(dl->color, 1, 1, 0);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/hyprbf1a.wav"), volume, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/hyprbf1a.wav"), volume, ATTN_NORM, 0);
         const vec3_t offset = { 23.5f, 6.0f, -6.0f };
         CL_AddWeaponMuzzleFX(MFLASH_BLAST, offset, 9.0f);
         break;
@@ -258,22 +258,22 @@ void CL_MuzzleFlash(void)
     case MZ_MACHINEGUN: {
         VectorSet(dl->color, 1, 1, 0);
         Q_snprintf(soundname, sizeof(soundname), "weapons/machgf%ib.wav", (Q_rand() % 5) + 1);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound(soundname), volume, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound(soundname), volume, ATTN_NORM, 0);
         const vec3_t offset = { 29.0f, 9.7f, -8.0f };
         CL_AddWeaponMuzzleFX(MFLASH_MACHN, offset, 12.0f);
         break;
     }
     case MZ_SHOTGUN: {
         VectorSet(dl->color, 1, 1, 0);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/shotgf1b.wav"), volume, ATTN_NORM, 0);
-        S_StartSound(NULL, mz.entity, CHAN_AUTO,   S_RegisterSound("weapons/shotgr1b.wav"), volume, ATTN_NORM, cl_rerelease_effects->integer ? 0.35f : 0.1f);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/shotgf1b.wav"), volume, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_AUTO,   S_RegisterSound("weapons/shotgr1b.wav"), volume, ATTN_NORM, cl_rerelease_effects->integer ? 0.35f : 0.1f);
         const vec3_t offset = { 26.5f, 8.6f, -9.5f };
         CL_AddWeaponMuzzleFX(MFLASH_SHOTG, offset, 12.0f);
         break;
     }
     case MZ_SSHOTGUN: {
         VectorSet(dl->color, 1, 1, 0);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/sshotf1b.wav"), volume, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/sshotf1b.wav"), volume, ATTN_NORM, 0);
         const vec3_t offset = { 25.0f, 7.0f, -5.5f };
         CL_AddWeaponMuzzleFX(MFLASH_SHOTG2, offset, 12.0f);
         break;
@@ -282,7 +282,7 @@ void CL_MuzzleFlash(void)
         dl->radius = 200 + (Q_rand() & 31);
         VectorSet(dl->color, 1, 0.25f, 0);
         Q_snprintf(soundname, sizeof(soundname), "weapons/machgf%ib.wav", (Q_rand() % 5) + 1);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound(soundname), volume, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound(soundname), volume, ATTN_NORM, 0);
         const vec3_t offset = { 29.0f, 9.7f, -10.0f };
         CL_AddWeaponMuzzleFX(MFLASH_MACHN, offset, 12.0f);
         break;
@@ -291,9 +291,9 @@ void CL_MuzzleFlash(void)
         dl->radius = 225 + (Q_rand() & 31);
         VectorSet(dl->color, 1, 0.5f, 0);
         Q_snprintf(soundname, sizeof(soundname), "weapons/machgf%ib.wav", (Q_rand() % 5) + 1);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound(soundname), volume, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound(soundname), volume, ATTN_NORM, 0);
         Q_snprintf(soundname, sizeof(soundname), "weapons/machgf%ib.wav", (Q_rand() % 5) + 1);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound(soundname), volume, ATTN_NORM, 0.05f);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound(soundname), volume, ATTN_NORM, 0.05f);
         const vec3_t offset = { 29.0f, 9.7f, -10.0f };
         CL_AddWeaponMuzzleFX(MFLASH_MACHN, offset, 16.0f);
         break;
@@ -302,43 +302,43 @@ void CL_MuzzleFlash(void)
         dl->radius = 250 + (Q_rand() & 31);
         VectorSet(dl->color, 1, 1, 0);
         Q_snprintf(soundname, sizeof(soundname), "weapons/machgf%ib.wav", (Q_rand() % 5) + 1);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound(soundname), volume, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound(soundname), volume, ATTN_NORM, 0);
         Q_snprintf(soundname, sizeof(soundname), "weapons/machgf%ib.wav", (Q_rand() % 5) + 1);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound(soundname), volume, ATTN_NORM, 0.033f);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound(soundname), volume, ATTN_NORM, 0.033f);
         Q_snprintf(soundname, sizeof(soundname), "weapons/machgf%ib.wav", (Q_rand() % 5) + 1);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound(soundname), volume, ATTN_NORM, 0.066f);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound(soundname), volume, ATTN_NORM, 0.066f);
         const vec3_t offset = { 29.0f, 9.7f, -10.0f };
         CL_AddWeaponMuzzleFX(MFLASH_MACHN, offset, 20.0f);
         break;
     }
     case MZ_RAILGUN: {
         VectorSet(dl->color, 0.5f, 0.5f, 1.0f);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/railgf1a.wav"), volume, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/railgf1a.wav"), volume, ATTN_NORM, 0);
         if (cl_rerelease_effects->integer)
-            S_StartSound(NULL, mz.entity, CHAN_AUX3, S_RegisterSound("weapons/railgr1b.wav"), volume, ATTN_NORM, 0.4f);
+            S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_AUX3, S_RegisterSound("weapons/railgr1b.wav"), volume, ATTN_NORM, 0.4f);
         const vec3_t offset = { 20.0f, 5.2f, -7.0f };
         CL_AddWeaponMuzzleFX(MFLASH_RAIL, offset, 12.0f);
         break;
     }
     case MZ_ROCKET: {
         VectorSet(dl->color, 1, 0.5f, 0.2f);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/rocklf1a.wav"), volume, ATTN_NORM, 0);
-        S_StartSound(NULL, mz.entity, CHAN_AUTO,   S_RegisterSound("weapons/rocklr1b.wav"), volume, ATTN_NORM, cl_rerelease_effects->integer ? 0.15f : 0.1f);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/rocklf1a.wav"), volume, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_AUTO,   S_RegisterSound("weapons/rocklr1b.wav"), volume, ATTN_NORM, cl_rerelease_effects->integer ? 0.15f : 0.1f);
         const vec3_t offset = { 20.8f, 5.0f, -11.0f };
         CL_AddWeaponMuzzleFX(MFLASH_ROCKET, offset, 10.0f);
         break;
     }
     case MZ_GRENADE: {
         VectorSet(dl->color, 1, 0.5f, 0);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/grenlf1a.wav"), volume, ATTN_NORM, 0);
-        S_StartSound(NULL, mz.entity, CHAN_AUTO,   S_RegisterSound("weapons/grenlr1b.wav"), volume, ATTN_NORM, cl_rerelease_effects->integer ? 0.15f : 0.1f);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/grenlf1a.wav"), volume, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_AUTO,   S_RegisterSound("weapons/grenlr1b.wav"), volume, ATTN_NORM, cl_rerelease_effects->integer ? 0.15f : 0.1f);
         const vec3_t offset = { 18.0f, 6.0f, -6.5f };
         CL_AddWeaponMuzzleFX(MFLASH_LAUNCH, offset, 9.0f);
         break;
     }
     case MZ_BFG:
         VectorSet(dl->color, 0, 1, 0);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/bfg__f1y.wav"), volume, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/bfg__f1y.wav"), volume, ATTN_NORM, 0);
         break;
     case MZ_BFG2: {
         VectorSet(dl->color, 0, 1, 0);
@@ -349,22 +349,22 @@ void CL_MuzzleFlash(void)
 
     case MZ_LOGIN:
         VectorSet(dl->color, 0, 1, 0);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/grenlf1a.wav"), 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/grenlf1a.wav"), 1, ATTN_NORM, 0);
         CL_LogoutEffect(pl->current.origin, 0xd0);  // green
         break;
     case MZ_LOGOUT:
         VectorSet(dl->color, 1, 0, 0);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/grenlf1a.wav"), 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/grenlf1a.wav"), 1, ATTN_NORM, 0);
         CL_LogoutEffect(pl->current.origin, 0x40);  // red
         break;
     case MZ_RESPAWN:
         VectorSet(dl->color, 1, 1, 0);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/grenlf1a.wav"), 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/grenlf1a.wav"), 1, ATTN_NORM, 0);
         CL_LogoutEffect(pl->current.origin, 0xe0);  // yellow
         break;
     case MZ_PHALANX:
         VectorSet(dl->color, 1, 0.5f, 0.5f);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/plasshot.wav"), volume, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/plasshot.wav"), volume, ATTN_NORM, 0);
         break;
     case MZ_PHALANX2: {
         VectorSet(dl->color, 1, 0.5f, 0.5f);
@@ -374,7 +374,7 @@ void CL_MuzzleFlash(void)
     }
     case MZ_IONRIPPER: {
         VectorSet(dl->color, 1, 0.5f, 0.5f);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/rippfire.wav"), volume, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/rippfire.wav"), volume, ATTN_NORM, 0);
         const vec3_t offset = { 24.0f, 3.8f, -5.5f };
         CL_AddWeaponMuzzleFX(MFLASH_BOOMER, offset, 15.0f);
         break;
@@ -382,15 +382,15 @@ void CL_MuzzleFlash(void)
 
     case MZ_PROX: {
         VectorSet(dl->color, 1, 0.5f, 0);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/grenlf1a.wav"), volume, ATTN_NORM, 0);
-        S_StartSound(NULL, mz.entity, CHAN_AUTO,   S_RegisterSound("weapons/proxlr1a.wav"), volume, ATTN_NORM, cl_rerelease_effects->integer ? 0.15f : 0.1f);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/grenlf1a.wav"), volume, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_AUTO,   S_RegisterSound("weapons/proxlr1a.wav"), volume, ATTN_NORM, cl_rerelease_effects->integer ? 0.15f : 0.1f);
         const vec3_t offset = { 18.0f, 6.0f, -6.5f };
         CL_AddWeaponMuzzleFX(MFLASH_LAUNCH, offset, 9.0f);
         break;
     }
     case MZ_ETF_RIFLE: {
         VectorSet(dl->color, 0.9f, 0.7f, 0);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/nail1.wav"), volume, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/nail1.wav"), volume, ATTN_NORM, 0);
         const vec3_t offset = { 24.0f, 5.25f, -5.5f };
         CL_AddWeaponMuzzleFX(MFLASH_ETF_RIFLE, offset, 4.0f);
         break;
@@ -399,12 +399,12 @@ void CL_MuzzleFlash(void)
         // remaster overloads this as MZ_ETF_RIFLE_2
         if (cl.csr.extended) {
             VectorSet(dl->color, 0.9f, 0.7f, 0);
-            S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/nail1.wav"), volume, ATTN_NORM, 0);
+            S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/nail1.wav"), volume, ATTN_NORM, 0);
             const vec3_t offset = { 24.0f, 4.0f, -5.5f };
             CL_AddWeaponMuzzleFX(MFLASH_ETF_RIFLE, offset, 4.0f);
         } else {
             VectorSet(dl->color, 1, 1, 0);
-            S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/shotg2.wav"), volume, ATTN_NORM, 0);
+            S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/shotg2.wav"), volume, ATTN_NORM, 0);
         }
         break;
     case MZ_HEATBEAM: {
@@ -418,12 +418,12 @@ void CL_MuzzleFlash(void)
     case MZ_BLASTER2:
         VectorSet(dl->color, 0, 1, 0);
         // FIXME - different sound for blaster2 ??
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/blastf1a.wav"), volume, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/blastf1a.wav"), volume, ATTN_NORM, 0);
         break;
     case MZ_TRACKER: {
         // negative flashes handled the same in gl/soft until CL_AddDLights
         VectorSet(dl->color, -1, -1, -1);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/disint2.wav"), volume, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/disint2.wav"), volume, ATTN_NORM, 0);
         const vec3_t offset = { 18.0f, 6.0f, -6.5f };
         CL_AddWeaponMuzzleFX(MFLASH_DIST, offset, 10.0f);
         break;
@@ -519,7 +519,7 @@ void CL_MuzzleFlash2(void)
         VectorSet(dl->color, 1, 1, 0);
         CL_ParticleEffect(origin, vec3_origin, 0, 40);
         CL_SmokeAndFlash(origin);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("infantry/infatck1.wav"), 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("infantry/infatck1.wav"), 1, ATTN_NORM, 0);
         CL_AddMuzzleFX(flash_origin, ent->current.angles, MFLASH_MACHN, 0, 18.0f * scale);
         break;
 
@@ -535,7 +535,7 @@ void CL_MuzzleFlash2(void)
         VectorSet(dl->color, 1, 1, 0);
         CL_ParticleEffect(origin, vec3_origin, 0, 40);
         CL_SmokeAndFlash(origin);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("soldier/solatck3.wav"), 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("soldier/solatck3.wav"), 1, ATTN_NORM, 0);
         CL_AddMuzzleFX(flash_origin, ent->current.angles, MFLASH_MACHN, 0, 13.0f * scale);
         break;
 
@@ -550,7 +550,7 @@ void CL_MuzzleFlash2(void)
         VectorSet(dl->color, 1, 1, 0);
         CL_ParticleEffect(origin, vec3_origin, 0, 40);
         CL_SmokeAndFlash(origin);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("gunner/gunatck2.wav"), 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("gunner/gunatck2.wav"), 1, ATTN_NORM, 0);
         CL_AddMuzzleFX(flash_origin, ent->current.angles, MFLASH_MACHN, 0, 24.0f * scale);
         break;
 
@@ -565,7 +565,7 @@ void CL_MuzzleFlash2(void)
         VectorSet(dl->color, 1, 1, 0);
         CL_ParticleEffect(origin, vec3_origin, 0, 40);
         CL_SmokeAndFlash(origin);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("infantry/infatck1.wav"), 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("infantry/infatck1.wav"), 1, ATTN_NORM, 0);
         CL_AddMuzzleFX(flash_origin, ent->current.angles, MFLASH_MACHN, 0, 32.0f * scale);
         break;
 
@@ -578,12 +578,12 @@ void CL_MuzzleFlash2(void)
     case MZ2_CARRIER_MACHINEGUN_L2:
         VectorSet(dl->color, 1, 1, 0);
         if (cl.csr.extended && mz.weapon == MZ2_BOSS2_MACHINEGUN_L2) {
-            S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("flyer/flyatck3.wav"), 1, ATTN_NONE, 0);
+            S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("flyer/flyatck3.wav"), 1, ATTN_NONE, 0);
             CL_AddMuzzleFX(flash_origin, ent->current.angles, MFLASH_BLAST, 0, 12.0f * scale);
         } else {
             CL_ParticleEffect(origin, vec3_origin, 0, 40);
             CL_SmokeAndFlash(origin);
-            S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("infantry/infatck1.wav"), 1, ATTN_NONE, 0);
+            S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("infantry/infatck1.wav"), 1, ATTN_NONE, 0);
             CL_AddMuzzleFX(flash_origin, ent->current.angles, MFLASH_MACHN, 0, 32.0f * scale);
         }
         break;
@@ -599,14 +599,14 @@ void CL_MuzzleFlash2(void)
     case MZ2_SOLDIER_BLASTER_9:
     case MZ2_TURRET_BLASTER:
         VectorSet(dl->color, 1, 1, 0);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("soldier/solatck2.wav"), 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("soldier/solatck2.wav"), 1, ATTN_NORM, 0);
         CL_AddMuzzleFX(flash_origin, ent->current.angles, MFLASH_BLAST, 0, 8.0f * scale);
         break;
 
     case MZ2_FLYER_BLASTER_1:
     case MZ2_FLYER_BLASTER_2:
         VectorSet(dl->color, 1, 1, 0);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("flyer/flyatck3.wav"), 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("flyer/flyatck3.wav"), 1, ATTN_NORM, 0);
         CL_AddMuzzleFX(flash_origin, ent->current.angles, MFLASH_BLAST, 0, 8.0f * scale);
         break;
 
@@ -624,20 +624,20 @@ void CL_MuzzleFlash2(void)
     case MZ2_MEDIC_HYPERBLASTER1_11:
     case MZ2_MEDIC_HYPERBLASTER1_12:
         VectorSet(dl->color, 1, 1, 0);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("medic/medatck1.wav"), 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("medic/medatck1.wav"), 1, ATTN_NORM, 0);
         CL_AddMuzzleFX(flash_origin, ent->current.angles, MFLASH_BLAST, 0, 8.0f * scale);
         break;
 
     case MZ2_HOVER_BLASTER_1:
     case MZ2_HOVER_BLASTER_2:
         VectorSet(dl->color, 1, 1, 0);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("hover/hovatck1.wav"), 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("hover/hovatck1.wav"), 1, ATTN_NORM, 0);
         CL_AddMuzzleFX(flash_origin, ent->current.angles, MFLASH_BLAST, 0, 8.0f * scale);
         break;
 
     case MZ2_FLOAT_BLASTER_1:
         VectorSet(dl->color, 1, 1, 0);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("floater/fltatck1.wav"), 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("floater/fltatck1.wav"), 1, ATTN_NORM, 0);
         CL_AddMuzzleFX(flash_origin, ent->current.angles, MFLASH_BLAST, 0, 8.0f * scale);
         break;
 
@@ -652,7 +652,7 @@ void CL_MuzzleFlash2(void)
     case MZ2_SOLDIER_SHOTGUN_9:
         VectorSet(dl->color, 1, 1, 0);
         CL_SmokeAndFlash(origin);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("soldier/solatck1.wav"), 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("soldier/solatck1.wav"), 1, ATTN_NORM, 0);
         CL_AddMuzzleFX(flash_origin, ent->current.angles, MFLASH_SHOTG, 0, 17.0f * scale);
         break;
 
@@ -660,7 +660,7 @@ void CL_MuzzleFlash2(void)
     case MZ2_TANK_BLASTER_2:
     case MZ2_TANK_BLASTER_3:
         VectorSet(dl->color, 1, 1, 0);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("tank/tnkatck3.wav"), 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("tank/tnkatck3.wav"), 1, ATTN_NORM, 0);
         CL_AddMuzzleFX(flash_origin, ent->current.angles, MFLASH_BLAST, 0, 24.0f * scale);
         break;
 
@@ -687,14 +687,14 @@ void CL_MuzzleFlash2(void)
         CL_ParticleEffect(origin, vec3_origin, 0, 40);
         CL_SmokeAndFlash(origin);
         Q_snprintf(soundname, sizeof(soundname), "tank/tnkatk2%c.wav", 'a' + Q_rand() % 5);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound(soundname), 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound(soundname), 1, ATTN_NORM, 0);
         CL_AddMuzzleFX(flash_origin, ent->current.angles, MFLASH_MACHN, 0, 20.0f * scale);
         break;
 
     case MZ2_CHICK_ROCKET_1:
     case MZ2_TURRET_ROCKET:
         VectorSet(dl->color, 1, 0.5f, 0.2f);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("chick/chkatck2.wav"), 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("chick/chkatck2.wav"), 1, ATTN_NORM, 0);
         CL_AddMuzzleFX(flash_origin, ent->current.angles, MFLASH_ROCKET, 0, 16.0f * scale);
         break;
 
@@ -702,7 +702,7 @@ void CL_MuzzleFlash2(void)
     case MZ2_TANK_ROCKET_2:
     case MZ2_TANK_ROCKET_3:
         VectorSet(dl->color, 1, 0.5f, 0.2f);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("tank/tnkatck1.wav"), 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("tank/tnkatck1.wav"), 1, ATTN_NORM, 0);
         CL_AddMuzzleFX(flash_origin, ent->current.angles, MFLASH_ROCKET, 0, 28.0f * scale);
         break;
 
@@ -718,7 +718,7 @@ void CL_MuzzleFlash2(void)
 //  case MZ2_CARRIER_ROCKET_3:
 //  case MZ2_CARRIER_ROCKET_4:
         VectorSet(dl->color, 1, 0.5f, 0.2f);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("tank/rocket.wav"), 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("tank/rocket.wav"), 1, ATTN_NORM, 0);
         CL_AddMuzzleFX(flash_origin, ent->current.angles, MFLASH_ROCKET, 0, 28.0f * scale);
         break;
 
@@ -733,7 +733,7 @@ void CL_MuzzleFlash2(void)
     case MZ2_SUPERTANK_GRENADE_1:
     case MZ2_SUPERTANK_GRENADE_2:
         VectorSet(dl->color, 1, 0.5f, 0);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("gunner/gunatck3.wav"), 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("gunner/gunatck3.wav"), 1, ATTN_NORM, 0);
         CL_AddMuzzleFX(flash_origin, ent->current.angles, MFLASH_LAUNCH, 0, 18.0f * scale);
         break;
 
@@ -773,7 +773,7 @@ void CL_MuzzleFlash2(void)
     case MZ2_MAKRON_BLASTER_16:
     case MZ2_MAKRON_BLASTER_17:
         VectorSet(dl->color, 1, 1, 0);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("makron/blaster.wav"), 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("makron/blaster.wav"), 1, ATTN_NORM, 0);
         CL_AddMuzzleFX(flash_origin, ent->current.angles, MFLASH_BLAST, 0, 22.0f * scale);
         break;
 
@@ -786,7 +786,7 @@ void CL_MuzzleFlash2(void)
         VectorSet(dl->color, 1, 1, 0);
         CL_ParticleEffect(origin, vec3_origin, 0, 40);
         CL_SmokeAndFlash(origin);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("boss3/xfire.wav"), 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("boss3/xfire.wav"), 1, ATTN_NORM, 0);
         CL_AddMuzzleFX(flash_origin, ent->current.angles, MFLASH_MACHN, 0, 32.0f * scale);
         break;
 
@@ -815,7 +815,7 @@ void CL_MuzzleFlash2(void)
     case MZ2_CARRIER_MACHINEGUN_R1:
     case MZ2_CARRIER_MACHINEGUN_R2:
         if (cl.csr.extended && mz.weapon == MZ2_BOSS2_MACHINEGUN_R2) {
-            S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("flyer/flyatck3.wav"), 1, ATTN_NONE, 0);
+            S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("flyer/flyatck3.wav"), 1, ATTN_NONE, 0);
             CL_AddMuzzleFX(flash_origin, ent->current.angles, MFLASH_BLAST, 0, 12.0f * scale);
         } else {
             VectorSet(dl->color, 1, 1, 0);
@@ -878,13 +878,13 @@ void CL_MuzzleFlash2(void)
     case MZ2_MEDIC_HYPERBLASTER2_11:
     case MZ2_MEDIC_HYPERBLASTER2_12:
         VectorSet(dl->color, 0, 1, 0);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("tank/tnkatck3.wav"), 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("tank/tnkatck3.wav"), 1, ATTN_NORM, 0);
         CL_AddMuzzleFX(flash_origin, ent->current.angles, MFLASH_BLAST, 2, 22.0f * scale);
         break;
 
     case MZ2_WIDOW_DISRUPTOR:
         VectorSet(dl->color, -1, -1, -1);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/disint2.wav"), 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/disint2.wav"), 1, ATTN_NORM, 0);
         CL_AddMuzzleFX(flash_origin, ent->current.angles, MFLASH_DIST, 0, 32.0f * scale);
         break;
 
@@ -921,7 +921,7 @@ void CL_MuzzleFlash2(void)
     case MZ2_SOLDIER_RIPPER_8:
     case MZ2_SOLDIER_RIPPER_9:
         VectorSet(dl->color, 1, 0.5f, 0.5f);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/rippfire.wav"), 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/rippfire.wav"), 1, ATTN_NORM, 0);
         CL_AddMuzzleFX(flash_origin, ent->current.angles, MFLASH_BOOMER, 0, 32.0f * scale);
         break;
 
@@ -935,20 +935,20 @@ void CL_MuzzleFlash2(void)
     case MZ2_SOLDIER_HYPERGUN_8:
     case MZ2_SOLDIER_HYPERGUN_9:
         VectorSet(dl->color, 0, 0, 1);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/hyprbf1a.wav"), 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/hyprbf1a.wav"), 1, ATTN_NORM, 0);
         CL_AddMuzzleFX(flash_origin, ent->current.angles, MFLASH_BLAST, 1, 8.0f * scale);
         break;
 
     case MZ2_GUARDIAN_BLASTER:
         VectorSet(dl->color, 1, 1, 0);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/hyprbf1a.wav"), 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("weapons/hyprbf1a.wav"), 1, ATTN_NORM, 0);
         CL_AddMuzzleFX(flash_origin, ent->current.angles, MFLASH_BLAST, 0, 16.0f * scale);
         break;
 
     case MZ2_GUNCMDR_CHAINGUN_1:
     case MZ2_GUNCMDR_CHAINGUN_2:
         VectorSet(dl->color, 0, 0, 1);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("guncmdr/gcdratck2.wav"), 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("guncmdr/gcdratck2.wav"), 1, ATTN_NORM, 0);
         CL_AddMuzzleFX(flash_origin, ent->current.angles, MFLASH_ETF_RIFLE, 0, 16.0f * scale);
         break;
 
@@ -959,7 +959,7 @@ void CL_MuzzleFlash2(void)
     case MZ2_GUNCMDR_GRENADE_FRONT_2:
     case MZ2_GUNCMDR_GRENADE_FRONT_3:
         VectorSet(dl->color, 1, 0.5f, 0);
-        S_StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("guncmdr/gcdratck3.wav"), 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, mz.entity, CHAN_WEAPON, S_RegisterSound("guncmdr/gcdratck3.wav"), 1, ATTN_NORM, 0);
         CL_AddMuzzleFX(flash_origin, ent->current.angles, MFLASH_LAUNCH, 0, 18.0f * scale);
         break;
     }

--- a/src/client/entities.cpp
+++ b/src/client/entities.cpp
@@ -245,11 +245,11 @@ static void parse_entity_event(int number)
 
     switch (cent->current.event) {
     case EV_ITEM_RESPAWN:
-        S_StartSound(NULL, number, CHAN_WEAPON, S_RegisterSound("items/respawn1.wav"), 1, ATTN_IDLE, 0);
+        S_GetSoundSystem().StartSound(NULL, number, CHAN_WEAPON, S_RegisterSound("items/respawn1.wav"), 1, ATTN_IDLE, 0);
         CL_ItemRespawnParticles(cent->current.origin);
         break;
     case EV_PLAYER_TELEPORT:
-        S_StartSound(NULL, number, CHAN_WEAPON, S_RegisterSound("misc/tele1.wav"), 1, ATTN_IDLE, 0);
+        S_GetSoundSystem().StartSound(NULL, number, CHAN_WEAPON, S_RegisterSound("misc/tele1.wav"), 1, ATTN_IDLE, 0);
         CL_TeleportParticles(cent->current.origin);
         break;
     case EV_FOOTSTEP:
@@ -265,13 +265,13 @@ static void parse_entity_event(int number)
             CL_PlayFootstepSfx(FOOTSTEP_ID_LADDER, number, 0.5f, ATTN_IDLE);
         break;
     case EV_FALLSHORT:
-        S_StartSound(NULL, number, CHAN_AUTO, S_RegisterSound("player/land1.wav"), 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, number, CHAN_AUTO, S_RegisterSound("player/land1.wav"), 1, ATTN_NORM, 0);
         break;
     case EV_FALL:
-        S_StartSound(NULL, number, CHAN_AUTO, S_RegisterSound("*fall2.wav"), 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, number, CHAN_AUTO, S_RegisterSound("*fall2.wav"), 1, ATTN_NORM, 0);
         break;
     case EV_FALLFAR:
-        S_StartSound(NULL, number, CHAN_AUTO, S_RegisterSound("*fall1.wav"), 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(NULL, number, CHAN_AUTO, S_RegisterSound("*fall1.wav"), 1, ATTN_NORM, 0);
         break;
     }
 }

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -692,7 +692,7 @@ CL_ClearState
 */
 void CL_ClearState(void)
 {
-    S_StopAllSounds();
+    S_GetSoundSystem().StopAllSounds();
     SCR_StopCinematic();
     CL_ClearEffects();
     CL_ClearTEnts();
@@ -1404,7 +1404,7 @@ static void CL_ConnectionlessPacket(void)
             q2proto_client_write(&cls.q2proto_ctx, Q2PROTO_IOARG_CLIENT_WRITE, &nop_message);
             MSG_FlushTo(&cls.netchan.message);
             Netchan_Transmit(&cls.netchan, 0, NULL, 3);
-            S_StopAllSounds();
+            S_GetSoundSystem().StopAllSounds();
             cls.connect_count = -1;
             Com_Printf("Loading anticheat, this may take a few moments...\n");
             SCR_UpdateScreen();
@@ -1750,7 +1750,7 @@ static void CL_Precache_f(void)
     cls.state = ca_loading;
     CL_LoadState(LOAD_MAP);
 
-    S_StopAllSounds();
+    S_GetSoundSystem().StopAllSounds();
 
     CL_RegisterVWepModels();
 
@@ -2400,7 +2400,7 @@ void CL_RestartFilesystem(bool total)
 
     UI_Shutdown();
 
-    S_StopAllSounds();
+    S_GetSoundSystem().StopAllSounds();
     S_FreeAllSounds();
 
     // write current config before changing game directory
@@ -2463,7 +2463,7 @@ void CL_RestartRefresh(bool total)
 
     Con_Popup(false);
 
-    S_StopAllSounds();
+    S_GetSoundSystem().StopAllSounds();
 
     if (total) {
         IN_Shutdown();
@@ -3270,7 +3270,7 @@ void CL_AddHitMarker(void)
         cl.hit_marker_count++;
 
         if (cl_hit_markers->integer > 1)
-            S_StartSound(NULL, listener_entnum, 257, cl.sfx_hit_marker, 1, ATTN_NONE, 0);
+            S_GetSoundSystem().StartSound(NULL, listener_entnum, 257, cl.sfx_hit_marker, 1, ATTN_NONE, 0);
     }
 }
 
@@ -3434,11 +3434,11 @@ unsigned CL_Frame(unsigned msec)
         R_FRAMES++;
 
         // update audio after the 3D view was drawn
-        S_Update();
+        S_GetSoundSystem().Update();
     } else if (sync_mode == SYNC_SLEEP_10) {
         // force audio and effects update if not rendering
         CL_CalcViewValues();
-        S_Update();
+        S_GetSoundSystem().Update();
     }
 
     // check connection timeout

--- a/src/client/screen.cpp
+++ b/src/client/screen.cpp
@@ -1878,7 +1878,7 @@ void SCR_BeginLoadingPlaque(void)
         return;
     }
 
-    S_StopAllSounds();
+    S_GetSoundSystem().StopAllSounds();
     OGG_Update();
 
     if (cls.disable_screen) {

--- a/src/client/sound/SoundSystem.cpp
+++ b/src/client/sound/SoundSystem.cpp
@@ -22,13 +22,16 @@ void SoundSystem::Configure(const Config &config)
 void SoundSystem::InitializeStorage()
 {
     known_sfx_.assign(config_.maxSfx, sfx_t{});
-    playsounds_.assign(config_.maxPlaysounds, playsound_t{});
+    playsounds_.clear();
+    playsounds_.reserve(config_.maxPlaysounds);
     freeplays_.clear();
     pendingplays_.clear();
-    for (auto &ps : playsounds_) {
-        std::memset(&ps, 0, sizeof(ps));
-        List_Init(&ps.entry);
-        freeplays_.push_back(&ps);
+    for (std::size_t i = 0; i < config_.maxPlaysounds; ++i) {
+        auto playsound = std::make_unique<playsound_t>();
+        std::memset(playsound.get(), 0, sizeof(*playsound));
+        List_Init(&playsound->entry);
+        freeplays_.push_back(playsound.get());
+        playsounds_.push_back(std::move(playsound));
     }
 
     num_sfx_ = 0;
@@ -166,10 +169,10 @@ void SoundSystem::ResetPlaysounds()
 {
     pendingplays_.clear();
     freeplays_.clear();
-    for (auto &ps : playsounds_) {
-        std::memset(&ps, 0, sizeof(ps));
-        List_Init(&ps.entry);
-        freeplays_.push_back(&ps);
+    for (auto &playsound : playsounds_) {
+        std::memset(playsound.get(), 0, sizeof(*playsound));
+        List_Init(&playsound->entry);
+        freeplays_.push_back(playsound.get());
     }
 }
 

--- a/src/client/sound/SoundSystem.hpp
+++ b/src/client/sound/SoundSystem.hpp
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <deque>
+#include <memory>
 #include <vector>
 
 #include "sound.hpp"
@@ -46,6 +47,19 @@ public:
     bool HasPendingPlays() const;
     void ResetPlaysounds();
 
+    sfx_t *SfxForHandle(qhandle_t hSfx);
+    sfxcache_t *LoadSound(sfx_t *s);
+    channel_t *PickChannel(int entnum, int entchannel);
+    void IssuePlaysound(playsound_t *ps);
+    int BuildSoundList(int *sounds);
+    void SpatializeOrigin(const vec3_t origin, float master_vol, float dist_mult,
+                          float *left_vol, float *right_vol, bool stereo);
+
+    void StartSound(const vec3_t origin, int entnum, int entchannel, qhandle_t hSfx,
+                    float vol, float attenuation, float timeofs);
+    void StopAllSounds();
+    void Update();
+
     vec3_t &listener_origin();
     vec3_t &listener_forward();
     vec3_t &listener_right();
@@ -62,7 +76,7 @@ private:
     std::vector<channel_t> channels_;
     int num_channels_ = 0;
     int max_channels_ = 0;
-    std::vector<playsound_t> playsounds_;
+    std::vector<std::unique_ptr<playsound_t>> playsounds_;
     std::deque<playsound_t *> freeplays_;
     std::deque<playsound_t *> pendingplays_;
     vec3_t listener_origin_ = { 0.0f, 0.0f, 0.0f };

--- a/src/client/sound/al.cpp
+++ b/src/client/sound/al.cpp
@@ -579,7 +579,7 @@ static void s_underwater_gain_hf_changed(cvar_t *self)
 
 static void al_reverb_changed(cvar_t *self)
 {
-    S_StopAllSounds();
+    S_GetSoundSystem().StopAllSounds();
 }
 
 static void al_merge_looping_changed(cvar_t *self)
@@ -958,7 +958,7 @@ static void AL_IssuePlaysounds(void)
             break;  // no more pending sounds
         if (ps->begin > s_paintedtime)
             break;
-        S_IssuePlaysound(ps);
+        S_GetSoundSystem().IssuePlaysound(ps);
     }
 }
 
@@ -1013,14 +1013,14 @@ static void AL_MergeLoopSounds(void)
     entity_state_t *ent;
     vec3_t      origin;
 
-    if (!S_BuildSoundList(sounds))
+    if (!S_GetSoundSystem().BuildSoundList(sounds))
         return;
 
     for (i = 0; i < cl.frame.numEntities; i++) {
         if (!sounds[i])
             continue;
 
-        sfx = S_SfxForHandle(cl.sound_precache[sounds[i]]);
+        sfx = S_GetSoundSystem().SfxForHandle(cl.sound_precache[sounds[i]]);
         if (!sfx)
             continue;       // bad sound effect
         sc = sfx->cache;
@@ -1041,7 +1041,7 @@ static void AL_MergeLoopSounds(void)
             VectorSubtract(origin, offset, base);
             CL_DebugTrail(base, origin);
         }
-        S_SpatializeOrigin(origin, vol, att,
+        S_GetSoundSystem().SpatializeOrigin(origin, vol, att,
                            &left_total, &right_total,
                            S_GetEntityLoopStereoPan(ent));
         for (j = i + 1; j < cl.frame.numEntities; j++) {
@@ -1058,7 +1058,7 @@ static void AL_MergeLoopSounds(void)
                 VectorSubtract(origin, offset, base);
                 CL_DebugTrail(base, origin);
             }
-            S_SpatializeOrigin(origin,
+            S_GetSoundSystem().SpatializeOrigin(origin,
                                S_GetEntityLoopVolume(ent),
                                S_GetEntityLoopDistMult(ent),
                                &left, &right,
@@ -1088,7 +1088,7 @@ static void AL_MergeLoopSounds(void)
         }
 
         // allocate a channel
-        ch = S_PickChannel(0, 0);
+        ch = S_GetSoundSystem().PickChannel(0, 0);
         if (!ch)
             continue;
 
@@ -1138,13 +1138,13 @@ static void AL_AddLoopSounds(void)
     if (cls.state != ca_active || sv_paused->integer || !s_ambient->integer)
         return;
 
-    S_BuildSoundList(sounds);
+    S_GetSoundSystem().BuildSoundList(sounds);
 
     for (i = 0; i < cl.frame.numEntities; i++) {
         if (!sounds[i])
             continue;
 
-        sfx = S_SfxForHandle(cl.sound_precache[sounds[i]]);
+        sfx = S_GetSoundSystem().SfxForHandle(cl.sound_precache[sounds[i]]);
         if (!sfx)
             continue;       // bad sound effect
         sc = sfx->cache;
@@ -1162,7 +1162,7 @@ static void AL_AddLoopSounds(void)
         }
 
         // allocate a channel
-        ch = S_PickChannel(0, 0);
+        ch = S_GetSoundSystem().PickChannel(0, 0);
         if (!ch)
             continue;
 
@@ -1296,7 +1296,7 @@ static void AL_UpdateUnderWater(void)
 
 static void AL_Activate(void)
 {
-    S_StopAllSounds();
+    S_GetSoundSystem().StopAllSounds();
     AL_StreamPause(s_stream_paused);
 }
 
@@ -1316,7 +1316,7 @@ static void AL_Update(void)
     // handle time wraparound. FIXME: get rid of this?
     i = cls.realtime & MASK(30);
     if (i < s_paintedtime)
-        S_StopAllSounds();
+        S_GetSoundSystem().StopAllSounds();
     s_paintedtime = i;
 
     // set listener parameters

--- a/src/client/sound/dma.cpp
+++ b/src/client/sound/dma.cpp
@@ -445,7 +445,7 @@ static void PaintChannels(int endtime)
                 end = min(end, ps->begin);  // stop here
                 break;
             }
-            S_IssuePlaysound(ps);
+            S_GetSoundSystem().IssuePlaysound(ps);
         }
 
         // clear the paint buffer
@@ -461,7 +461,7 @@ static void PaintChannels(int endtime)
                 if (!ch->sfx || (!ch->leftvol && !ch->rightvol))
                     break;
 
-                sfxcache_t *sc = S_LoadSound(ch->sfx);
+                sfxcache_t *sc = S_GetSoundSystem().LoadSound(ch->sfx);
                 if (!sc)
                     break;
 
@@ -619,7 +619,7 @@ static void DMA_Shutdown(void)
 static void DMA_Activate(void)
 {
     if (snddma->activate) {
-        S_StopAllSounds();
+        S_GetSoundSystem().StopAllSounds();
         snddma->activate(s_active);
     }
 }
@@ -692,7 +692,7 @@ static void DMA_Spatialize(channel_t *ch)
         }
     }
 
-    S_SpatializeOrigin(origin, ch->master_vol, ch->dist_mult, &ch->leftvol, &ch->rightvol, dma.channels - 1);
+    S_GetSoundSystem().SpatializeOrigin(origin, ch->master_vol, ch->dist_mult, &ch->leftvol, &ch->rightvol, dma.channels - 1);
 }
 
 #define GET_STEREO(ent) (S_GetEntityLoopStereoPan(ent) && dma.channels - 1)
@@ -718,14 +718,14 @@ static void AddLoopSounds(void)
     entity_state_t *ent;
     vec3_t      origin;
 
-    if (!S_BuildSoundList(sounds))
+    if (!S_GetSoundSystem().BuildSoundList(sounds))
         return;
 
     for (i = 0; i < cl.frame.numEntities; i++) {
         if (!sounds[i])
             continue;
 
-        sfx = S_SfxForHandle(cl.sound_precache[sounds[i]]);
+        sfx = S_GetSoundSystem().SfxForHandle(cl.sound_precache[sounds[i]]);
         if (!sfx)
             continue;       // bad sound effect
         sc = sfx->cache;
@@ -746,7 +746,7 @@ static void AddLoopSounds(void)
             VectorSubtract(origin, offset, base);
             CL_DebugTrail(base, origin);
         }
-        S_SpatializeOrigin(origin, vol, att, &left_total,
+        S_GetSoundSystem().SpatializeOrigin(origin, vol, att, &left_total,
                            &right_total, GET_STEREO(ent));
         for (j = i + 1; j < cl.frame.numEntities; j++) {
             if (sounds[j] != sounds[i])
@@ -762,7 +762,7 @@ static void AddLoopSounds(void)
                 VectorSubtract(origin, offset, base);
                 CL_DebugTrail(base, origin);
             }
-            S_SpatializeOrigin(origin,
+            S_GetSoundSystem().SpatializeOrigin(origin,
                                S_GetEntityLoopVolume(ent),
                                S_GetEntityLoopDistMult(ent),
                                &left, &right, GET_STEREO(ent));
@@ -774,7 +774,7 @@ static void AddLoopSounds(void)
             continue;       // not audible
 
         // allocate a channel
-        ch = S_PickChannel(0, 0);
+        ch = S_GetSoundSystem().PickChannel(0, 0);
         if (!ch)
             return;
 
@@ -803,7 +803,7 @@ static int DMA_GetTime(void)
             // time to chop things off to avoid 32 bit limits
             buffers = 0;
             s_rawend = s_paintedtime = fullsamples;
-            S_StopAllSounds();
+            S_GetSoundSystem().StopAllSounds();
         }
     }
     oldsamplepos = dma.samplepos;

--- a/src/client/sound/main.cpp
+++ b/src/client/sound/main.cpp
@@ -98,8 +98,13 @@ static void S_SoundList_f(void)
     Com_Printf("Total resident: %zu\n", total);
 }
 
+static void S_StopAllSounds_Cmd(void)
+{
+    S_GetSoundSystem().StopAllSounds();
+}
+
 static const cmdreg_t c_sound[] = {
-    { "stopsound", S_StopAllSounds },
+    { "stopsound", S_StopAllSounds_Cmd },
     { "soundlist", S_SoundList_f },
     { "soundinfo", S_SoundInfo_f },
 
@@ -174,7 +179,7 @@ void S_Init(void)
 
     // init playsound list
     // clear DMA buffer
-    S_StopAllSounds();
+    soundSystem.StopAllSounds();
 
     s_auto_focus->changed = s_auto_focus_changed;
     s_auto_focus_changed(s_auto_focus);
@@ -229,7 +234,7 @@ void S_Shutdown(void)
     if (s_started == SoundBackend::Not)
         return;
 
-    S_StopAllSounds();
+    S_GetSoundSystem().StopAllSounds();
     S_FreeAllSounds();
     OGG_Stop();
 
@@ -283,17 +288,14 @@ void S_Activate(void)
 S_SfxForHandle
 ==================
 */
-sfx_t *S_SfxForHandle(qhandle_t hSfx)
+sfx_t *SoundSystem::SfxForHandle(qhandle_t hSfx)
 {
     if (!hSfx) {
         return NULL;
     }
 
-    SoundSystem &soundSystem = S_GetSoundSystem();
-    int num_sfx = soundSystem.num_sfx();
-    Q_assert(hSfx > 0 && hSfx <= num_sfx);
-    sfx_t *known_sfx = soundSystem.known_sfx_data();
-    return &known_sfx[hSfx - 1];
+    Q_assert(hSfx > 0 && hSfx <= num_sfx_);
+    return &known_sfx_[hSfx - 1];
 }
 
 static sfx_t *S_AllocSfx(void)
@@ -412,7 +414,7 @@ qhandle_t S_RegisterSound(const char *name)
     }
 
     if (!s_registering) {
-        S_LoadSound(sfx);
+        soundSystem.LoadSound(sfx);
     }
 
     return static_cast<qhandle_t>((sfx - known_sfx) + 1);
@@ -447,7 +449,7 @@ static sfx_t *S_RegisterSexedSound(int entnum, const char *base)
     sfx = S_FindName(buffer, FS_NormalizePath(buffer));
 
     // see if it exists
-    if (sfx && !sfx->truename && !s_registering && !S_LoadSound(sfx)) {
+    if (sfx && !sfx->truename && !s_registering && !S_GetSoundSystem().LoadSound(sfx)) {
         // no, revert to the male sound in the pak0.pak
         if (Q_concat(buffer, MAX_QPATH, "sound/player/male/", base + 1) < MAX_QPATH) {
             FS_NormalizePath(buffer);
@@ -504,7 +506,7 @@ void S_EndRegistration(void)
     S_RegisterSexedSounds();
 
     // clear playsound list, so we don't free sfx still present there
-    S_StopAllSounds();
+    soundSystem.StopAllSounds();
 
     // free any sounds not from this registration sequence
     for (int i = 0; i < num_sfx; i++) {
@@ -526,7 +528,7 @@ void S_EndRegistration(void)
         sfx_t *sfx = &known_sfx[i];
         if (!sfx->name[0])
             continue;
-        S_LoadSound(sfx);
+        soundSystem.LoadSound(sfx);
     }
 
     if (s_started != SoundBackend::Not && s_api->end_registration)
@@ -545,25 +547,21 @@ S_PickChannel
 picks a channel based on priorities, empty slots, number of channels
 =================
 */
-channel_t *S_PickChannel(int entnum, int entchannel)
+channel_t *SoundSystem::PickChannel(int entnum, int entchannel)
 {
     int         ch_idx;
     int         first_to_die;
     int         life_left;
     channel_t   *ch;
 
-    SoundSystem &soundSystem = S_GetSoundSystem();
-    channel_t *channels = soundSystem.channels_data();
-    int num_channels = soundSystem.num_channels();
-
-    if (!channels || num_channels <= 0)
+    if (channels_.empty() || num_channels_ <= 0)
         return NULL;
 
 // Check for replacement sound, or find the best one to replace
     first_to_die = -1;
     life_left = INT_MAX;
-    for (ch_idx = 0; ch_idx < num_channels; ch_idx++) {
-        ch = &channels[ch_idx];
+    for (ch_idx = 0; ch_idx < num_channels_; ch_idx++) {
+        ch = &channels_[ch_idx];
         // channel 0 never overrides unless out of channels
         if (ch->entnum == entnum && ch->entchannel == entchannel && entchannel != 0) {
             if (entchannel > 255 && ch->sfx)
@@ -586,33 +584,13 @@ channel_t *S_PickChannel(int entnum, int entchannel)
     if (first_to_die == -1)
         return NULL;
 
-    ch = &channels[first_to_die];
+    ch = &channels_[first_to_die];
     if (s_api->stop_channel)
         s_api->stop_channel(ch);
     memset(ch, 0, sizeof(*ch));
     ch->has_spatial_offset = false;
 
     return ch;
-}
-
-/*
-=================
-S_AllocPlaysound
-=================
-*/
-static playsound_t *S_AllocPlaysound(void)
-{
-    return S_GetSoundSystem().AllocatePlaysound();
-}
-
-/*
-=================
-S_FreePlaysound
-=================
-*/
-static void S_FreePlaysound(playsound_t *ps)
-{
-    S_GetSoundSystem().FreePlaysound(ps);
 }
 
 /*
@@ -624,7 +602,7 @@ This is never called directly by S_Play*, but only
 by the update loop.
 ===============
 */
-void S_IssuePlaysound(playsound_t *ps)
+void SoundSystem::IssuePlaysound(playsound_t *ps)
 {
     channel_t   *ch;
     sfxcache_t  *sc;
@@ -634,16 +612,16 @@ void S_IssuePlaysound(playsound_t *ps)
         Com_Printf("Issue %i\n", ps->begin);
 #endif
     // pick a channel to play on
-    ch = S_PickChannel(ps->entnum, ps->entchannel);
+    ch = PickChannel(ps->entnum, ps->entchannel);
     if (!ch) {
-        S_FreePlaysound(ps);
+        FreePlaysound(ps);
         return;
     }
 
-    sc = S_LoadSound(ps->sfx);
+    sc = LoadSound(ps->sfx);
     if (!sc) {
         Com_Printf("S_IssuePlaysound: couldn't load %s\n", ps->sfx->name);
-        S_FreePlaysound(ps);
+        FreePlaysound(ps);
         return;
     }
 
@@ -664,7 +642,7 @@ void S_IssuePlaysound(playsound_t *ps)
     s_api->play_channel(ch);
 
     // free the playsound
-    S_FreePlaysound(ps);
+    FreePlaysound(ps);
 }
 
 // =======================================================================
@@ -680,7 +658,7 @@ if pos is NULL, the sound will be dynamically sourced from the entity
 Entchannel 0 will never override a playing sound
 ====================
 */
-void S_StartSound(const vec3_t origin, int entnum, int entchannel, qhandle_t hSfx, float vol, float attenuation, float timeofs)
+void SoundSystem::StartSound(const vec3_t origin, int entnum, int entchannel, qhandle_t hSfx, float vol, float attenuation, float timeofs)
 {
     sfxcache_t  *sc;
     playsound_t *ps;
@@ -690,10 +668,8 @@ void S_StartSound(const vec3_t origin, int entnum, int entchannel, qhandle_t hSf
         return;
     if (!s_active)
         return;
-    if (!(sfx = S_SfxForHandle(hSfx)))
+    if (!(sfx = SfxForHandle(hSfx)))
         return;
-
-    SoundSystem &soundSystem = S_GetSoundSystem();
 
     if (sfx->name[0] == '*') {
         sfx = S_RegisterSexedSound(entnum, sfx->name);
@@ -702,12 +678,12 @@ void S_StartSound(const vec3_t origin, int entnum, int entchannel, qhandle_t hSf
     }
 
     // make sure the sound is loaded
-    sc = S_LoadSound(sfx);
+    sc = LoadSound(sfx);
     if (!sc)
         return;     // couldn't load the sound's data
 
     // make the playsound_t
-    ps = S_AllocPlaysound();
+    ps = AllocatePlaysound();
     if (!ps)
         return;
 
@@ -726,7 +702,7 @@ void S_StartSound(const vec3_t origin, int entnum, int entchannel, qhandle_t hSf
     ps->begin = s_api->get_begin_ofs(timeofs);
 
     // sort into the pending sound list
-    soundSystem.QueuePendingPlay(ps);
+    QueuePendingPlay(ps);
 }
 
 void S_ParseStartSound(void)
@@ -741,9 +717,9 @@ void S_ParseStartSound(void)
         CL_CheckEntityPresent(snd.entity, "sound");
 #endif
 
-    S_StartSound(snd.has_position ? snd.pos : NULL,
-                 snd.entity, snd.channel, handle,
-                 snd.volume, snd.attenuation, snd.timeofs);
+    S_GetSoundSystem().StartSound(snd.has_position ? snd.pos : NULL,
+                                  snd.entity, snd.channel, handle,
+                                  snd.volume, snd.attenuation, snd.timeofs);
 }
 
 /*
@@ -755,7 +731,7 @@ void S_StartLocalSound(const char *sound)
 {
     if (s_started != SoundBackend::Not) {
         qhandle_t sfx = S_RegisterSound(sound);
-        S_StartSound(NULL, listener_entnum, 0, sfx, 1, ATTN_NONE, 0);
+        S_GetSoundSystem().StartSound(NULL, listener_entnum, 0, sfx, 1, ATTN_NONE, 0);
     }
 }
 
@@ -763,7 +739,7 @@ void S_StartLocalSoundOnce(const char *sound)
 {
     if (s_started != SoundBackend::Not) {
         qhandle_t sfx = S_RegisterSound(sound);
-        S_StartSound(NULL, listener_entnum, 256, sfx, 1, ATTN_NONE, 0);
+        S_GetSoundSystem().StartSound(NULL, listener_entnum, 256, sfx, 1, ATTN_NONE, 0);
     }
 }
 
@@ -772,18 +748,17 @@ void S_StartLocalSoundOnce(const char *sound)
 S_StopAllSounds
 ==================
 */
-void S_StopAllSounds(void)
+void SoundSystem::StopAllSounds()
 {
     if (s_started == SoundBackend::Not)
         return;
 
-    SoundSystem &soundSystem = S_GetSoundSystem();
-    soundSystem.ResetPlaysounds();
+    ResetPlaysounds();
 
     if (s_api && s_api->stop_all_sounds)
         s_api->stop_all_sounds();
 
-    soundSystem.clear_channels();
+    clear_channels();
 }
 
 void S_RawSamples(int samples, int rate, int width, int channels, const void *data)
@@ -814,7 +789,7 @@ void S_PauseRawSamples(bool paused)
 // Update sound buffer
 // =======================================================================
 
-int S_BuildSoundList(int *sounds)
+int SoundSystem::BuildSoundList(int *sounds)
 {
     int             i, num, count;
     entity_state_t  *ent;
@@ -827,7 +802,7 @@ int S_BuildSoundList(int *sounds)
         ent = &cl.entityStates[num];
         if (s_ambient->integer == 2 && !ent->modelindex) {
             sounds[i] = 0;
-        } else if (s_ambient->integer == 3 && ent->number != listener_entnum) {
+        } else if (s_ambient->integer == 3 && ent->number != listener_entnum_) {
             sounds[i] = 0;
         } else {
             sounds[i] = ent->sound;
@@ -848,7 +823,7 @@ S_SpatializeOrigin
 Used for spatializing channels and autosounds
 =================
 */
-void S_SpatializeOrigin(const vec3_t origin, float master_vol, float dist_mult, float *left_vol, float *right_vol, bool stereo)
+void SoundSystem::SpatializeOrigin(const vec3_t origin, float master_vol, float dist_mult, float *left_vol, float *right_vol, bool stereo)
 {
     vec_t       dot;
     vec_t       dist;
@@ -856,7 +831,7 @@ void S_SpatializeOrigin(const vec3_t origin, float master_vol, float dist_mult, 
     vec3_t      source_vec;
 
 // calculate stereo separation and distance attenuation
-    VectorSubtract(origin, listener_origin, source_vec);
+    VectorSubtract(origin, listener_origin_, source_vec);
 
     dist = VectorNormalize(source_vec);
     dist -= SOUND_FULLVOLUME;
@@ -869,7 +844,7 @@ void S_SpatializeOrigin(const vec3_t origin, float master_vol, float dist_mult, 
         rscale = 1.0f;
         lscale = 1.0f;
     } else {
-        dot = DotProduct(listener_right, source_vec);
+        dot = DotProduct(listener_right_, source_vec);
         rscale = 0.5f * (1.0f + dot);
         lscale = 0.5f * (1.0f - dot);
     }
@@ -893,7 +868,7 @@ S_Update
 Called once each time through the main loop
 ============
 */
-void S_Update(void)
+void SoundSystem::Update()
 {
     if (cvar_modified & CVAR_SOUND) {
         Cbuf_AddText(&cmd_buffer, "snd_restart\n");
@@ -915,9 +890,9 @@ void S_Update(void)
     // set listener entity number
     // other parameters should be already set up by CL_CalcViewValues
     if (cls.state != ca_active) {
-        listener_entnum = -1;
+        listener_entnum_ = -1;
     } else {
-        listener_entnum = cl.frame.clientNum + 1;
+        listener_entnum_ = cl.frame.clientNum + 1;
     }
 
     OGG_Update();

--- a/src/client/sound/mem.cpp
+++ b/src/client/sound/mem.cpp
@@ -17,6 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 // snd_mem.c: sound caching
 
+#include "SoundSystem.hpp"
 #include "sound.hpp"
 #include "common/intreadwrite.hpp"
 
@@ -477,7 +478,7 @@ static void ConvertSamples(void)
 S_LoadSound
 ==============
 */
-sfxcache_t *S_LoadSound(sfx_t *s)
+sfxcache_t *SoundSystem::LoadSound(sfx_t *s)
 {
     sizebuf_t   sz;
     byte        *data;

--- a/src/client/sound/sound.hpp
+++ b/src/client/sound/sound.hpp
@@ -181,9 +181,3 @@ extern cvar_t       *s_debug_soundorigins;
 #define S_GetEntityLoopDistMult(ent)    Com_GetEntityLoopDistMult((ent)->loop_attenuation)
 #define S_GetEntityLoopStereoPan(ent)   !(cl.csr.extended && (ent)->renderfx & RF_NO_STEREO)
 
-sfx_t *S_SfxForHandle(qhandle_t hSfx);
-sfxcache_t *S_LoadSound(sfx_t *s);
-channel_t *S_PickChannel(int entnum, int entchannel);
-void S_IssuePlaysound(playsound_t *ps);
-int S_BuildSoundList(int *sounds);
-void S_SpatializeOrigin(const vec3_t origin, float master_vol, float dist_mult, float *left_vol, float *right_vol, bool stereo);

--- a/src/client/tent.cpp
+++ b/src/client/tent.cpp
@@ -176,7 +176,7 @@ void CL_PlayFootstepSfx(int step_id, int entnum, float volume, float attenuation
     if (footstep_sfx == cl_last_footstep)
         footstep_sfx = sfx->sfx[(sfx_num + 1) % sfx->num_sfx];
 
-    S_StartSound(NULL, entnum, CHAN_FOOTSTEP, footstep_sfx, volume, attenuation, 0);
+    S_GetSoundSystem().StartSound(NULL, entnum, CHAN_FOOTSTEP, footstep_sfx, volume, attenuation, 0);
     cl_last_footstep = footstep_sfx;
 }
 
@@ -787,7 +787,7 @@ override:
             VectorCopy(te.offset, b->offset);
 
             if (model == cl_mod_lightning && b->soundtime < cl.time) {
-                S_StartSound(NULL, te.entity1, CHAN_WEAPON, cl_sfx_lightning, 1, ATTN_NORM, 0);
+                S_GetSoundSystem().StartSound(NULL, te.entity1, CHAN_WEAPON, cl_sfx_lightning, 1, ATTN_NORM, 0);
                 b->soundtime = cl.time + 500;
             }
 
@@ -1341,11 +1341,11 @@ void CL_ParseTEnt(void)
             // impact sound
             r = Q_rand() & 15;
             if (r == 1)
-                S_StartSound(te.pos1, 0, 0, cl_sfx_ric1, 1, ATTN_NORM, 0);
+                S_GetSoundSystem().StartSound(te.pos1, 0, 0, cl_sfx_ric1, 1, ATTN_NORM, 0);
             else if (r == 2)
-                S_StartSound(te.pos1, 0, 0, cl_sfx_ric2, 1, ATTN_NORM, 0);
+                S_GetSoundSystem().StartSound(te.pos1, 0, 0, cl_sfx_ric2, 1, ATTN_NORM, 0);
             else if (r == 3)
-                S_StartSound(te.pos1, 0, 0, cl_sfx_ric3, 1, ATTN_NORM, 0);
+                S_GetSoundSystem().StartSound(te.pos1, 0, 0, cl_sfx_ric3, 1, ATTN_NORM, 0);
         }
         break;
 
@@ -1356,7 +1356,7 @@ void CL_ParseTEnt(void)
         else
             CL_ParticleEffect(te.pos1, te.dir, 0xb0, 40);
         //FIXME : replace or remove this sound
-        S_StartSound(te.pos1, 0, 257, cl_sfx_lashit, 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(te.pos1, 0, 257, cl_sfx_lashit, 1, ATTN_NORM, 0);
         break;
 
     case TE_SHOTGUN:            // bullet hitting wall
@@ -1380,11 +1380,11 @@ void CL_ParseTEnt(void)
         if (te.color == SPLASH_SPARKS) {
             r = Q_rand() & 3;
             if (r == 0)
-                S_StartSound(te.pos1, 0, 0, cl_sfx_spark5, 1, ATTN_STATIC, 0);
+                S_GetSoundSystem().StartSound(te.pos1, 0, 0, cl_sfx_spark5, 1, ATTN_STATIC, 0);
             else if (r == 1)
-                S_StartSound(te.pos1, 0, 0, cl_sfx_spark6, 1, ATTN_STATIC, 0);
+                S_GetSoundSystem().StartSound(te.pos1, 0, 0, cl_sfx_spark6, 1, ATTN_STATIC, 0);
             else
-                S_StartSound(te.pos1, 0, 0, cl_sfx_spark7, 1, ATTN_STATIC, 0);
+                S_GetSoundSystem().StartSound(te.pos1, 0, 0, cl_sfx_spark7, 1, ATTN_STATIC, 0);
         }
         break;
 
@@ -1432,13 +1432,13 @@ void CL_ParseTEnt(void)
         ex->start = cl.servertime - CL_FRAMETIME;
         ex->ent.model = cl_mod_explode;
         ex->frames = 4;
-        S_StartSound(te.pos1,  0, 0, cl_sfx_lashit, 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(te.pos1,  0, 0, cl_sfx_lashit, 1, ATTN_NORM, 0);
         break;
 
     case TE_RAILTRAIL:          // railgun effect
     case TE_RAILTRAIL2:
         CL_RailTrail();
-        S_StartSound(te.pos2, 0, 0, cl_sfx_railg, 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(te.pos2, 0, 0, cl_sfx_railg, 1, ATTN_NORM, 0);
         break;
 
     case TE_GRENADE_EXPLOSION:
@@ -1456,9 +1456,9 @@ void CL_ParseTEnt(void)
             ex->light = 200;
 
         if (te.type == TE_GRENADE_EXPLOSION_WATER)
-            S_StartSound(te.pos1, 0, 0, cl_sfx_watrexp, 1, ATTN_NORM, 0);
+            S_GetSoundSystem().StartSound(te.pos1, 0, 0, cl_sfx_watrexp, 1, ATTN_NORM, 0);
         else
-            S_StartSound(te.pos1, 0, 0, cl_sfx_grenexp, 1, ATTN_NORM, 0);
+            S_GetSoundSystem().StartSound(te.pos1, 0, 0, cl_sfx_grenexp, 1, ATTN_NORM, 0);
         break;
 
     case TE_EXPLOSION2:
@@ -1469,7 +1469,7 @@ void CL_ParseTEnt(void)
         if (te.type == TE_EXPLOSION2_NL)
             ex->light = 0;
         CL_ExplosionParticles(te.pos1);
-        S_StartSound(te.pos1, 0, 0, cl_sfx_grenexp, 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(te.pos1, 0, 0, cl_sfx_grenexp, 1, ATTN_NORM, 0);
         break;
 
     case TE_ROCKET_EXPLOSION:
@@ -1485,9 +1485,9 @@ void CL_ParseTEnt(void)
             ex->light = 200;
 
         if (te.type == TE_ROCKET_EXPLOSION_WATER)
-            S_StartSound(te.pos1, 0, 0, cl_sfx_watrexp, 1, ATTN_NORM, 0);
+            S_GetSoundSystem().StartSound(te.pos1, 0, 0, cl_sfx_watrexp, 1, ATTN_NORM, 0);
         else
-            S_StartSound(te.pos1, 0, 0, cl_sfx_rockexp, 1, ATTN_NORM, 0);
+            S_GetSoundSystem().StartSound(te.pos1, 0, 0, cl_sfx_rockexp, 1, ATTN_NORM, 0);
         break;
 
     case TE_EXPLOSION1:
@@ -1497,19 +1497,19 @@ void CL_ParseTEnt(void)
         if (te.type == TE_EXPLOSION1_NL)
             ex->light = 0;
         CL_ExplosionParticles(te.pos1);
-        S_StartSound(te.pos1, 0, 0, cl_sfx_rockexp, 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(te.pos1, 0, 0, cl_sfx_rockexp, 1, ATTN_NORM, 0);
         break;
 
     case TE_EXPLOSION1_NP:
         CL_PlainExplosion();
-        S_StartSound(te.pos1, 0, 0, cl_sfx_rockexp, 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(te.pos1, 0, 0, cl_sfx_rockexp, 1, ATTN_NORM, 0);
         break;
 
     case TE_EXPLOSION1_BIG:
         ex = CL_PlainExplosion();
         ex->ent.model = cl_mod_explo4;
         VectorSet(ex->ent.scale, 2.0f, 2.0f, 2.0f);
-        S_StartSound(te.pos1, 0, 0, cl_sfx_rockexp, 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(te.pos1, 0, 0, cl_sfx_rockexp, 1, ATTN_NORM, 0);
         break;
 
     case TE_BFG_EXPLOSION:
@@ -1542,7 +1542,7 @@ void CL_ParseTEnt(void)
 
     case TE_BOSSTPORT:          // boss teleporting to station
         CL_BigTeleportParticles(te.pos1);
-        S_StartSound(te.pos1, 0, 0, S_RegisterSound("misc/bigtele.wav"), 1, ATTN_NONE, 0);
+        S_GetSoundSystem().StartSound(te.pos1, 0, 0, S_RegisterSound("misc/bigtele.wav"), 1, ATTN_NONE, 0);
         break;
 
     case TE_GRAPPLE_CABLE:
@@ -1607,12 +1607,12 @@ void CL_ParseTEnt(void)
 
     case TE_HEATBEAM_SPARKS:
         CL_ParticleSteamEffect(te.pos1, te.dir, 0x8, 50, 60);
-        S_StartSound(te.pos1,  0, 0, cl_sfx_lashit, 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(te.pos1,  0, 0, cl_sfx_lashit, 1, ATTN_NORM, 0);
         break;
 
     case TE_HEATBEAM_STEAM:
         CL_ParticleSteamEffect(te.pos1, te.dir, 0xE0, 20, 60);
-        S_StartSound(te.pos1,  0, 0, cl_sfx_lashit, 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(te.pos1,  0, 0, cl_sfx_lashit, 1, ATTN_NORM, 0);
         break;
 
     case TE_STEAM:
@@ -1621,7 +1621,7 @@ void CL_ParseTEnt(void)
 
     case TE_BUBBLETRAIL2:
         CL_BubbleTrail2(te.pos1, te.pos2, 8);
-        S_StartSound(te.pos1,  0, 0, cl_sfx_lashit, 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(te.pos1,  0, 0, cl_sfx_lashit, 1, ATTN_NORM, 0);
         break;
 
     case TE_MOREBLOOD:
@@ -1636,13 +1636,13 @@ void CL_ParseTEnt(void)
     case TE_ELECTRIC_SPARKS:
         CL_ParticleEffect(te.pos1, te.dir, 0x75, 40);
         //FIXME : replace or remove this sound
-        S_StartSound(te.pos1, 0, 0, cl_sfx_lashit, 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(te.pos1, 0, 0, cl_sfx_lashit, 1, ATTN_NORM, 0);
         break;
 
     case TE_TRACKER_EXPLOSION:
         CL_ColorFlash(te.pos1, 0, 150, -1, -1, -1);
         CL_ColorExplosionParticles(te.pos1, 0, 1);
-        S_StartSound(te.pos1, 0, 0, cl_sfx_disrexp, 1, ATTN_NORM, 0);
+        S_GetSoundSystem().StartSound(te.pos1, 0, 0, cl_sfx_disrexp, 1, ATTN_NORM, 0);
         break;
 
     case TE_TELEPORT_EFFECT:

--- a/src/client/ui/demos.cpp
+++ b/src/client/ui/demos.cpp
@@ -289,7 +289,7 @@ static void BuildList(void)
     int i;
 
     // this can be a lengthy process
-    S_StopAllSounds();
+    S_GetSoundSystem().StopAllSounds();
 
     m_demos.menu.status = m_demos.status_building;
     SCR_UpdateScreen();

--- a/src/client/ui/servers.cpp
+++ b/src/client/ui/servers.cpp
@@ -739,7 +739,7 @@ static void PingServers(void)
 {
     netadr_t broadcast;
 
-    S_StopAllSounds();
+    S_GetSoundSystem().StopAllSounds();
 
     ClearServers();
     UpdateStatus();


### PR DESCRIPTION
## Summary
- extend `SoundSystem` with playback APIs (`StartSound`, `Update`, etc.) and manage playsound storage with smart pointers
- thread the shared `SoundSystem` through client modules so callers invoke member functions instead of global sound helpers
- expose the sound system header via `client.hpp` and remove the obsolete declarations from the public sound header

## Testing
- `ninja -C build` *(fails: build.ninja missing)*

------
https://chatgpt.com/codex/tasks/task_e_690762330fe08328981ce47032094286