### PR TITLE
Normalize FreeType font paths to TTF files

### DIFF
--- a/src/client/screen.cpp
+++ b/src/client/screen.cpp
@@ -153,6 +153,16 @@ static std::string SCR_NormalizeFontPath(const std::string& rawPath)
                 normalized.append(filename);
         }
 
+        const size_t dot = normalized.find_last_of('.');
+        if (dot == std::string::npos) {
+                normalized.append(".ttf");
+        } else {
+                const char* ext = normalized.c_str() + dot;
+                if (!Q_stricmp(ext, ".pcx")) {
+                        normalized.replace(dot, std::string::npos, ".ttf");
+                }
+        }
+
         return normalized;
 }
 


### PR DESCRIPTION
## Summary
- update FreeType font path normalization so that `.ttf` files are requested instead of `.pcx`
- ensure paths without an extension or using the legacy `.pcx` suffix are rewritten to `.ttf`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690a4c8285c08328b00769166a74f8c8