### PR TITLE
Restore Ctrl+arrow console search shortcuts

### DIFF
--- a/doc/server.asciidoc
+++ b/doc/server.asciidoc
@@ -547,6 +547,8 @@ when command line editing is enabled:
 * Up arrow, Ctrl+P — previous line in command history
 * Ctrl+R — reverse search in command history
 * Ctrl+S — forward search in command history
+* Ctrl+Up arrow — search backward for the current prompt text in console output
+* Ctrl+Down arrow — search forward for the current prompt text in console output
 * Tab — complete command
 
 In Windows console additional key bindings are supported:

--- a/src/client/console.cpp
+++ b/src/client/console.cpp
@@ -1142,15 +1142,27 @@ namespace {
 				return;
 			}
 			break;
-		case 'b':
-			if (Key_IsDown(K_CTRL)) {
-				searchUp();
-				return;
-			}
-			break;
-		case K_PGUP:
-		case K_MWHEELUP:
-			displayIndex_ -= Key_IsDown(K_CTRL) ? kScrollLargeStep : kScrollSmallStep;
+                case 'b':
+                        if (Key_IsDown(K_CTRL)) {
+                                searchUp();
+                                return;
+                        }
+                        break;
+                case K_UPARROW:
+                        if (Key_IsDown(K_CTRL)) {
+                                searchUp();
+                                return;
+                        }
+                        break;
+                case K_DOWNARROW:
+                        if (Key_IsDown(K_CTRL)) {
+                                searchDown();
+                                return;
+                        }
+                        break;
+                case K_PGUP:
+                case K_MWHEELUP:
+                        displayIndex_ -= Key_IsDown(K_CTRL) ? kScrollLargeStep : kScrollSmallStep;
 			if (displayIndex_ < 0)
 				displayIndex_ = 0;
 			return;


### PR DESCRIPTION
## Summary
- hook Ctrl+Up/Ctrl+Down in the client console to jump through log search results
- document the restored shortcuts alongside other console key bindings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6909b9d778d083218c5338a5e347f5b8