### PR TITLE
Fix bloom postprocess forward declaration order

### DIFF
--- a/src/refresh/postprocess/bloom.cpp
+++ b/src/refresh/postprocess/bloom.cpp
@@ -5,6 +5,8 @@
 #include "../qgl.hpp"
 #include "crt.hpp"
 
+extern void GL_PostProcess(glStateBits_t bits, int x, int y, int w, int h);
+
 BloomEffect g_bloom_effect;
 
 namespace {
@@ -219,8 +221,6 @@ bool BloomEffect::resize(int sceneWidth, int sceneHeight)
         resizeErrorLogged_ = false;
         return true;
 }
-
-extern void GL_PostProcess(glStateBits_t bits, int x, int y, int w, int h);
 
 void BloomEffect::render(const BloomRenderContext& ctx)
 {


### PR DESCRIPTION
## Summary
- declare GL_PostProcess before its use in bloom.cpp so MSVC can compile

## Testing
- meson compile -C builddir *(fails: build directory not generated in container)*

------
https://chatgpt.com/codex/tasks/task_e_690a45e327e08328a9eb97875509dfc0