### PR TITLE
Expose CRT warp curvature controls

### DIFF
--- a/doc/client.asciidoc
+++ b/doc/client.asciidoc
@@ -755,6 +755,48 @@ r_bloomThreshold::
     this threshold are ignored during the bright-pass filter. Default value is
     0.8.
 
+r_crtmode::
+    Enables the CRT-Lottes post-processing shader. Default value is 0 (disabled).
+      - 0 — bypass the effect entirely
+      - 1 — enable CRT simulation using the shader parameters below
+
+r_crt_hardScan::
+    Adjusts scanline hardness. Lower (more negative) values sharpen dark scanline
+    falloff, higher values soften the transition. Default value is -8.0.
+
+r_crt_hardPix::
+    Controls pixel hardness within the shader's subpixel simulation. Default
+    value is -3.0.
+
+r_crt_maskDark::
+    Specifies the intensity of dark phosphor stripes in the simulated mask.
+    Default value is 0.5.
+
+r_crt_maskLight::
+    Specifies the intensity of bright phosphor stripes in the simulated mask.
+    Default value is 1.5.
+
+r_crt_scaleInLinearGamma::
+    Chooses whether mask computations are done in linear gamma space. Set to 1
+    to reduce banding and maintain brightness consistency. Default value is 1.
+
+r_crt_shadowMask::
+    Selects the shadow mask pattern. Values range from 0 to 4, with higher
+    values emulating denser phosphor layouts. Default value is 3.
+
+r_crt_brightBoost::
+    Increases overall brightness to compensate for mask darkening. Default value
+    is 1.0.
+
+r_crt_warpX::
+    Controls horizontal curvature. Use small positive values (default 0.031) for
+    subtle barrel distortion, or set to 0 to keep the display flat while
+    retaining scanlines and masks.
+
+r_crt_warpY::
+    Controls vertical curvature. Use small positive values (default 0.041) for a
+    rounded top/bottom edge, or set to 0 for a flat presentation.
+
 gl_flarespeed::
     Specifies flare fading effect speed. Default value is 8. Set this to 0
     for instant fading.

--- a/doc/crt-post-processing.md
+++ b/doc/crt-post-processing.md
@@ -20,6 +20,12 @@ To add a convincing cathode-ray tube presentation while staying performant, adop
 3. Expose key uniforms (mask strength, scanline weight, curvature, sharpness) to configuration so players can tailor the look.
 4. Consider pairing with an adjustable bloom pass to simulate phosphor persistence when bright highlights fade.
 
+### In-game configuration
+- `r_crt_hardScan`, `r_crt_hardPix`, and the mask/light controls focus on scanline thickness and subpixel layout.
+- `r_crt_warpX` and `r_crt_warpY` now provide direct access to horizontal and vertical curvature. Setting either value to `0`
+  flattens the display without altering scanline or mask intensity. Mode `0` of `r_crtmode` remains a quick way to disable the
+  entire post-process without changing stored curvature values.
+
 ## Licensing and Provenance
 - **License:** MIT (compatible with WORR's licensing).
 - **Source:** Maintained within the [libretro/glsl-shaders](https://github.com/libretro/glsl-shaders/blob/master/crt/shaders/crt-lottes.glsl) repository and mirrored in the ReShade shader collection.

--- a/src/refresh/main.cpp
+++ b/src/refresh/main.cpp
@@ -105,6 +105,8 @@ cvar_t *r_crt_maskLight;
 cvar_t *r_crt_scaleInLinearGamma;
 cvar_t *r_crt_shadowMask;
 cvar_t *r_crt_brightBoost;
+cvar_t *r_crt_warpX;
+cvar_t *r_crt_warpY;
 cvar_t *gl_dof;
 cvar_t *gl_swapinterval;
 
@@ -1695,6 +1697,8 @@ static void GL_Register(void)
     r_crt_scaleInLinearGamma = Cvar_Get("r_crt_scaleInLinearGamma", "1", CVAR_ARCHIVE);
     r_crt_shadowMask = Cvar_Get("r_crt_shadowMask", "3", CVAR_ARCHIVE);
     r_crt_brightBoost = Cvar_Get("r_crt_brightBoost", "1.0", CVAR_ARCHIVE);
+    r_crt_warpX = Cvar_Get("r_crt_warpX", "0.031", CVAR_ARCHIVE);
+    r_crt_warpY = Cvar_Get("r_crt_warpY", "0.041", CVAR_ARCHIVE);
     gl_dof = Cvar_Get("gl_dof", "1", 0);
     gl_swapinterval = Cvar_Get("gl_swapinterval", "1", CVAR_ARCHIVE);
     gl_swapinterval->changed = gl_swapinterval_changed;

--- a/src/refresh/postprocess/crt.cpp
+++ b/src/refresh/postprocess/crt.cpp
@@ -11,6 +11,8 @@ extern cvar_t* r_crt_maskLight;
 extern cvar_t* r_crt_scaleInLinearGamma;
 extern cvar_t* r_crt_shadowMask;
 extern cvar_t* r_crt_brightBoost;
+extern cvar_t* r_crt_warpX;
+extern cvar_t* r_crt_warpY;
 
 namespace {
         struct CrtConfig {
@@ -54,8 +56,9 @@ namespace {
 
         [[nodiscard]] CrtConfig gather_config(int mode) noexcept
         {
-                const float warpX = (mode == 1) ? 0.031f : 0.0f;
-                const float warpY = (mode == 1) ? 0.041f : 0.0f;
+                const bool warp_enabled = mode != 0;
+                const float warpX = warp_enabled ? (r_crt_warpX ? r_crt_warpX->value : 0.031f) : 0.0f;
+                const float warpY = warp_enabled ? (r_crt_warpY ? r_crt_warpY->value : 0.041f) : 0.0f;
 
                 return CrtConfig{
                         .hardScan = r_crt_hardScan ? r_crt_hardScan->value : -8.0f,


### PR DESCRIPTION
## Summary
- add r_crt_warpX and r_crt_warpY cvars alongside the existing CRT settings
- source curvature values from the new cvars so mode 0 can disable warp without losing tweaks
- document the curvature controls in the client manual and CRT post-processing guide

## Testing
- `ninja -C build` *(fails: build directory not configured in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_690a3a86c24883289cee35ea1664e5c3