### PR TITLE
Fix listener entity fallback for local sounds

### DIFF
--- a/src/client/sound/main.cpp
+++ b/src/client/sound/main.cpp
@@ -894,7 +894,15 @@ void SoundSystem::Update()
     if (cls.state != ca_active) {
         listener_entnum_ = -1;
     } else {
-        listener_entnum_ = cl.frame.clientNum + 1;
+        int clientNum = cl.frame.clientNum;
+
+        if (clientNum < 0)
+            clientNum = cl.clientNum;
+
+        if (clientNum >= 0 && clientNum < cl.csr.max_edicts)
+            listener_entnum_ = clientNum + 1;
+        else
+            listener_entnum_ = -1;
     }
 
     OGG_Update();


### PR DESCRIPTION
## Summary
- ensure the sound system falls back to the configured client number when the current frame lacks a valid client id
- keep the listener entity unset when neither value is valid so positional audio stays centered on the player

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_6907723fc55c832891338578daa1f30d