### PR TITLE
Refactor sound listener globals to use SoundSystem accessors

### DIFF
--- a/inc/client/sound/sound.hpp
+++ b/inc/client/sound/sound.hpp
@@ -60,8 +60,3 @@ void OGG_Restart(void);
 #define OGG_Restart()       (void)0
 #endif
 
-extern vec3_t   &listener_origin;
-extern vec3_t   &listener_forward;
-extern vec3_t   &listener_right;
-extern vec3_t   &listener_up;
-extern int      &listener_entnum;

--- a/src/client/entities.cpp
+++ b/src/client/entities.cpp
@@ -1660,10 +1660,11 @@ void CL_CalcViewValues(void)
 
     cl.refdef.vieworg[2] += viewheight;
 
-    VectorCopy(cl.refdef.vieworg, listener_origin);
-    VectorCopy(cl.v_forward, listener_forward);
-    VectorCopy(cl.v_right, listener_right);
-    VectorCopy(cl.v_up, listener_up);
+    SoundSystem &soundSystem = S_GetSoundSystem();
+    VectorCopy(cl.refdef.vieworg, soundSystem.listener_origin());
+    VectorCopy(cl.v_forward, soundSystem.listener_forward());
+    VectorCopy(cl.v_right, soundSystem.listener_right());
+    VectorCopy(cl.v_up, soundSystem.listener_up());
 }
 
 /*
@@ -1732,6 +1733,9 @@ bool CL_GetEntitySoundOrigin(unsigned entnum, vec3_t org, vec3_t offset)
     const mmodel_t  *mod;
     vec3_t          mid, base_origin;
     bool            anchored = false;
+    SoundSystem &soundSystem = S_GetSoundSystem();
+    const vec3_t &listener_origin = soundSystem.listener_origin();
+    const int listener_entnum = soundSystem.listener_entnum();
 
     if (offset)
         VectorClear(offset);

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -3269,8 +3269,10 @@ void CL_AddHitMarker(void)
         cl.hit_marker_time = cls.realtime;
         cl.hit_marker_count++;
 
-        if (cl_hit_markers->integer > 1)
-            S_GetSoundSystem().StartSound(NULL, listener_entnum, 257, cl.sfx_hit_marker, 1, ATTN_NONE, 0);
+        if (cl_hit_markers->integer > 1) {
+            SoundSystem &soundSystem = S_GetSoundSystem();
+            soundSystem.StartSound(NULL, soundSystem.listener_entnum(), 257, cl.sfx_hit_marker, 1, ATTN_NONE, 0);
+        }
     }
 }
 

--- a/src/client/sound/SoundSystem.cpp
+++ b/src/client/sound/SoundSystem.cpp
@@ -206,10 +206,3 @@ SoundSystem &S_GetSoundSystem()
     static SoundSystem system;
     return system;
 }
-
-vec3_t &listener_origin = S_GetSoundSystem().listener_origin();
-vec3_t &listener_forward = S_GetSoundSystem().listener_forward();
-vec3_t &listener_right = S_GetSoundSystem().listener_right();
-vec3_t &listener_up = S_GetSoundSystem().listener_up();
-int &listener_entnum = S_GetSoundSystem().listener_entnum();
-

--- a/src/client/sound/al.cpp
+++ b/src/client/sound/al.cpp
@@ -195,6 +195,8 @@ static bool AL_EstimateDimensions(void)
         return false;
 
     s_reverb_probe_time = cl.time + 13;
+    SoundSystem &soundSystem = S_GetSoundSystem();
+    const vec3_t &listener_origin = soundSystem.listener_origin();
     vec3_t end;
     VectorMA(listener_origin, 8192.0f, s_reverb_probes[s_reverb_probe_index], end);
 
@@ -256,6 +258,9 @@ static void AL_UpdateReverb(void)
         return;
 
     AL_EstimateDimensions();
+
+    SoundSystem &soundSystem = S_GetSoundSystem();
+    const vec3_t &listener_origin = soundSystem.listener_origin();
 
     trace_t tr;
     const vec3_t mins = { -16, -16, 0 };
@@ -1310,6 +1315,9 @@ static void AL_Update(void)
     SoundSystem &soundSystem = S_GetSoundSystem();
     channel_t *channels = soundSystem.channels_data();
     int num_channels = soundSystem.num_channels();
+    const vec3_t &listener_origin = soundSystem.listener_origin();
+    const vec3_t &listener_forward = soundSystem.listener_forward();
+    const vec3_t &listener_up = soundSystem.listener_up();
 
     if (!s_active)
         return;

--- a/src/client/sound/main.cpp
+++ b/src/client/sound/main.cpp
@@ -730,16 +730,18 @@ S_StartLocalSound
 void S_StartLocalSound(const char *sound)
 {
     if (s_started != SoundBackend::Not) {
+        SoundSystem &soundSystem = S_GetSoundSystem();
         qhandle_t sfx = S_RegisterSound(sound);
-        S_GetSoundSystem().StartSound(NULL, listener_entnum, 0, sfx, 1, ATTN_NONE, 0);
+        soundSystem.StartSound(NULL, soundSystem.listener_entnum(), 0, sfx, 1, ATTN_NONE, 0);
     }
 }
 
 void S_StartLocalSoundOnce(const char *sound)
 {
     if (s_started != SoundBackend::Not) {
+        SoundSystem &soundSystem = S_GetSoundSystem();
         qhandle_t sfx = S_RegisterSound(sound);
-        S_GetSoundSystem().StartSound(NULL, listener_entnum, 256, sfx, 1, ATTN_NONE, 0);
+        soundSystem.StartSound(NULL, soundSystem.listener_entnum(), 256, sfx, 1, ATTN_NONE, 0);
     }
 }
 

--- a/src/client/sound/sound.hpp
+++ b/src/client/sound/sound.hpp
@@ -169,7 +169,9 @@ extern cvar_t       *s_num_channels;
 extern cvar_t       *s_debug_soundorigins;
 
 #define S_IsFullVolume(ch) \
-    ((ch)->entnum == -1 || ((ch)->entnum == listener_entnum && !cl.thirdPersonView) || (ch)->dist_mult == 0)
+    ((ch)->entnum == -1 || \
+     ((ch)->entnum == S_GetSoundSystem().listener_entnum() && !cl.thirdPersonView) || \
+     (ch)->dist_mult == 0)
 
 #define S_IsUnderWater() \
     (cls.state == ca_active && (cl.frame.ps.rdflags | cl.predicted_rdflags) & RDF_UNDERWATER && s_underwater->integer)


### PR DESCRIPTION
## Summary
- remove the listener extern declarations and the associated global definitions in favor of SoundSystem accessors
- update client sound call sites to read and write listener state through S_GetSoundSystem()
- adjust sound utility macros to query the listener entity from SoundSystem

## Testing
- ninja -C build *(fails: build.ninja not found)*

------
https://chatgpt.com/codex/tasks/task_e_69076c8f0ff48328bc2057244a8edbca