### PR TITLE
Fix HDR bloom shader uniforms and motion blur bit

### DIFF
--- a/src/refresh/gl.hpp
+++ b/src/refresh/gl.hpp
@@ -762,7 +762,7 @@ void GL_LoadWorld(const char *name);
 #define GLS_BOKEH_COMBINE       BIT_ULL(40)
 #define GLS_TONEMAP_ENABLE      BIT_ULL(41)
 #define GLS_CRT_ENABLE          BIT_ULL(42)
-#define GLS_MOTION_BLUR         BIT_ULL(42)
+#define GLS_MOTION_BLUR         BIT_ULL(43)
 
 #define GLS_BLEND_MASK          (GLS_BLEND_BLEND | GLS_BLEND_ADD | GLS_BLEND_MODULATE)
 #define GLS_BOKEH_MASK          (GLS_BOKEH_COC | GLS_BOKEH_INITIAL | GLS_BOKEH_DOWNSAMPLE | GLS_BOKEH_GATHER | GLS_BOKEH_COMBINE)
@@ -777,9 +777,9 @@ void GL_LoadWorld(const char *name);
                                  GLS_LIGHTMAP_ENABLE | GLS_WARP_ENABLE | GLS_INTENSITY_ENABLE | \
                                  GLS_GLOWMAP_ENABLE | GLS_SKY_MASK | GLS_DEFAULT_FLARE | GLS_MESH_MASK | \
                                  GLS_FOG_MASK | GLS_BLOOM_MASK | GLS_BLUR_MASK | GLS_DYNAMIC_LIGHTS | GLS_BOKEH_MASK | \
-                                 GLS_TONEMAP_ENABLE | GLS_MOTION_BLUR)
+                                 GLS_TONEMAP_ENABLE | GLS_CRT_ENABLE | GLS_MOTION_BLUR)
 #define GLS_UNIFORM_MASK        (GLS_WARP_ENABLE | GLS_LIGHTMAP_ENABLE | GLS_INTENSITY_ENABLE | \
-                                 GLS_SKY_MASK | GLS_FOG_MASK | GLS_BLOOM_BRIGHTPASS | GLS_BLUR_MASK | GLS_DYNAMIC_LIGHTS | GLS_BOKEH_MASK | \
+                                 GLS_SKY_MASK | GLS_FOG_MASK | GLS_BLOOM_BRIGHTPASS | GLS_BLOOM_OUTPUT | GLS_BLUR_MASK | GLS_DYNAMIC_LIGHTS | GLS_BOKEH_MASK | \
                                  GLS_TONEMAP_ENABLE | GLS_CRT_ENABLE | GLS_MOTION_BLUR)
 
 inline constexpr float R_MOTION_BLUR_MAX_SAMPLES = 12.0f;


### PR DESCRIPTION
## Summary
- ensure the bloom combine shaders bind the uniform block so HDR parameters compile
- give motion blur its own state bit and include CRT in the shader mask to avoid collisions

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_690998ff32e08321a5ce817666c48b79