### PR TITLE
Always include uniform block in fragment shaders

### DIFF
--- a/src/refresh/gl.hpp
+++ b/src/refresh/gl.hpp
@@ -881,6 +881,7 @@ typedef struct {
     GLfloat     heightfog_falloff;
     GLfloat     pad;
     GLfloat     pad2;
+    vec4_t      bbr_params;
     vec4_t      dof_params;
     vec4_t      dof_screen;
     vec4_t      dof_depth;

--- a/src/refresh/shader.cpp
+++ b/src/refresh/shader.cpp
@@ -156,6 +156,7 @@ static void write_block(sizebuf_t *buf, glStateBits_t bits)
         float u_heightfog_falloff;
         float pad_5;
         float pad_4;
+        vec4 u_bbr_params;
         vec4 u_dof_params;
         vec4 u_dof_screen;
         vec4 u_dof_depth;
@@ -1088,8 +1089,7 @@ static void write_fragment_shader(sizebuf_t *buf, glStateBits_t bits)
 
     write_header(buf, bits);
 
-    if (bits & GLS_UNIFORM_MASK)
-        write_block(buf, bits);
+    write_block(buf, bits);
 
     if (bits & GLS_TONEMAP_ENABLE)
         write_tonemap_block(buf);
@@ -1228,14 +1228,14 @@ static void write_fragment_shader(sizebuf_t *buf, glStateBits_t bits)
             GLSL(vec2 crt_uv = tc;)
 
         if (bits & GLS_BLUR_MASK)
-            GLSL(vec4 diffuse = blur(u_texture, tc, u_fog_color.xy);)
+            GLSL(vec4 diffuse = blur(u_texture, tc, u_bbr_params.xy);)
         else
             GLSL(vec4 diffuse = texture(u_texture, tc);)
 
         if (bits & GLS_BLOOM_BRIGHTPASS) {
             GLSL(vec4 scene = texture(u_scene, tc);)
             GLSL(float luminance = dot(scene.rgb, bloom_luminance);)
-            GLSL(float threshold = u_fog_color.z;)
+            GLSL(float threshold = u_bbr_params.z;)
             GLSL(luminance = max(0.0, luminance - threshold);)
             GLSL(diffuse.rgb *= sign(luminance);)
             GLSL(diffuse.a = 1.0;)


### PR DESCRIPTION
## Summary
- always emit the shared uniform block in fragment shaders so post-process uniforms such as u_bbr_params are declared

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_690907b6ab788321997cd862565135bf