### PR TITLE
Use std::max in FreeType fallbacks

### DIFF
--- a/inc/refresh/refresh.hpp
+++ b/inc/refresh/refresh.hpp
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #pragma once
 
 #include <type_traits>
+#include <algorithm>
 
 #include "common/cvar.hpp"
 #include "common/error.hpp"
@@ -389,7 +390,7 @@ inline int R_MeasureFreeTypeString(int scale, int flags, size_t maxChars,
         char ch = *string++;
 
         if ((flags & UI_MULTILINE) && ch == '\n') {
-            maxWidth = max(maxWidth, width);
+            maxWidth = std::max(maxWidth, width);
             width = 0;
             continue;
         }
@@ -397,12 +398,12 @@ inline int R_MeasureFreeTypeString(int scale, int flags, size_t maxChars,
         width += CONCHAR_WIDTH * scale;
     }
 
-    return max(maxWidth, width);
+    return std::max(maxWidth, width);
 }
 
 inline float R_FreeTypeFontLineHeight(int scale, const struct ftfont_t * = nullptr)
 {
-    return CONCHAR_HEIGHT * max(scale, 1);
+    return CONCHAR_HEIGHT * std::max(scale, 1);
 }
 #endif
 


### PR DESCRIPTION
## Summary
- include `<algorithm>` in the refresh header so the fallback FreeType helpers can rely on `std::max`
- switch the fallback implementations to call `std::max`, avoiding dependence on platform-specific macros

## Testing
- not run (no Meson build directory available)


------
https://chatgpt.com/codex/tasks/task_e_69076c485b3c83288e8a063e9ee059b3