### PR TITLE
Fix MSVC build error in client state definition

### DIFF
--- a/src/client/client.hpp
+++ b/src/client/client.hpp
@@ -67,7 +67,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 //=============================================================================
 
-typedef struct {
+struct client_state_t {
     entity_state_t     current;
     entity_state_t     prev;           // will always be valid, but might just be a copy of current
 
@@ -467,7 +467,7 @@ typedef struct {
         float to{1.0f};
         std::chrono::steady_clock::time_point start{};
     } slow_time;
-} client_state_t;
+};
 
 extern client_state_t   cl;
 


### PR DESCRIPTION
## Summary
- replace the C-style typedef for `client_state_t` with a standard struct definition
- allow MSVC to accept the nested struct members that use default initializers

## Testing
- `meson compile -C WORR/build` *(fails: `/workspace/WORR/build` is not a Meson build directory)*
- `meson compile -C WORR/builddir` *(fails: `/workspace/WORR/builddir` is not a Meson build directory)*

------
https://chatgpt.com/codex/tasks/task_e_6907801572808328b076983736d7ca5c