### PR TITLE
Ensure local player sounds are non-positional

### DIFF
--- a/src/client/entities.cpp
+++ b/src/client/entities.cpp
@@ -1757,7 +1757,7 @@ bool CL_GetEntitySoundOrigin(unsigned entnum, vec3_t org, vec3_t offset)
         return false;
     }
 
-    if (entnum == listener_entnum && !cl.thirdPersonView) {
+    if (entnum == listener_entnum) {
         VectorCopy(listener_origin, org);
         return false;
     }

--- a/src/client/sound/sound.hpp
+++ b/src/client/sound/sound.hpp
@@ -170,7 +170,7 @@ extern cvar_t       *s_debug_soundorigins;
 
 #define S_IsFullVolume(ch) \
     ((ch)->entnum == -1 || \
-     ((ch)->entnum == S_GetSoundSystem().listener_entnum() && !cl.thirdPersonView) || \
+     (ch)->entnum == S_GetSoundSystem().listener_entnum() || \
      (ch)->dist_mult == 0)
 
 #define S_IsUnderWater() \


### PR DESCRIPTION
## Summary
- treat sounds emitted by the listener entity as non-positional even in third-person view
- simplify the full-volume channel check so the listener entity never gets spatialized

## Testing
- ninja -C build *(fails: build.ninja missing)*

------
https://chatgpt.com/codex/tasks/task_e_69077add1ea883289541855dd94bc966