### PR TITLE
Fix GLSL texture usage and stabilize DOF timescale fallback

### DIFF
--- a/src/client/wheel.cpp
+++ b/src/client/wheel.cpp
@@ -371,7 +371,8 @@ float CL_Wheel_TimeScale(void)
 float CL_ActiveTimeScale(void)
 {
     const float slow_factor = cl.slow_time.initialized ? cl.slow_time.factor : 1.0f;
-    return max(0.0f, cl.wheel.timescale * slow_factor);
+    const float wheel_factor = cl.wheel.timescale > 0.0f ? cl.wheel.timescale : 1.0f;
+    return max(0.0f, wheel_factor * slow_factor);
 }
 
 void CL_Wheel_ClearInput(void)

--- a/src/refresh/shader.cpp
+++ b/src/refresh/shader.cpp
@@ -102,6 +102,11 @@ static void write_header(sizebuf_t *buf, glStateBits_t bits)
         if (bits & GLS_MESH_ANY)
             GLSL(precision mediump int;)
     }
+
+    GLSF("#if __VERSION__ < 130\n");
+    GLSF("vec4 texture(sampler2D s, vec2 coord) { return texture2D(s, coord); }\n");
+    GLSF("vec4 texture(samplerCube s, vec3 coord) { return textureCube(s, coord); }\n");
+    GLSF("#endif\n");
 }
 
 static void write_block(sizebuf_t *buf, glStateBits_t bits)


### PR DESCRIPTION
## Summary
- add GLSL helper overloads so older drivers that only expose texture2D/textureCube can compile the fragment shaders without errors
- clamp the client timescale calculation so depth of field only engages when the weapon wheel or slow-time actually reduces time

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_6908fb9a641c832c84a83d677d6bd2f9