### PR TITLE
Fix extension detection when normalizing FreeType font paths

### DIFF
--- a/src/client/screen.cpp
+++ b/src/client/screen.cpp
@@ -153,8 +153,10 @@ static std::string SCR_NormalizeFontPath(const std::string& rawPath)
                 normalized.append(filename);
         }
 
+        const size_t lastSlash = normalized.find_last_of('/');
         const size_t dot = normalized.find_last_of('.');
-        if (dot == std::string::npos) {
+        const bool hasExtension = (dot != std::string::npos) && (lastSlash == std::string::npos || dot > lastSlash);
+        if (!hasExtension) {
                 normalized.append(".ttf");
         } else {
                 const char* ext = normalized.c_str() + dot;


### PR DESCRIPTION
## Summary
- ensure SCR_NormalizeFontPath only treats dots that appear after the last directory separator as an extension so font paths without real extensions fall back to .ttf correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690a53296478832887be2ce929d71a45