### PR TITLE
Add checkbox/dropdown/radio menu controls with grouping support

### DIFF
--- a/doc/client.asciidoc
+++ b/doc/client.asciidoc
@@ -1274,6 +1274,38 @@ ui_pingrate::
     second. Default value is 0, which estimates the default pinging rate based
     on ‘rate’ client variable.
 
+Menu JSON
+~~~~~~~~~
+
+The UI menu shipped with the client (`worr.menu.json`) defines its controls via
+JSON. The schema now recognises additional item types and layout helpers that
+make it easier to express complex interactions:
+
+* `checkbox` items toggle a boolean cvar, a named bit within a mask, or a pair
+  of string values (`checkedValue`/`uncheckedValue`). They accept the same
+  `negate`/`bit` helpers as legacy toggles.
+* `dropdown` items behave like a compact spin control. Provide the visible
+  `options`, an optional `valueBinding` (`label`, `value`, or `index`), and the
+  number of rows that may be shown at once via `maxVisible`.
+* `radio` items represent a single choice. Multiple radio definitions that
+  share the same cvar automatically behave as a group and set the cvar to their
+  `value` when activated.
+* Menu items may now react to cvars through `enableWhen` and `disableWhen`. Each
+  property accepts a condition object or an array of conditions containing
+  `cvar` along with `equals`, `notEquals`, `greater`, `greaterOrEquals`, `less`,
+  or `lessOrEquals` comparators.
+* Individual menus can declare `groups` to cluster items. A group definition
+  supplies `name`, an optional `label`, visual hints such as `background` colour
+  and `border`, and layout hints (`indent`, `padding`, `headerHeight`). Menu
+  items reference a group by name through their `group` property.
+
+The checkbox, radio, and dropdown controls currently use font glyphs as a
+placeholder. UI artists should create dedicated 32×32 glyphs for the checked
+and unchecked checkbox states, radio on/off states, and a dropdown caret, and
+store them alongside the rest of the UI artwork (for example under
+`pics/ui/checkbox_checked.tga`, `pics/ui/radio_on.tga`, and
+`pics/ui/dropdown_caret.tga`).
+
 com_time_format::
     Time format used by ‘com_time’ macro. Default value is "%H.%M" on Win32 and
     "%H:%M" on UNIX. See strftime(3) for syntax description.

--- a/src/client/ui/ui.hpp
+++ b/src/client/ui/ui.hpp
@@ -54,6 +54,9 @@ typedef enum {
     MTYPE_STRINGS,
     MTYPE_VALUES,
     MTYPE_TOGGLE,
+    MTYPE_CHECKBOX,
+    MTYPE_DROPDOWN,
+    MTYPE_RADIO,
     MTYPE_STATIC,
     MTYPE_KEYBIND,
     MTYPE_BITMAP,
@@ -95,6 +98,9 @@ typedef enum {
      (item)->type != MTYPE_STATIC && \
      !((item)->flags & (QMF_GRAYED | QMF_HIDDEN | QMF_DISABLED)))
 
+struct uiItemGroup_s;
+struct uiConditionalBlock_s;
+
 typedef struct menuFrameWork_s {
     list_t  entry;
 
@@ -102,6 +108,9 @@ typedef struct menuFrameWork_s {
 
     void    **items;
     int     nitems;
+
+    struct uiItemGroup_s   **groups;
+    int                     numGroups;
 
     bool compact;
     bool transparent;
@@ -146,6 +155,10 @@ typedef struct menuCommon_s {
 
     int flags;
     int uiFlags;
+
+    struct uiItemGroup_s *group;
+    struct uiConditionalBlock_s *conditional;
+    bool defaultDisabled;
 
     menuSound_t (*activate)(struct menuCommon_s *);
     menuSound_t (*change)(struct menuCommon_s *);
@@ -244,6 +257,81 @@ typedef struct {
     menuSpinControl_t   spin;
     int                 *itemindices;
 } menuUnitSelector_t;
+
+typedef enum {
+    UI_CONDITION_EQUALS,
+    UI_CONDITION_NOT_EQUALS,
+    UI_CONDITION_GREATER,
+    UI_CONDITION_GREATER_EQUAL,
+    UI_CONDITION_LESS,
+    UI_CONDITION_LESS_EQUAL,
+} uiConditionOp_t;
+
+typedef struct uiItemCondition_s {
+    struct uiItemCondition_s *next;
+    cvar_t *cvar;
+    char *value;
+    float numericValue;
+    bool hasNumericValue;
+    uiConditionOp_t op;
+} uiItemCondition_t;
+
+typedef struct uiConditionalBlock_s {
+    uiItemCondition_t *enable;
+    uiItemCondition_t *disable;
+} uiConditionalBlock_t;
+
+typedef struct uiItemGroup_s {
+    char *name;
+    char *label;
+    color_t background;
+    bool hasBackground;
+    bool border;
+    int indent;
+    int padding;
+    int headerHeight;
+    int headerY;
+    int contentTop;
+    int contentBottom;
+    int baseX;
+    bool active;
+    bool hasItems;
+    vrect_t rect;
+    vrect_t headerRect;
+} uiItemGroup_t;
+
+typedef struct {
+    menuCommon_t generic;
+    cvar_t *cvar;
+    uint32_t mask;
+    bool useBitmask;
+    bool negate;
+    bool useStrings;
+    char *checkedValue;
+    char *uncheckedValue;
+} menuCheckbox_t;
+
+typedef enum {
+    DROPDOWN_BINDING_LABEL,
+    DROPDOWN_BINDING_VALUE,
+    DROPDOWN_BINDING_INDEX,
+} menuDropdownBinding_t;
+
+typedef struct {
+    menuSpinControl_t   spin;
+    menuDropdownBinding_t binding;
+    int                 maxVisibleItems;
+    int                 hovered;
+    int                 scrollOffset;
+    bool                open;
+    vrect_t             listRect;
+} menuDropdown_t;
+
+typedef struct {
+    menuCommon_t generic;
+    cvar_t *cvar;
+    char *value;
+} menuRadioButton_t;
 
 typedef struct {
     menuCommon_t generic;

--- a/src/client/ui/worr.menu.json
+++ b/src/client/ui/worr.menu.json
@@ -153,41 +153,78 @@
     {
       "name": "sound",
       "title": "Sound Setup",
+      "groups": [
+        {
+          "name": "playback",
+          "label": "Playback",
+          "indent": 24,
+          "padding": 12,
+          "border": true,
+          "background": "#0f90eb20"
+        },
+        {
+          "name": "music",
+          "label": "Music",
+          "indent": 24,
+          "padding": 12,
+          "background": "#0f90eb10"
+        }
+      ],
       "items": [
         {
           "type": "values",
           "label": "sound engine",
           "cvar": "s_enable",
+          "group": "playback",
           "options": [
             "no sound",
             "software",
             "OpenAL"
           ]
         },
-        { "type": "range", "label": "sound latency", "cvar": "s_mixahead", "min": 0.05, "max": 0.2 },
-        { "type": "range", "label": "sound volume", "cvar": "s_volume", "min": 0, "max": 1 },
-        { "type": "range", "label": "music volume", "cvar": "ogg_volume", "min": 0, "max": 1 },
-        { "type": "toggle", "label": "enable music", "cvar": "ogg_enable" },
-        { "type": "toggle", "label": "shuffle tracks", "cvar": "ogg_shuffle" },
-        { "type": "toggle", "label": "underwater effect", "cvar": "s_underwater" },
         {
-          "type": "values",
-          "label": "ambient sounds",
-          "cvar": "s_ambient",
+          "type": "dropdown",
+          "label": "sample rate",
+          "cvar": "s_khz",
+          "group": "playback",
+          "maxVisible": 3,
+          "valueBinding": "value",
+          "disableWhen": [
+            { "cvar": "s_enable", "equals": "0" }
+          ],
           "options": [
-            "no",
-            "yes",
-            "only player's own"
+            { "label": "11 kHz", "value": "11" },
+            { "label": "22 kHz", "value": "22" },
+            { "label": "44 kHz", "value": "44" }
           ]
         },
+        { "type": "checkbox", "label": "swap stereo channels", "cvar": "s_swapstereo", "group": "playback" },
+        { "type": "range", "label": "sound latency", "cvar": "s_mixahead", "min": 0.05, "max": 0.2, "group": "playback" },
+        { "type": "range", "label": "sound volume", "cvar": "s_volume", "min": 0, "max": 1, "group": "playback" },
+        { "type": "checkbox", "label": "underwater effect", "cvar": "s_underwater", "group": "playback" },
+        { "type": "radio", "label": "ambient sounds off", "cvar": "s_ambient", "value": "0", "group": "playback" },
+        { "type": "radio", "label": "ambient sounds on", "cvar": "s_ambient", "value": "1", "group": "playback" },
+        { "type": "radio", "label": "ambient player's own", "cvar": "s_ambient", "value": "2", "group": "playback" },
         {
           "type": "values",
           "label": "chat beep",
           "cvar": "cl_chat_sound",
+          "group": "playback",
           "options": [
             "disabled",
             "default",
             "alternative"
+          ]
+        },
+        { "type": "range", "label": "music volume", "cvar": "ogg_volume", "min": 0, "max": 1, "group": "music" },
+        { "type": "checkbox", "label": "enable music", "cvar": "ogg_enable", "group": "music" },
+        {
+          "type": "checkbox",
+          "label": "shuffle tracks",
+          "cvar": "ogg_shuffle",
+          "group": "music",
+          "enableWhen": [
+            { "cvar": "ogg_enable", "equals": "1" }
           ]
         }
       ]


### PR DESCRIPTION
## Summary
- add checkbox, dropdown, and radio menu controls with conditional enablement plus item grouping
- extend the menu JSON parser and sample data to support the new controls and conditional logic
- document the updated scripting options and note the UI art assets still needed for the new widgets

## Testing
- not run (meson not available in container)


------
https://chatgpt.com/codex/tasks/task_e_6909f7a42078832cb190980cb7fa184c