### PR TITLE
Fix SoundSystem include path in client header

### DIFF
--- a/src/client/client.hpp
+++ b/src/client/client.hpp
@@ -53,7 +53,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "system/system.hpp"
 #include "client/input.hpp"
 #include "client/keys.hpp"
-#include "client/sound/SoundSystem.hpp"
+#include "sound/SoundSystem.hpp"
 #include "client/sound/sound.hpp"
 #include "client/ui.hpp"
 #include "client/video.hpp"


### PR DESCRIPTION
## Summary
- correct the SoundSystem include path in `src/client/client.hpp` so the header resolves during compilation

## Testing
- meson compile -C build *(fails: /workspace/WORR/build is not a Meson build directory in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_690765ea1d0c8328bbb697dcebf9fb56