### PR TITLE
Improve remotemode completion suggestions

### DIFF
--- a/src/client/console.cpp
+++ b/src/client/console.cpp
@@ -1482,11 +1482,14 @@ namespace {
 			FS_File_g("condumps", ".txt", FS_SEARCH_STRIPEXT, ctx);
 	}
 
-	static void CL_RemoteMode_c(genctx_t* ctx, int argnum)
-	{
-		(void)ctx;
-		(void)argnum;
-	}
+        static void CL_RemoteMode_c(genctx_t* ctx, int argnum)
+        {
+                if (argnum == 1) {
+                        Com_Address_g(ctx);
+                } else if (argnum > 1) {
+                        Com_Generic_c(ctx, argnum - 2);
+                }
+        }
 
 } // namespace
 


### PR DESCRIPTION
## Summary
- call `Com_Address_g` for the first `remotemode` argument so stored addresses are suggested
- delegate later arguments to `Com_Generic_c` to keep generic completion (e.g. password) working
- ensured the `remotemode` command continues to register the updated generator

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6909b9dd83c883218bf90e65a41ee793