### PR TITLE
Remove gl_waterwarp and revise underwater FX default

### DIFF
--- a/doc/client.asciidoc
+++ b/doc/client.asciidoc
@@ -733,9 +733,9 @@ gl_cubemaps::
     skies in re-release maps. Only effective if ‘gl_shaders’ is enabled.
     Default value is 0 (disabled).
 
-gl_waterwarp::
-    Enable screen warping effect when underwater. Only effective when using
-    GLSL backend. Default value is 0 (disabled).
+r_skipUnderWaterFX::
+    Skips rendering the underwater screen warping effect. Default value is 0
+    (render effect).
 
 gl_fog::
     Enable re-release fog effect. Only effective when using GLSL backend.

--- a/src/client/ui/worr.menu.json
+++ b/src/client/ui/worr.menu.json
@@ -278,7 +278,7 @@
           ]
         },
         { "type": "toggle", "label": "screen blending", "cvar": "gl_polyblend" },
-        { "type": "toggle", "label": "screen warping", "cvar": "gl_waterwarp" },
+        { "type": "toggle", "label": "screen warping", "cvar": "r_skipUnderWaterFX", "negate": true },
         { "type": "toggle", "label": "grenade explosions", "cvar": "cl_disable_explosions", "negate": true, "bit": 0 },
         { "type": "toggle", "label": "rocket explosions", "cvar": "cl_disable_explosions", "negate": true, "bit": 1 },
         { "type": "blank" },

--- a/src/refresh/gl.hpp
+++ b/src/refresh/gl.hpp
@@ -398,7 +398,7 @@ extern cvar_t *gl_md5_use;
 extern cvar_t *gl_md5_distance;
 #endif
 extern cvar_t *gl_damageblend_frac;
-extern cvar_t *gl_waterwarp;
+extern cvar_t *r_skipUnderWaterFX;
 extern cvar_t *gl_bloom;
 extern cvar_t *gl_bloom_height;
 extern cvar_t *gl_dof;

--- a/src/refresh/main.cpp
+++ b/src/refresh/main.cpp
@@ -61,7 +61,7 @@ cvar_t *gl_md5_use;
 cvar_t *gl_md5_distance;
 #endif
 cvar_t *gl_damageblend_frac;
-cvar_t *gl_waterwarp;
+cvar_t *r_skipUnderWaterFX;
 cvar_t *gl_fog;
 cvar_t *gl_bloom;
 cvar_t *gl_dof;
@@ -904,7 +904,7 @@ static void GL_DrawDepthOfField(pp_flags_t flags)
     GL_PostProcess(bits, glr.fd.x, glr.fd.y, glr.fd.width, glr.fd.height);
 }
 
-static int32_t gl_waterwarp_modified = 0;
+static int32_t r_skipUnderWaterFX_modified = 0;
 static int32_t gl_bloom_modified = 0;
 static int32_t gl_dof_modified = 0;
 
@@ -917,7 +917,7 @@ static pp_flags_t GL_BindFramebuffer(void)
     if (!gl_static.use_shaders)
         return PP_NONE;
 
-    if ((glr.fd.rdflags & RDF_UNDERWATER) && gl_waterwarp->integer)
+    if ((glr.fd.rdflags & RDF_UNDERWATER) && !r_skipUnderWaterFX->integer)
         flags |= PP_WATERWARP;
 
     if (!(glr.fd.rdflags & RDF_NOWORLDMODEL) && gl_bloom->integer)
@@ -929,13 +929,13 @@ static pp_flags_t GL_BindFramebuffer(void)
     if (flags)
         resized = glr.fd.width != glr.framebuffer_width || glr.fd.height != glr.framebuffer_height;
 
-    if (resized || gl_waterwarp->modified_count != gl_waterwarp_modified ||
+    if (resized || r_skipUnderWaterFX->modified_count != r_skipUnderWaterFX_modified ||
         gl_bloom->modified_count != gl_bloom_modified ||
         gl_dof->modified_count != gl_dof_modified) {
         glr.framebuffer_ok     = GL_InitFramebuffers();
         glr.framebuffer_width  = glr.fd.width;
         glr.framebuffer_height = glr.fd.height;
-        gl_waterwarp_modified = gl_waterwarp->modified_count;
+        r_skipUnderWaterFX_modified = r_skipUnderWaterFX->modified_count;
         gl_bloom_modified = gl_bloom->modified_count;
         gl_dof_modified = gl_dof->modified_count;
         if (flags & PP_BLOOM)
@@ -1295,7 +1295,7 @@ static void GL_Register(void)
     gl_md5_distance = Cvar_Get("gl_md5_distance", "2048", 0);
 #endif
     gl_damageblend_frac = Cvar_Get("gl_damageblend_frac", "0.2", 0);
-    gl_waterwarp = Cvar_Get("gl_waterwarp", "1", 0);
+    r_skipUnderWaterFX = Cvar_Get("r_skipUnderWaterFX", "0", 0);
     gl_fog = Cvar_Get("gl_fog", "1", 0);
     gl_bloom = Cvar_Get("gl_bloom", "1", 0);
     gl_dof = Cvar_Get("gl_dof", "1", 0);

--- a/src/refresh/texture.cpp
+++ b/src/refresh/texture.cpp
@@ -1212,7 +1212,7 @@ bool GL_InitFramebuffers(void)
     int dof_w = 0, dof_h = 0;
     const bool dof_active = gl_dof->integer && glr.fd.depth_of_field;
 
-    if (gl_waterwarp->integer || gl_bloom->integer || dof_active) {
+    if (!r_skipUnderWaterFX->integer || gl_bloom->integer || dof_active) {
         scene_w = glr.fd.width;
         scene_h = glr.fd.height;
     }


### PR DESCRIPTION
## Summary
- remove the redundant gl_waterwarp cvar so underwater warp is governed solely by r_skipUnderWaterFX
- change r_skipUnderWaterFX to default to 0 and update framebuffer setup to track its state
- refresh the client documentation for the underwater effect toggle

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69079ecd6f9883268cdf80809e332213