### PR TITLE
Fix screenshot cleanup ownership handling

### DIFF
--- a/src/refresh/images.cpp
+++ b/src/refresh/images.cpp
@@ -1320,6 +1320,9 @@ static void screenshot_done_cb(void* arg)
 
 	if (s->async) {
 		Z_Free(s->filename);
+	}
+
+	if (s->owns_storage) {
 		Z_Free(s);
 	}
 }
@@ -1344,6 +1347,7 @@ static void make_screenshot(const char* name, const char* ext,
 	s.status = -1;
 	s.param = param;
 	s.async = async;
+	s.owns_storage = false;
 
 	ret = IMG_ReadPixels(&s);
 	if (ret < 0) {
@@ -1356,7 +1360,9 @@ static void make_screenshot(const char* name, const char* ext,
 		asyncwork_t work{};
 		work.work_cb = screenshot_work_cb;
 		work.done_cb = screenshot_done_cb;
-		work.cb_arg = Z_CopyStruct(&s);
+		auto* async_s = Z_CopyStruct(&s);
+		async_s->owns_storage = true;
+		work.cb_arg = async_s;
 		Com_QueueAsyncWork(&work);
 	}
 	else {

--- a/src/refresh/images.hpp
+++ b/src/refresh/images.hpp
@@ -100,9 +100,10 @@ struct screenshot_s {
 	save_cb_t save_cb;
 	byte* pixels;
 	FILE* fp;
-	char* filename;
-	int width, height, rowbytes, bpp, status, param;
-	bool async;
+        char* filename;
+        int width, height, rowbytes, bpp, status, param;
+        bool async;
+        bool owns_storage;
 };
 
 int IMG_ReadPixels(screenshot_t* s);


### PR DESCRIPTION
## Summary
- track whether screenshot structs own their storage
- only free heap-allocated screenshot structs while still releasing async filenames

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690a774c7c1c83288d6efe27aff6b988