### PR TITLE
Cache bloom effect postprocess format metadata

### DIFF
--- a/src/refresh/postprocess/bloom.hpp
+++ b/src/refresh/postprocess/bloom.hpp
@@ -50,19 +50,22 @@ private:
 		FramebufferCount
 	};
 
-	void destroyTextures();
-	void destroyFramebuffers();
-	void ensureInitialized();
-	void allocateTexture(GLuint tex, int width, int height) const;
-	bool attachFramebuffer(GLuint fbo, GLuint texture, int width, int height, const char* name) const;
+        void destroyTextures();
+        void destroyFramebuffers();
+        void ensureInitialized();
+        void allocateTexture(GLuint tex, int width, int height, GLenum internalFormat, GLenum format, GLenum type) const;
+        bool attachFramebuffer(GLuint fbo, GLuint texture, int width, int height, const char* name) const;
 
-	GLuint textures_[TextureCount];
-	GLuint framebuffers_[FramebufferCount];
-	int sceneWidth_;
-	int sceneHeight_;
-	int downsampleWidth_;
-	int downsampleHeight_;
-	bool initialized_;
+        GLuint textures_[TextureCount];
+        GLuint framebuffers_[FramebufferCount];
+        int sceneWidth_;
+        int sceneHeight_;
+        int downsampleWidth_;
+        int downsampleHeight_;
+        GLenum postprocessInternalFormat_;
+        GLenum postprocessFormat_;
+        GLenum postprocessType_;
+        bool initialized_;
 };
 
 extern BloomEffect g_bloom_effect;


### PR DESCRIPTION
## Summary
- cache the bloom effect's post-process texture format triple alongside its stored dimensions
- reallocate bloom textures whenever either the dimensions or post-process formats change

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690a3a6d5b488328a1f4effeda0f1e61