### PR TITLE
Fix CRT post-process flag collision and cache uniforms

### DIFF
--- a/src/refresh/main.cpp
+++ b/src/refresh/main.cpp
@@ -1052,7 +1052,7 @@ typedef enum {
     PP_DEPTH_OF_FIELD = BIT(2),
     PP_HDR       = BIT(3),
     PP_CRT       = BIT(4),
-    PP_MOTION_BLUR = BIT(4),
+    PP_MOTION_BLUR = BIT(5),
 } pp_flags_t;
 
 constexpr pp_flags_t operator|(pp_flags_t lhs, pp_flags_t rhs) noexcept

--- a/src/refresh/postprocess/crt.cpp
+++ b/src/refresh/postprocess/crt.cpp
@@ -1,6 +1,7 @@
 #include "crt.hpp"
 
 #include <algorithm>
+#include <cmath>
 
 extern cvar_t* r_crtmode;
 extern cvar_t* r_crt_hardScan;
@@ -12,35 +13,62 @@ extern cvar_t* r_crt_shadowMask;
 extern cvar_t* r_crt_brightBoost;
 
 namespace {
-	struct CrtConfig {
-		float hardScan;
-		float hardPix;
-		float maskDark;
-		float maskLight;
-		float scaleInLinearGamma;
-		float shadowMask;
-		float brightBoost;
-		float warpX;
-		float warpY;
-	};
+        struct CrtConfig {
+                float hardScan;
+                float hardPix;
+                float maskDark;
+                float maskLight;
+                float scaleInLinearGamma;
+                float shadowMask;
+                float brightBoost;
+                float warpX;
+                float warpY;
+        };
 
-	[[nodiscard]] CrtConfig gather_config(int mode) noexcept
-	{
-		const float warpX = (mode == 1) ? 0.031f : 0.0f;
-		const float warpY = (mode == 1) ? 0.041f : 0.0f;
+        struct CrtStateCache {
+                CrtConfig config{};
+                int width = 0;
+                int height = 0;
+                bool initialized = false;
+        };
 
-		return CrtConfig{
-			.hardScan = r_crt_hardScan ? r_crt_hardScan->value : -8.0f,
-			.hardPix = r_crt_hardPix ? r_crt_hardPix->value : -3.0f,
-			.maskDark = r_crt_maskDark ? r_crt_maskDark->value : 0.5f,
-			.maskLight = r_crt_maskLight ? r_crt_maskLight->value : 1.5f,
-			.scaleInLinearGamma = (r_crt_scaleInLinearGamma && r_crt_scaleInLinearGamma->integer) ? 1.0f : 0.0f,
-			.shadowMask = r_crt_shadowMask ? std::clamp(r_crt_shadowMask->value, 0.0f, 4.0f) : 3.0f,
-			.brightBoost = r_crt_brightBoost ? (std::max)(r_crt_brightBoost->value, 0.0f) : 1.0f,
-			.warpX = warpX,
-			.warpY = warpY,
-		};
-	}
+        [[nodiscard]] bool nearly_equal(float lhs, float rhs) noexcept
+        {
+                const float diff = std::fabs(lhs - rhs);
+                const float scale = (std::max)((std::max)(std::fabs(lhs), std::fabs(rhs)), 1.0f);
+                return diff <= scale * 1.0e-6f;
+        }
+
+        [[nodiscard]] bool config_changed(const CrtConfig& lhs, const CrtConfig& rhs) noexcept
+        {
+                return !nearly_equal(lhs.hardScan, rhs.hardScan) ||
+                        !nearly_equal(lhs.hardPix, rhs.hardPix) ||
+                        !nearly_equal(lhs.maskDark, rhs.maskDark) ||
+                        !nearly_equal(lhs.maskLight, rhs.maskLight) ||
+                        !nearly_equal(lhs.scaleInLinearGamma, rhs.scaleInLinearGamma) ||
+                        !nearly_equal(lhs.shadowMask, rhs.shadowMask) ||
+                        !nearly_equal(lhs.brightBoost, rhs.brightBoost) ||
+                        !nearly_equal(lhs.warpX, rhs.warpX) ||
+                        !nearly_equal(lhs.warpY, rhs.warpY);
+        }
+
+        [[nodiscard]] CrtConfig gather_config(int mode) noexcept
+        {
+                const float warpX = (mode == 1) ? 0.031f : 0.0f;
+                const float warpY = (mode == 1) ? 0.041f : 0.0f;
+
+                return CrtConfig{
+                        .hardScan = r_crt_hardScan ? r_crt_hardScan->value : -8.0f,
+                        .hardPix = r_crt_hardPix ? r_crt_hardPix->value : -3.0f,
+                        .maskDark = r_crt_maskDark ? r_crt_maskDark->value : 0.5f,
+                        .maskLight = r_crt_maskLight ? r_crt_maskLight->value : 1.5f,
+                        .scaleInLinearGamma = (r_crt_scaleInLinearGamma && r_crt_scaleInLinearGamma->integer) ? 1.0f : 0.0f,
+                        .shadowMask = r_crt_shadowMask ? std::clamp(r_crt_shadowMask->value, 0.0f, 4.0f) : 3.0f,
+                        .brightBoost = r_crt_brightBoost ? (std::max)(r_crt_brightBoost->value, 0.0f) : 1.0f,
+                        .warpX = warpX,
+                        .warpY = warpY,
+                };
+        }
 } // namespace
 
 [[nodiscard]] bool R_CRTEnabled() noexcept
@@ -50,22 +78,37 @@ namespace {
 
 glStateBits_t R_CRTPrepare(glStateBits_t bits, int viewportWidth, int viewportHeight)
 {
-	if (!R_CRTEnabled())
-		return bits;
+        if (!R_CRTEnabled())
+                return bits;
 
-	const auto mode = r_crtmode->integer;
-	const CrtConfig config = gather_config(mode);
+        static CrtStateCache cache;
 
-	const float width = static_cast<float>((std::max)(viewportWidth, 1));
-	const float height = static_cast<float>((std::max)(viewportHeight, 1));
-	const float invWidth = 1.0f / width;
-	const float invHeight = 1.0f / height;
+        const auto mode = r_crtmode->integer;
+        const CrtConfig config = gather_config(mode);
 
-	Vector4Set(gls.u_block.crt_params0, config.hardScan, config.hardPix, config.maskDark, config.maskLight);
-	Vector4Set(gls.u_block.crt_params1, config.warpX, config.warpY, config.scaleInLinearGamma, config.shadowMask);
-	Vector4Set(gls.u_block.crt_params2, config.brightBoost, 0.0f, 0.0f, 0.0f);
-	Vector4Set(gls.u_block.crt_screen, width, height, invWidth, invHeight);
-	gls.u_block_dirty = true;
+        const int width = (std::max)(viewportWidth, 1);
+        const int height = (std::max)(viewportHeight, 1);
 
-	return bits | GLS_CRT_ENABLE;
+        const bool changed = !cache.initialized || config_changed(config, cache.config);
+        const bool viewport_changed = !cache.initialized || cache.width != width || cache.height != height;
+
+        if (changed || viewport_changed) {
+                const float width_f = static_cast<float>(width);
+                const float height_f = static_cast<float>(height);
+                const float invWidth = 1.0f / width_f;
+                const float invHeight = 1.0f / height_f;
+
+                Vector4Set(gls.u_block.crt_params0, config.hardScan, config.hardPix, config.maskDark, config.maskLight);
+                Vector4Set(gls.u_block.crt_params1, config.warpX, config.warpY, config.scaleInLinearGamma, config.shadowMask);
+                Vector4Set(gls.u_block.crt_params2, config.brightBoost, 0.0f, 0.0f, 0.0f);
+                Vector4Set(gls.u_block.crt_screen, width_f, height_f, invWidth, invHeight);
+                gls.u_block_dirty = true;
+
+                cache.config = config;
+                cache.width = width;
+                cache.height = height;
+                cache.initialized = true;
+        }
+
+        return bits | GLS_CRT_ENABLE;
 }


### PR DESCRIPTION
## Summary
- assign motion blur its own post-processing bit so it no longer collides with the CRT toggle
- cache CRT configuration and viewport data before uploading uniforms to avoid redundant updates

## Testing
- not run (not configured in this environment)


------
https://chatgpt.com/codex/tasks/task_e_6909d9bb6a78832c87476363ba645dcb