### PR TITLE
Add bobskip toggle to suppress view bobbing

### DIFF
--- a/src/client/tent.cpp
+++ b/src/client/tent.cpp
@@ -954,9 +954,18 @@ static void CL_AddPlayerBeams(void)
             ps = CL_KEYPS;
             ops = CL_OLDKEYPS;
 
-            for (j = 0; j < 3; j++)
-                b->start[j] = cl.refdef.vieworg[j] + ops->gunoffset[j] +
-                    CL_KEYLERPFRAC * (ps->gunoffset[j] - ops->gunoffset[j]);
+            const bool skipBob = info_bobskip && info_bobskip->integer;
+
+            for (j = 0; j < 3; j++) {
+                float gunOffset = 0.0f;
+
+                if (!skipBob) {
+                    gunOffset = ops->gunoffset[j] +
+                        CL_KEYLERPFRAC * (ps->gunoffset[j] - ops->gunoffset[j]);
+                }
+
+                b->start[j] = cl.refdef.vieworg[j] + gunOffset;
+            }
 
             x = b->offset[0];
             y = b->offset[1];


### PR DESCRIPTION
## Summary
- respect the `bobskip` client cvar when positioning the view weapon and applying kick angles
- keep player weapon beams anchored when bobbing is disabled

## Testing
- ninja -C build *(fails: build.ninja not found in repository)*

------
https://chatgpt.com/codex/tasks/task_e_69076f71fd788328bdcf577aa9250a6c