### PR TITLE
Fix MSVC build errors in client view code

### DIFF
--- a/src/client/client.hpp
+++ b/src/client/client.hpp
@@ -459,13 +459,13 @@ typedef struct {
     } shadowdefs[MAX_SHADOW_LIGHTS];
 
     struct {
-        bool active{};
-        bool desired{};
-        bool initialized{};
-        float factor{1.0f};
-        float from{1.0f};
-        float to{1.0f};
-        std::chrono::steady_clock::time_point start{};
+        bool active;
+        bool desired;
+        bool initialized;
+        float factor;
+        float from;
+        float to;
+        std::chrono::steady_clock::time_point start;
     } slow_time;
 } client_state_t;
 

--- a/src/client/view.cpp
+++ b/src/client/view.cpp
@@ -658,12 +658,12 @@ void V_RenderView(void)
     }
 
     if (cl_dof->integer) {
-        const float slow_scale = std::max(0.0f, 1.0f - CL_Wheel_TimeScale());
+        const float slow_scale = (std::max)(0.0f, 1.0f - CL_Wheel_TimeScale());
         const float base_blend = Q_clipf(slow_scale, 0.0f, 1.0f);
-        const float blur_range = std::max(cl_dof_blur_range->value * base_blend, 0.0f);
-        const float focus_distance = std::max(cl_dof_focus_distance->value, 0.0f);
-        const float focus_range = std::max(cl_dof_focus_range->value, 0.001f);
-        const float luma_strength = std::max(cl_dof_luma_strength->value, 0.0f);
+        const float blur_range = (std::max)(cl_dof_blur_range->value * base_blend, 0.0f);
+        const float focus_distance = (std::max)(cl_dof_focus_distance->value, 0.0f);
+        const float focus_range = (std::max)(cl_dof_focus_range->value, 0.001f);
+        const float luma_strength = (std::max)(cl_dof_luma_strength->value, 0.0f);
 
         cl.refdef.depth_of_field = base_blend > 0.0f && blur_range > 0.0f;
         cl.refdef.dof_blur_range = blur_range;


### PR DESCRIPTION
## Summary
- remove in-struct default member initializers from `client_state_t::slow_time` so MSVC accepts the anonymous typedef
- invoke `std::max` with macro-safe syntax in the depth-of-field setup to avoid Windows macro collisions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690784cc34d48326b2c1fe7566a7db77