### PR TITLE
Fix HDR luminance reducer missing GL_PostProcess declaration

### DIFF
--- a/src/refresh/postprocess/hdr_luminance.cpp
+++ b/src/refresh/postprocess/hdr_luminance.cpp
@@ -1,5 +1,6 @@
 #include "hdr_luminance.hpp"
-#include "hdr_luminance.hpp"
+
+extern void GL_PostProcess(glStateBits_t bits, int x, int y, int w, int h);
 
 #include <algorithm>
 


### PR DESCRIPTION
## Summary
- remove the duplicate header include in `hdr_luminance.cpp`
- declare the `GL_PostProcess` helper so the file can link against its definition

## Testing
- meson compile -C builddir *(fails: Current directory is not a meson build directory)*

------
https://chatgpt.com/codex/tasks/task_e_690a445a1da083289a80787173a66a9a