### PR TITLE
Add configurable client font backends

### DIFF
--- a/src/client/client.hpp
+++ b/src/client/client.hpp
@@ -1290,7 +1290,6 @@ void    SCR_AddNetgraph(void);
 float   SCR_FadeAlpha(unsigned startTime, unsigned visTime, unsigned fadeTime);
 int     SCR_DrawStringStretch(int x, int y, int scale, int flags, size_t maxlen, const char *s, color_t color, qhandle_t font);
 void    SCR_DrawStringMultiStretch(int x, int y, int scale, int flags, size_t maxlen, const char *s, color_t color, qhandle_t font);
-void    SCR_DrawKStringMultiStretch(int x, int y, int scale, int flags, size_t maxlen, const char *s, color_t color, const kfont_t *kfont);
 
 qhandle_t SCR_DefaultFontHandle(void);
 int     SCR_FontLineHeight(int scale, qhandle_t font);


### PR DESCRIPTION
## Summary
- add a "ttf"-defaulted scr_text_backend mode that lets players choose between TTF, legacy bitmap, and kfont rendering
- integrate kfont measurement and drawing into the shared client string utilities with consistent cursor handling
- update the cgame helpers to rely on the unified font pipeline

## Testing
- not run (not built)

------
https://chatgpt.com/codex/tasks/task_e_6907d14ecb9483268d29993026b5f5fd