### PR TITLE
Fix centity_t typedef for MSVC compatibility

### DIFF
--- a/src/client/client.hpp
+++ b/src/client/client.hpp
@@ -67,7 +67,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 //=============================================================================
 
-struct centity_t {
+typedef struct centity_s {
     entity_state_t     current;
     entity_state_t     prev;           // will always be valid, but might just be a copy of current
 
@@ -95,7 +95,7 @@ struct centity_t {
     int             stair_time;
     float           stair_height;
 // KEX
-};
+} centity_t;
 
 extern centity_t    cl_entities[MAX_EDICTS];
 


### PR DESCRIPTION
## Summary
- define `centity_t` via a typedef so the name is available in C compilation units
- unblock Windows builds that rely on the alias when including the client header

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6907822bf3e88328952a33a7dbfd16c3