### PR TITLE
Fix HDR bounds and restore FreeType guard

### DIFF
--- a/inc/shared/shared.hpp
+++ b/inc/shared/shared.hpp
@@ -427,6 +427,16 @@ static inline int Q_clip(int a, int b, int c)
     return a;
 }
 
+template <typename T>
+static inline T Q_bound(T min_value, T value, T max_value)
+{
+    if (value < min_value)
+        return min_value;
+    if (value > max_value)
+        return max_value;
+    return value;
+}
+
 static inline float Q_clipf(float a, float b, float c)
 {
 #if defined(__GNUC__) && defined(__SSE__)

--- a/src/client/screen.cpp
+++ b/src/client/screen.cpp
@@ -210,21 +210,23 @@ static bool SCR_LoadDefaultFreeTypeFont(void)
 
 static const ftfont_t* SCR_FTFontForHandle(qhandle_t handle)
 {
-	auto handleIt = scr.freetype.handleLookup.find(handle);
-	if (handleIt == scr.freetype.handleLookup.end())
-		return nullptr;
+        auto handleIt = scr.freetype.handleLookup.find(handle);
+        if (handleIt == scr.freetype.handleLookup.end())
+                return nullptr;
 
-	auto fontIt = scr.freetype.fonts.find(handleIt->second);
-	if (fontIt == scr.freetype.fonts.end())
-		return nullptr;
+        auto fontIt = scr.freetype.fonts.find(handleIt->second);
+        if (fontIt == scr.freetype.fonts.end())
+                return nullptr;
 
-	return &fontIt->second.renderInfo;
+        return &fontIt->second.renderInfo;
 }
 
+#endif // USE_FREETYPE
+
 enum class scr_text_backend_mode {
-	LEGACY,
-	TTF,
-	KFONT,
+        LEGACY,
+        TTF,
+        KFONT,
 };
 
 static scr_text_backend_mode scr_activeTextBackend = scr_text_backend_mode::LEGACY;

--- a/src/refresh/qgl.cpp
+++ b/src/refresh/qgl.cpp
@@ -71,6 +71,7 @@ static constexpr glfunction_t kGl11Functions[] = {
     QGL_FN(GetString),
     QGL_FN(IsEnabled),
     QGL_FN(LineWidth),
+    QGL_FN(ReadBuffer),
     QGL_FN(PixelStorei),
     QGL_FN(PolygonOffset),
     QGL_FN(ReadPixels),

--- a/src/refresh/qgl.hpp
+++ b/src/refresh/qgl.hpp
@@ -63,6 +63,7 @@ QGLAPI void (APIENTRYP qglGetTexImage)(GLenum target, GLint level, GLenum format
 QGLAPI const GLubyte *(APIENTRYP qglGetString)(GLenum name);
 QGLAPI GLboolean (APIENTRYP qglIsEnabled)(GLenum cap);
 QGLAPI void (APIENTRYP qglLineWidth)(GLfloat width);
+QGLAPI void (APIENTRYP qglReadBuffer)(GLenum src);
 QGLAPI void (APIENTRYP qglPixelStorei)(GLenum pname, GLint param);
 QGLAPI void (APIENTRYP qglPolygonOffset)(GLfloat factor, GLfloat units);
 QGLAPI void (APIENTRYP qglReadPixels)(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, void *pixels);


### PR DESCRIPTION
## Summary
- add a reusable Q_bound helper for HDR configuration code
- expose qglReadBuffer through the GL loader so HDR histogram reads compile
- close an unbalanced USE_FREETYPE guard that broke MSVC compilation

## Testing
- `meson compile -C builddir` *(fails: meson not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_69083fad97b88326ba6b5faf270d9603