### PR TITLE
Fix listener floor trace arguments

### DIFF
--- a/src/client/sound/al.cpp
+++ b/src/client/sound/al.cpp
@@ -267,7 +267,7 @@ static void AL_UpdateReverb(void)
     const vec3_t maxs = { 16, 16, 0 };
     const vec3_t listener_start = { listener_origin[0], listener_origin[1], listener_origin[2] + 1.0f };
     const vec3_t listener_down = { listener_start[0], listener_start[1], listener_start[2] - 256.0f };
-    CL_Trace(&tr, listener_start, mins, maxs, listener_down, NULL, MASK_SOLID);
+    CL_Trace(&tr, listener_down, mins, maxs, listener_start, NULL, MASK_SOLID);
 
     uint8_t new_preset = s_reverb_current_preset;
 


### PR DESCRIPTION
## Summary
- correct the listener floor trace in `AL_UpdateReverb` so the line trace uses the intended end point and bounding box vectors

## Testing
- meson setup builddir *(fails: wrap-redirect /workspace/WORR/subprojects/ffmpeg/subprojects/nasm.wrap filename does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6907a013939c8326aeda403d6199be94