### PR TITLE
Fix solid leaf detection in GL_DrawLeaf

### DIFF
--- a/src/refresh/world.cpp
+++ b/src/refresh/world.cpp
@@ -500,9 +500,8 @@ static inline bool GL_ClipNode(const mnode_t *node, int *clipflags)
 
 static inline void GL_DrawLeaf(const mleaf_t *leaf)
 {
-    // FIXME: use `&' here?
-    if (leaf->contents[0] == CONTENTS_SOLID)
-        return; // solid leaf
+    if (leaf->contents[0] & CONTENTS_SOLID)
+        return; // skip any solid leaf (even with extra flags)
 
     if (glr.fd.areabits && !Q_IsBitSet(glr.fd.areabits, leaf->area))
         return; // door blocks sight


### PR DESCRIPTION
## Summary
- replace the GL_DrawLeaf solid leaf check with a bitmask-aware contents test
- clarify the comment to note that solid leaves may carry extra flags

## Testing
- meson setup build *(fails: wrap-redirect subprojects/ffmpeg/subprojects/nasm.wrap filename does not exist)*


------
https://chatgpt.com/codex/tasks/task_e_690a774f76e0832894b7b31f3aa02124