### PR TITLE
Fix missing UI constants for refresh header

### DIFF
--- a/inc/refresh/refresh.hpp
+++ b/inc/refresh/refresh.hpp
@@ -23,6 +23,22 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "common/cvar.hpp"
 #include "common/error.hpp"
 
+// Some client UI constants are required by inline helpers in this header. They
+// are normally provided by client headers, but a few refresh translation units
+// include this header without pulling those in. Provide compatible fallbacks so
+// the renderer can be built in isolation.
+#ifndef CONCHAR_WIDTH
+#define CONCHAR_WIDTH 8
+#endif
+
+#ifndef CONCHAR_HEIGHT
+#define CONCHAR_HEIGHT 8
+#endif
+
+#ifndef UI_MULTILINE
+#define UI_MULTILINE (1u << 9)
+#endif
+
 #if USE_FREETYPE
 #include <ft2build.h>
 #include FT_FREETYPE_H


### PR DESCRIPTION
## Summary
- provide fallback definitions for the console character dimensions and multiline flag in the refresh header
- unblock refresh-only compilation units that do not include the client headers

## Testing
- meson compile -C build *(fails: build directory is not configured in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_69076bc2f23c83288ee1158697203c82