### PR TITLE
Enable FreeType defaults and route client text through glyph helper

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -30,7 +30,7 @@ option('client-ui',
 
 option('freetype',
   type: 'feature',
-  value: 'auto',
+  value: 'enabled',
   description: 'FreeType2 font rendering support')
 
 option('default-game',

--- a/src/client/client.hpp
+++ b/src/client/client.hpp
@@ -1290,6 +1290,7 @@ void    SCR_AddNetgraph(void);
 float   SCR_FadeAlpha(unsigned startTime, unsigned visTime, unsigned fadeTime);
 int     SCR_DrawStringStretch(int x, int y, int scale, int flags, size_t maxlen, const char *s, color_t color, qhandle_t font);
 void    SCR_DrawStringMultiStretch(int x, int y, int scale, int flags, size_t maxlen, const char *s, color_t color, qhandle_t font);
+void    SCR_DrawGlyph(int x, int y, int scale, int flags, unsigned char glyph, color_t color);
 
 qhandle_t SCR_DefaultFontHandle(void);
 int     SCR_FontLineHeight(int scale, qhandle_t font);


### PR DESCRIPTION
## Summary
- default the build to require FreeType and make the screen font cvars pick a TTF file first with graceful fallback
- add a shared SCR_DrawGlyph helper so game-side text honors the selected text backend while preserving legacy glyphs when needed

## Testing
- not run (build system not configured in container)

------
https://chatgpt.com/codex/tasks/task_e_6908f5355904832ca78e9c05b6ab867f