### PR TITLE
Improve bloom post-processing robustness

### DIFF
--- a/src/refresh/postprocess/bloom.hpp
+++ b/src/refresh/postprocess/bloom.hpp
@@ -28,10 +28,10 @@ public:
 	void initialize();
 	void shutdown();
 
-	void resize(int sceneWidth, int sceneHeight);
-	void render(const BloomRenderContext& ctx);
+        bool resize(int sceneWidth, int sceneHeight);
+        void render(const BloomRenderContext& ctx);
 
-	[[nodiscard]] bool isInitialized() const noexcept { return initialized_; }
+        [[nodiscard]] bool isInitialized() const noexcept { return initialized_; }
 
 private:
 	enum TextureSlot : size_t {
@@ -66,6 +66,7 @@ private:
         GLenum postprocessFormat_;
         GLenum postprocessType_;
         bool initialized_;
+        bool resizeErrorLogged_;
 };
 
 extern BloomEffect g_bloom_effect;

--- a/src/refresh/texture.cpp
+++ b/src/refresh/texture.cpp
@@ -1309,10 +1309,12 @@ bool GL_InitFramebuffers(void)
 
     qglBindFramebuffer(GL_FRAMEBUFFER, 0);
 
-    if (r_bloom->integer)
-        g_bloom_effect.resize(bloom_w, bloom_h);
-    else
+    if (r_bloom->integer) {
+        if (!g_bloom_effect.resize(bloom_w, bloom_h))
+            g_bloom_effect.resize(0, 0);
+    } else {
         g_bloom_effect.resize(0, 0);
+    }
 
     gl_static.dof.full_width = dof_full_w;
     gl_static.dof.full_height = dof_full_h;


### PR DESCRIPTION
## Summary
- refactor the bloom compositing path to use a shared helper that safely falls back when inputs are missing and keeps debug output isolated
- guard bloom resizing with success/failure reporting and log framebuffer setup errors so the renderer can gracefully degrade
- clamp bloom bright-pass threshold inputs and update the resize API call sites to respect the new contract

## Testing
- ninja -C build *(fails: build.ninja not found in repository checkout)*

------
https://chatgpt.com/codex/tasks/task_e_690a42a7e97483288e694136f9b53d35