### PR TITLE
Fix sexed sound registration call

### DIFF
--- a/src/client/sound/main.cpp
+++ b/src/client/sound/main.cpp
@@ -449,7 +449,7 @@ void SoundSystem::StartSound(const vec3_t origin, int entnum, int entchannel, qh
         return;
 
     if (sfx->name[0] == '*') {
-        sfx = S_RegisterSexedSound(entnum, sfx->name);
+        sfx = RegisterSexedSound(entnum, sfx->name);
         if (!sfx)
             return;
     }


### PR DESCRIPTION
## Summary
- call the SoundSystem member function for registering sexed sounds to avoid undefined reference when building

## Testing
- meson compile -C builddir *(fails: build directory not present in repository clone)*

------
https://chatgpt.com/codex/tasks/task_e_690775c747888328a68c97b51464989c