### PR TITLE
Guard post-processing dependent motion blur checks

### DIFF
--- a/src/refresh/main.cpp
+++ b/src/refresh/main.cpp
@@ -1313,7 +1313,9 @@ static pp_flags_t GL_BindFramebuffer(void)
     const bool dof_active = gl_dof->integer && glr.fd.depth_of_field;
     const bool motion_blur_enabled = glr.motion_blur_enabled;
 
-    if (!gl_static.use_shaders || !r_postProcessing->integer) {
+    const bool post_processing_enabled = r_postProcessing && r_postProcessing->integer;
+
+    if (!gl_static.use_shaders || !post_processing_enabled) {
         const bool was_hdr_active = gl_static.hdr.active;
         gl_static.hdr.active = false;
         if (was_hdr_active)
@@ -1437,7 +1439,9 @@ void R_RenderFrame(const refdef_t *fd)
     glr.motion_blur_fov_y = glr.fd.fov_y;
     glr.ppl_bits  = 0;
 
-    glr.motion_blur_enabled = gl_static.use_shaders && r_postProcessing->integer && r_motionBlur->integer &&
+    const bool post_processing_enabled = r_postProcessing && r_postProcessing->integer;
+
+    glr.motion_blur_enabled = gl_static.use_shaders && post_processing_enabled && r_motionBlur->integer &&
         !(glr.fd.rdflags & RDF_NOWORLDMODEL) && glr.fd.width > 0 && glr.fd.height > 0;
 
     float motion_blur_scale = 0.0f;


### PR DESCRIPTION
## Summary
- gate motion blur enablement on a validated post-processing cvar to avoid null dereferences
- skip framebuffer setup when post-processing is unavailable without touching HDR state unnecessarily

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_690a5534b59883288e75cc0bf28e53dd