### PR TITLE
Add depth of field post-processing support

### DIFF
--- a/inc/refresh/refresh.hpp
+++ b/inc/refresh/refresh.hpp
@@ -160,6 +160,11 @@ typedef struct {
 
     int         num_particles;
     particle_t  *particles;
+
+    bool        depth_of_field;
+    float       dof_blend;
+    float       dof_focus;
+    float       dof_strength;
 } refdef_t;
 
 enum {

--- a/src/refresh/gl.hpp
+++ b/src/refresh/gl.hpp
@@ -64,7 +64,7 @@ constexpr auto to_underlying(Enum value) noexcept -> std::underlying_type_t<Enum
 #define TAB_COS(x)  gl_static.sintab[((x) + 64) & 255]
 
 // auto textures
-#define NUM_AUTO_TEXTURES       13
+#define NUM_AUTO_TEXTURES       15
 #define AUTO_TEX(n)             gl_static.texnums[n]
 
 #define TEXNUM_DEFAULT          AUTO_TEX(0)
@@ -80,12 +80,16 @@ constexpr auto to_underlying(Enum value) noexcept -> std::underlying_type_t<Enum
 #define TEXNUM_PP_BLOOM         AUTO_TEX(10)
 #define TEXNUM_PP_BLUR_0        AUTO_TEX(11)
 #define TEXNUM_PP_BLUR_1        AUTO_TEX(12)
+#define TEXNUM_PP_DOF_0         AUTO_TEX(13)
+#define TEXNUM_PP_DOF_1         AUTO_TEX(14)
 
 // framebuffers
-#define FBO_COUNT   3
+#define FBO_COUNT   5
 #define FBO_SCENE   gl_static.framebuffers[0]
 #define FBO_BLUR_0  gl_static.framebuffers[1]
 #define FBO_BLUR_1  gl_static.framebuffers[2]
+#define FBO_DOF_0   gl_static.framebuffers[3]
+#define FBO_DOF_1   gl_static.framebuffers[4]
 
 typedef struct {
     GLuint query;
@@ -391,6 +395,8 @@ extern cvar_t *gl_damageblend_frac;
 extern cvar_t *gl_waterwarp;
 extern cvar_t *gl_bloom;
 extern cvar_t *gl_bloom_height;
+extern cvar_t *gl_dof;
+extern cvar_t *gl_dof_sigma;
 
 // development variables
 extern cvar_t *gl_znear;
@@ -697,6 +703,7 @@ void GL_LoadWorld(const char *name);
 #define GLS_BLUR_BOX            BIT_ULL(33)
 
 #define GLS_DYNAMIC_LIGHTS      BIT_ULL(34)
+#define GLS_DOF_ENABLE          BIT_ULL(35)
 
 #define GLS_BLEND_MASK          (GLS_BLEND_BLEND | GLS_BLEND_ADD | GLS_BLEND_MODULATE)
 #define GLS_COMMON_MASK         (GLS_DEPTHMASK_FALSE | GLS_DEPTHTEST_DISABLE | GLS_CULL_DISABLE | GLS_BLEND_MASK)
@@ -709,9 +716,9 @@ void GL_LoadWorld(const char *name);
 #define GLS_SHADER_MASK         (GLS_ALPHATEST_ENABLE | GLS_TEXTURE_REPLACE | GLS_SCROLL_ENABLE | \
                                  GLS_LIGHTMAP_ENABLE | GLS_WARP_ENABLE | GLS_INTENSITY_ENABLE | \
                                  GLS_GLOWMAP_ENABLE | GLS_SKY_MASK | GLS_DEFAULT_FLARE | GLS_MESH_MASK | \
-                                 GLS_FOG_MASK | GLS_BLOOM_MASK | GLS_BLUR_MASK | GLS_DYNAMIC_LIGHTS)
+                                 GLS_FOG_MASK | GLS_BLOOM_MASK | GLS_BLUR_MASK | GLS_DYNAMIC_LIGHTS | GLS_DOF_ENABLE)
 #define GLS_UNIFORM_MASK        (GLS_WARP_ENABLE | GLS_LIGHTMAP_ENABLE | GLS_INTENSITY_ENABLE | \
-                                 GLS_SKY_MASK | GLS_FOG_MASK | GLS_BLUR_MASK | GLS_DYNAMIC_LIGHTS)
+                                 GLS_SKY_MASK | GLS_FOG_MASK | GLS_BLUR_MASK | GLS_DYNAMIC_LIGHTS | GLS_DOF_ENABLE)
 #define GLS_SCROLL_MASK         (GLS_SCROLL_ENABLE | GLS_SCROLL_X | GLS_SCROLL_Y | GLS_SCROLL_FLIP | GLS_SCROLL_SLOW)
 
 typedef enum {
@@ -809,6 +816,7 @@ typedef struct {
     GLfloat     heightfog_falloff;
     GLfloat     pad;
     GLfloat     pad2;
+    vec4_t      dof_params;
     vec4_t      vieworg;
 } glUniformBlock_t;
 

--- a/src/refresh/texture.cpp
+++ b/src/refresh/texture.cpp
@@ -1197,9 +1197,12 @@ static bool GL_CheckFramebufferStatus(bool check, const char *name)
 
 bool GL_InitFramebuffers(void)
 {
-    int scene_w = 0, scene_h = 0, bloom_w = 0, bloom_h = 0;
+    int scene_w = 0, scene_h = 0;
+    int bloom_w = 0, bloom_h = 0;
+    int dof_w = 0, dof_h = 0;
+    const bool dof_active = gl_dof->integer && glr.fd.depth_of_field;
 
-    if (gl_waterwarp->integer || gl_bloom->integer) {
+    if (gl_waterwarp->integer || gl_bloom->integer || dof_active) {
         scene_w = glr.fd.width;
         scene_h = glr.fd.height;
     }
@@ -1207,6 +1210,11 @@ bool GL_InitFramebuffers(void)
     if (gl_bloom->integer) {
         bloom_w = glr.fd.width;
         bloom_h = glr.fd.height;
+    }
+
+    if (dof_active) {
+        dof_w = glr.fd.width;
+        dof_h = glr.fd.height;
     }
 
     GL_ClearErrors();
@@ -1222,6 +1230,12 @@ bool GL_InitFramebuffers(void)
 
     GL_ForceTexture(TMU_TEXTURE, TEXNUM_PP_BLUR_1);
     GL_InitPostProcTexture(bloom_w / 4, bloom_h / 4);
+
+    GL_ForceTexture(TMU_TEXTURE, TEXNUM_PP_DOF_0);
+    GL_InitPostProcTexture(dof_w, dof_h);
+
+    GL_ForceTexture(TMU_TEXTURE, TEXNUM_PP_DOF_1);
+    GL_InitPostProcTexture(dof_w, dof_h);
 
     qglBindFramebuffer(GL_FRAMEBUFFER, FBO_SCENE);
     qglFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, scene_w ? TEXNUM_PP_SCENE : GL_NONE, 0);
@@ -1244,6 +1258,16 @@ bool GL_InitFramebuffers(void)
     qglFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, bloom_w ? TEXNUM_PP_BLUR_1 : GL_NONE, 0);
 
     CHECK_FB(bloom_w, "FBO_BLUR_1");
+
+    qglBindFramebuffer(GL_FRAMEBUFFER, FBO_DOF_0);
+    qglFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, dof_w ? TEXNUM_PP_DOF_0 : GL_NONE, 0);
+
+    CHECK_FB(dof_w, "FBO_DOF_0");
+
+    qglBindFramebuffer(GL_FRAMEBUFFER, FBO_DOF_1);
+    qglFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, dof_w ? TEXNUM_PP_DOF_1 : GL_NONE, 0);
+
+    CHECK_FB(dof_w, "FBO_DOF_1");
 
     qglBindFramebuffer(GL_FRAMEBUFFER, 0);
 


### PR DESCRIPTION
## Summary
- add depth-of-field controls to the renderer refdef and populate them from the client slow-time state
- allocate depth-of-field framebuffers/textures and mix the blurred scene alongside bloom and waterwarp
- update shader generation to sample the DoF texture and expose cvars for tuning the blur radius

## Testing
- not run (build blocked: meson setup requires subprojects/ffmpeg/subprojects/nasm.wrap)


------
https://chatgpt.com/codex/tasks/task_e_690777a9e95c832899b8aba4bf06d3b3