### PR TITLE
Restrict CRT effect to explicit mode

### DIFF
--- a/src/refresh/main.cpp
+++ b/src/refresh/main.cpp
@@ -1374,8 +1374,10 @@ void R_RenderFrame(const refdef_t *fd)
         if (pp_flags & PP_HDR) {
             R_HDRUpdateUniforms();
             bits |= GLS_TONEMAP_ENABLE;
-        bits = R_CRTPrepare(bits, glr.fd.width, glr.fd.height);
         }
+
+        if (pp_flags & PP_CRT)
+            bits = R_CRTPrepare(bits, glr.fd.width, glr.fd.height);
 
         GL_ForceTexture(TMU_TEXTURE, TEXNUM_PP_SCENE);
         if (glr.motion_blur_ready) {
@@ -1389,7 +1391,8 @@ void R_RenderFrame(const refdef_t *fd)
         glStateBits_t bits = GLS_TONEMAP_ENABLE;
         GL_ForceTexture(TMU_TEXTURE, TEXNUM_PP_SCENE);
         R_HDRUpdateUniforms();
-        bits = R_CRTPrepare(bits, glr.fd.width, glr.fd.height);
+        if (pp_flags & PP_CRT)
+            bits = R_CRTPrepare(bits, glr.fd.width, glr.fd.height);
         GL_PostProcess(bits, glr.fd.x, glr.fd.y, glr.fd.width, glr.fd.height);
     } else if (pp_flags & PP_CRT) {
         glStateBits_t bits = GLS_DEFAULT;

--- a/src/refresh/postprocess/crt.cpp
+++ b/src/refresh/postprocess/crt.cpp
@@ -45,7 +45,7 @@ struct CrtConfig {
 
 [[nodiscard]] bool R_CRTEnabled() noexcept
 {
-    return gl_static.use_shaders && r_crtmode && r_crtmode->integer > 0;
+    return gl_static.use_shaders && r_crtmode && r_crtmode->integer == 1;
 }
 
 glStateBits_t R_CRTPrepare(glStateBits_t bits, int viewportWidth, int viewportHeight)


### PR DESCRIPTION
## Summary
- ensure the CRT post-process only activates when `r_crtmode` is set to 1
- trigger CRT uniform setup even when combined with other post-processing passes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69090679a64c83218b8459ebb1e49a99