### PR TITLE
Fix MSVC typedef for client_state_t

### DIFF
--- a/src/client/client.hpp
+++ b/src/client/client.hpp
@@ -233,7 +233,7 @@ typedef struct {
 // the client_state_t structure is wiped completely at every
 // server map change
 //
-typedef struct {
+typedef struct client_state_s {
     int         timeoutcount;
 
     unsigned    lastTransmitTime;


### PR DESCRIPTION
## Summary
- give the client_state_t structure a tag so MSVC accepts its members

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690785e49a50832683de0154008de22d