### PR TITLE
Align depth of field with active time scale

### DIFF
--- a/src/client/view.cpp
+++ b/src/client/view.cpp
@@ -658,8 +658,8 @@ void V_RenderView(void)
     }
 
     if (cl_dof->integer) {
-        const float slow_scale = (std::max)(0.0f, 1.0f - CL_Wheel_TimeScale());
-        const float base_blend = Q_clipf(slow_scale, 0.0f, 1.0f);
+        const float time_scale = (std::max)(CL_ActiveTimeScale(), 0.0f);
+        const float base_blend = Q_clipf(1.0f - time_scale, 0.0f, 1.0f);
         const float blur_range = (std::max)(cl_dof_blur_range->value * base_blend, 0.0f);
         const float focus_distance = (std::max)(cl_dof_focus_distance->value, 0.0f);
         const float focus_range = (std::max)(cl_dof_focus_range->value, 0.001f);


### PR DESCRIPTION
## Summary
- ensure the depth-of-field blend factor is based on the active time scale so server-driven slow time engages the effect

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6908f68f88d4832c917a3fe29882cbd4