### PR TITLE
Fix Windows build failure caused by std::max macro expansion

### DIFF
--- a/inc/refresh/refresh.hpp
+++ b/inc/refresh/refresh.hpp
@@ -390,7 +390,7 @@ inline int R_MeasureFreeTypeString(int scale, int flags, size_t maxChars,
         char ch = *string++;
 
         if ((flags & UI_MULTILINE) && ch == '\n') {
-            maxWidth = std::max(maxWidth, width);
+            maxWidth = (std::max)(maxWidth, width);
             width = 0;
             continue;
         }
@@ -398,12 +398,12 @@ inline int R_MeasureFreeTypeString(int scale, int flags, size_t maxChars,
         width += CONCHAR_WIDTH * scale;
     }
 
-    return std::max(maxWidth, width);
+    return (std::max)(maxWidth, width);
 }
 
 inline float R_FreeTypeFontLineHeight(int scale, const struct ftfont_t * = nullptr)
 {
-    return CONCHAR_HEIGHT * std::max(scale, 1);
+    return CONCHAR_HEIGHT * (std::max)(scale, 1);
 }
 #endif
 


### PR DESCRIPTION
## Summary
- wrap std::max invocations in refresh.hpp with the macro-safe form
- prevent Windows min/max macros from breaking the renderer's inline helpers

## Testing
- not run (header-only change)

------
https://chatgpt.com/codex/tasks/task_e_69076d9ef9fc8328b762b34e399feea5