### PR TITLE
Enable FreeType Roboto Mono text by default

### DIFF
--- a/src/client/console.cpp
+++ b/src/client/console.cpp
@@ -461,7 +461,7 @@ void Con_Init(void)
     con_alpha = Cvar_Get("con_alpha", "1", 0);
     con_scale = Cvar_Get("con_scale", "0", 0);
     con_scale->changed = con_width_changed;
-    con_font = Cvar_Get("con_font", "conchars", 0);
+    con_font = Cvar_Get("con_font", "/fonts/RobotoMono-Regular.ttf", 0);
     con_font->changed = con_media_changed;
     con_background = Cvar_Get("con_background", "conback", 0);
     con_background->changed = con_media_changed;
@@ -666,6 +666,9 @@ void Con_RegisterMedia(void)
         if (strcmp(con_font->string, con_font->default_string)) {
             Cvar_Reset(con_font);
             con.charsetImage = R_RegisterFont(con_font->default_string);
+        }
+        if (!con.charsetImage) {
+            con.charsetImage = R_RegisterFont("conchars");
         }
         if (!con.charsetImage) {
             Com_Error(ERR_FATAL, "%s", Com_GetLastError());

--- a/src/client/screen.cpp
+++ b/src/client/screen.cpp
@@ -197,9 +197,9 @@ static bool SCR_LoadDefaultFreeTypeFont(void)
         if (!fontPath.empty() && fontPath.back() != '/' && fontPath.back() != '\\')
             fontPath.push_back('/');
     }
-    fontPath += "Arial.ttf";
+    fontPath += "RobotoMono-Regular.ttf";
 
-    std::string cacheKey = "Arial-" + std::to_string(defaultPixelHeight);
+    std::string cacheKey = "RobotoMono-Regular-" + std::to_string(defaultPixelHeight);
 
     if (!SCR_LoadFreeTypeFont(cacheKey, fontPath, defaultPixelHeight, scr.font_pic))
         return false;
@@ -1778,7 +1778,7 @@ void SCR_Init(void)
     scr_font->changed = scr_font_changed;
 #if USE_FREETYPE
     scr_fontpath = Cvar_Get("scr_fontpath", "fonts", CVAR_ARCHIVE);
-    scr_text_backend = Cvar_Get("scr_text_backend", "bitmap", CVAR_ARCHIVE);
+    scr_text_backend = Cvar_Get("scr_text_backend", "freetype", CVAR_ARCHIVE);
     scr_text_backend->changed = scr_text_backend_changed;
     scr_text_backend->generator = scr_text_backend_g;
     scr_text_backend_changed(scr_text_backend);


### PR DESCRIPTION
## Summary
- load Roboto Mono from the fonts directory for the default FreeType font and enable the FreeType backend by default
- set the console font cvar to point at the Roboto Mono TTF while preserving the bitmap fallback if the file is missing

## Testing
- ⚠️ `meson compile -C build` *(fails: wrap-redirect /workspace/WORR/subprojects/ffmpeg/subprojects/nasm.wrap filename does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_69077e6e07c4832897026782de6323b4