### PR TITLE
Fix shader GLSL macro blocks for MSVC

### DIFF
--- a/src/refresh/shader.cpp
+++ b/src/refresh/shader.cpp
@@ -1532,6 +1532,7 @@ static void write_fragment_shader(sizebuf_t *buf, glStateBits_t bits)
         }
         scene_color *= max(u_bloom_params.x, 0.0);
         diffuse.rgb = scene_color;
+    )
     GLSL(})
 
     if (bits & GLS_BLOOM_OUTPUT) {
@@ -1543,6 +1544,7 @@ static void write_fragment_shader(sizebuf_t *buf, glStateBits_t bits)
                 bloom_color = mix(vec3(bloom_luma), bloom_color, bloom_sat);
             }
             diffuse.rgb += bloom_color * u_hdr_params0.w;
+        )
         GLSL(})
     }
 


### PR DESCRIPTION
## Summary
- add the missing closing parentheses for two GLSL macro blocks so the MSVC preprocessor terminates the macro arguments correctly

## Testing
- meson compile -C build *(fails: `/workspace/WORR/build` is not a Meson build directory in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_690a4cfa17f4832893fc1f156a3248d3