### PR TITLE
Fix missing shared definitions in headers

### DIFF
--- a/inc/common/cmd.hpp
+++ b/inc/common/cmd.hpp
@@ -18,6 +18,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
+#include "shared/shared.hpp"
+
 //
 // cmd.h -- command text buffering and command execution
 //

--- a/inc/shared/game.hpp
+++ b/inc/shared/game.hpp
@@ -18,6 +18,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
+#include "shared/shared.hpp"
+
 #include "shared/list.hpp"
 #include "shared/m_flash.hpp"
 

--- a/inc/shared/m_flash.hpp
+++ b/inc/shared/m_flash.hpp
@@ -20,6 +20,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include <array>
 
+#include "shared/types.hpp"
+
 enum {
     MZ2_TANK_BLASTER_1 = 1,
     MZ2_TANK_BLASTER_2,


### PR DESCRIPTION
## Summary
- include shared headers in cmd, game, and muzzle flash headers so shared types and macros are defined
- resolve build failures caused by missing MAX_STRING_CHARS, qhandle_t, BIT_ULL, and vec3_t definitions

## Testing
- ⚠️ `meson compile -C build` *(fails: build directory is not configured in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_690a342bfd74832889d8103833ce26a7