### PR TITLE
Fix Windows min/max macro conflicts

### DIFF
--- a/src/windows/system.cpp
+++ b/src/windows/system.cpp
@@ -38,6 +38,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <string_view>
 #include <vector>
 
+#ifdef max
+#undef max
+#endif
+#ifdef min
+#undef min
+#endif
+
 #if USE_WINSVC
 #include <winsvc.h>
 #include <setjmp.h>


### PR DESCRIPTION
## Summary
- undefine Windows min/max macros in system.cpp so standard library algorithms compile correctly

## Testing
- not run (meson unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_690909e8f6188321994d9af9bc62be9b