### PR TITLE
Fix fragment shader uniform block requirement

### DIFF
--- a/src/refresh/shader.cpp
+++ b/src/refresh/shader.cpp
@@ -1089,7 +1089,8 @@ static void write_fragment_shader(sizebuf_t *buf, glStateBits_t bits)
 
     write_header(buf, bits);
 
-    write_block(buf, bits);
+    if (bits & GLS_UNIFORM_MASK)
+        write_block(buf, bits);
 
     if (bits & GLS_TONEMAP_ENABLE)
         write_tonemap_block(buf);


### PR DESCRIPTION
## Summary
- guard fragment shader generation so the Uniforms block is only emitted when the program actually uses uniform-buffer state
- avoid forcing uniform-buffer support in minimal shader permutations so the engine can start on older drivers again

## Testing
- not run (environment lacks the game runtime)


------
https://chatgpt.com/codex/tasks/task_e_6909928553ec83219ce63c6e46fd191b