### PR TITLE
Fix missing UI sound references and OpenAL goto handling

### DIFF
--- a/src/client/sound/al.cpp
+++ b/src/client/sound/al.cpp
@@ -605,6 +605,7 @@ static void s_volume_changed(cvar_t *self)
 static bool AL_Init(void)
 {
     int i;
+    int max_channels = 0;
 
     SoundSystem &soundSystem = S_GetSoundSystem();
 
@@ -622,7 +623,7 @@ static bool AL_Init(void)
     qalGetError();
     qalGenSources(1, &s_stream);
 
-    int max_channels = soundSystem.max_channels();
+    max_channels = soundSystem.max_channels();
     s_srcnums = Z_TagMalloc(sizeof(*s_srcnums) * max_channels, TAG_SOUND);
 
     for (i = 0; i < max_channels; i++) {

--- a/src/client/ui/ui.hpp
+++ b/src/client/ui/ui.hpp
@@ -28,6 +28,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "client/keys.hpp"
 #include "client/sound/sound.hpp"
 #include "client/client.hpp"
+#include "../client.hpp"
 #include "client/ui.hpp"
 #include "refresh/refresh.hpp"
 


### PR DESCRIPTION
## Summary
- expose client screen and sound symbols to the UI implementation by including the internal client header
- move the OpenAL max_channels declaration ahead of early goto paths to satisfy MSVC

## Testing
- meson setup builddir *(fails: wrap-redirect /workspace/WORR/subprojects/ffmpeg/subprojects/nasm.wrap filename does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_690768b7af6083288528aed63070bfde