### PR TITLE
Fix Windows build error caused by min macro collision

### DIFF
--- a/src/client/ui/menu.cpp
+++ b/src/client/ui/menu.cpp
@@ -1217,7 +1217,7 @@ static void Dropdown_UpdateScroll(menuDropdown_t *d)
         return;
     }
 
-    const int visible = std::min(d->maxVisibleItems, d->spin.numItems);
+    const int visible = (std::min)(d->maxVisibleItems, d->spin.numItems);
     if (visible <= 0)
         return;
 
@@ -1292,7 +1292,7 @@ static void Dropdown_DrawList(menuDropdown_t *d)
     if (!d->open || d->spin.numItems <= 0)
         return;
 
-    const int visible = std::min(d->maxVisibleItems, d->spin.numItems);
+    const int visible = (std::min)(d->maxVisibleItems, d->spin.numItems);
     if (visible <= 0)
         return;
 


### PR DESCRIPTION
## Summary
- prevent the Windows min macro from conflicting with std::min in the dropdown menu code by wrapping the call in parentheses

## Testing
- meson compile -C builddir *(fails: meson not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_690a2a74b44483219914bcb3ccfb420d