### PR TITLE
Provide shared type fallbacks for client builds

### DIFF
--- a/inc/shared/shared.hpp
+++ b/inc/shared/shared.hpp
@@ -59,10 +59,21 @@ typedef intptr_t ssize_t;
 #define YAW                 1       // left / right
 #define ROLL                2       // fall over
 
+#ifndef MAX_STRING_CHARS
 #define MAX_STRING_CHARS    1024    // max length of a string passed to Cmd_TokenizeString
+#endif
+
+#ifndef MAX_STRING_TOKENS
 #define MAX_STRING_TOKENS   256     // max tokens resulting from Cmd_TokenizeString
+#endif
+
+#ifndef MAX_TOKEN_CHARS
 #define MAX_TOKEN_CHARS     1024    // max length of an individual token
+#endif
+
+#ifndef MAX_NET_STRING
 #define MAX_NET_STRING      2048    // max length of a string used in network protocol
+#endif
 
 #define MAX_QPATH           64      // max length of a quake game pathname
 #define MAX_OSPATH          256     // max length of a filesystem pathname
@@ -1008,7 +1019,10 @@ struct cvar_s;
 struct genctx_s;
 
 typedef void (*xchanged_t)(struct cvar_s *);
+#ifndef XGENERATOR_T_DEFINED
 typedef void (*xgenerator_t)(struct genctx_s *);
+#define XGENERATOR_T_DEFINED 1
+#endif
 #endif
 
 // nothing outside the cvar.*() functions should modify these fields!

--- a/inc/shared/types.hpp
+++ b/inc/shared/types.hpp
@@ -29,6 +29,22 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define BIT_ULL(n)      (1ULL << (n))
 #endif
 
+#ifndef MAX_STRING_CHARS
+#define MAX_STRING_CHARS    1024    // max length of a string passed to Cmd_TokenizeString
+#endif
+
+#ifndef MAX_STRING_TOKENS
+#define MAX_STRING_TOKENS   256     // max tokens resulting from Cmd_TokenizeString
+#endif
+
+#ifndef MAX_TOKEN_CHARS
+#define MAX_TOKEN_CHARS     1024    // max length of an individual token
+#endif
+
+#ifndef MAX_NET_STRING
+#define MAX_NET_STRING      2048    // max length of a string used in network protocol
+#endif
+
 typedef unsigned char byte;
 
 typedef int qhandle_t;
@@ -47,5 +63,12 @@ typedef struct vrect_s {
     int height;
 } vrect_t;
 
+struct genctx_s;
 struct cvar_s;
+
 typedef struct cvar_s cvar_t;
+
+#ifndef XGENERATOR_T_DEFINED
+typedef void (*xgenerator_t)(struct genctx_s *);
+#define XGENERATOR_T_DEFINED 1
+#endif


### PR DESCRIPTION
## Summary
- expose the common string limit macros from shared/types.hpp for headers that do not include shared/shared.hpp
- provide a guarded typedef for xgenerator_t so MSVC sees the generator pointer type when building the client

## Testing
- not run (missing third-party wraps for Meson configuration)

------
https://chatgpt.com/codex/tasks/task_e_690a360227488328ae2bb727d05f6bd0