### PR TITLE
Fix async screenshot struct allocation for MSVC

### DIFF
--- a/src/refresh/images.cpp
+++ b/src/refresh/images.cpp
@@ -1360,7 +1360,7 @@ static void make_screenshot(const char* name, const char* ext,
 		asyncwork_t work{};
 		work.work_cb = screenshot_work_cb;
 		work.done_cb = screenshot_done_cb;
-		auto* async_s = Z_CopyStruct(&s);
+                auto* async_s = static_cast<screenshot_t*>(Z_CopyStruct(&s));
 		async_s->owns_storage = true;
 		work.cb_arg = async_s;
 		Com_QueueAsyncWork(&work);


### PR DESCRIPTION
## Summary
- add an explicit screenshot_t cast when duplicating the screenshot struct for async work
- ensure the duplicated struct exposes owns_storage to MSVC correctly

## Testing
- meson compile -C build *(fails: build directory not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_690a7898dd148328b94d3bdd5a02fd9d