### PR TITLE
Handle Ctrl+D to leave remote console mode

### DIFF
--- a/src/client/console.cpp
+++ b/src/client/console.cpp
@@ -1083,17 +1083,29 @@ namespace {
 				return;
 			}
 			break;
-		case 'c':
-			if (Key_IsDown(K_CTRL)) {
-				paste(vid ? vid->get_clipboard_data : nullptr);
-				return;
-			}
-			break;
-		case 'v':
-			if (Key_IsDown(K_CTRL)) {
-				paste(vid ? vid->get_clipboard_data : nullptr);
-				return;
-			}
+                case 'c':
+                        if (Key_IsDown(K_CTRL)) {
+                                paste(vid ? vid->get_clipboard_data : nullptr);
+                                return;
+                        }
+                        break;
+                case 'd':
+                        if (Key_IsDown(K_CTRL)) {
+                                if (mode_ == ConsoleMode::Remote) {
+                                        clearTyping();
+                                        mode_ = ConsoleMode::Default;
+                                        chatMode_ = ChatMode::None;
+                                        remoteAddress_ = {};
+                                        remotePassword_.clear();
+                                }
+                                return;
+                        }
+                        break;
+                case 'v':
+                        if (Key_IsDown(K_CTRL)) {
+                                paste(vid ? vid->get_clipboard_data : nullptr);
+                                return;
+                        }
 			break;
 		case 'y':
 			if (Key_IsDown(K_CTRL)) {


### PR DESCRIPTION
## Summary
- add a Ctrl+D shortcut that exits remote console mode without closing the console
- clear remote prompt state when leaving remote mode so subsequent input targets the local console

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6909b9ce254083218cccaebbf776f295