### PR TITLE
Preserve GL read buffer around HDR readbacks

### DIFF
--- a/src/refresh/main.cpp
+++ b/src/refresh/main.cpp
@@ -862,10 +862,19 @@ static void HDR_ComputeHistogram(int width, int height)
         hdr_state_local.histogram_scratch.resize(static_cast<size_t>(sample_w) * sample_h * 4);
         scratch = hdr_state_local.histogram_scratch.data();
 
+        GLint prev_fbo = 0;
+        GLint prev_read_buffer = 0;
+        qglGetIntegerv(GL_FRAMEBUFFER_BINDING, &prev_fbo);
+        if (qglReadBuffer)
+            qglGetIntegerv(GL_READ_BUFFER, &prev_read_buffer);
+
         qglBindFramebuffer(GL_FRAMEBUFFER, FBO_SCENE);
-        qglReadBuffer(GL_COLOR_ATTACHMENT0);
+        if (qglReadBuffer)
+            qglReadBuffer(GL_COLOR_ATTACHMENT0);
         qglReadPixels(0, 0, sample_w, sample_h, GL_RGBA, GL_FLOAT, scratch);
-        qglBindFramebuffer(GL_FRAMEBUFFER, 0);
+        qglBindFramebuffer(GL_FRAMEBUFFER, prev_fbo);
+        if (qglReadBuffer)
+            qglReadBuffer(prev_read_buffer);
         have_samples = true;
     }
 

--- a/src/refresh/postprocess/hdr_luminance.cpp
+++ b/src/refresh/postprocess/hdr_luminance.cpp
@@ -208,14 +208,20 @@ bool HdrLuminanceReducer::readbackAverage(float* rgba) const noexcept
 		return false;
 
 	const Level& level = levels_.back();
-	GLint prev_fbo = 0;
-	qglGetIntegerv(GL_FRAMEBUFFER_BINDING, &prev_fbo);
-	qglBindFramebuffer(GL_FRAMEBUFFER, level.fbo);
-	if (qglReadBuffer)
-		qglReadBuffer(kColorAttachment);
-	qglReadPixels(0, 0, level.width, level.height, GL_RGBA, GL_FLOAT, rgba);
-	restoreFramebuffer(prev_fbo);
-	return true;
+        GLint prev_fbo = 0;
+        GLint prev_read_buffer = 0;
+        qglGetIntegerv(GL_FRAMEBUFFER_BINDING, &prev_fbo);
+        if (qglReadBuffer)
+                qglGetIntegerv(GL_READ_BUFFER, &prev_read_buffer);
+
+        qglBindFramebuffer(GL_FRAMEBUFFER, level.fbo);
+        if (qglReadBuffer)
+                qglReadBuffer(kColorAttachment);
+        qglReadPixels(0, 0, level.width, level.height, GL_RGBA, GL_FLOAT, rgba);
+        restoreFramebuffer(prev_fbo);
+        if (qglReadBuffer)
+                qglReadBuffer(prev_read_buffer);
+        return true;
 }
 
 bool HdrLuminanceReducer::readbackHistogram(int maxSamples, std::vector<float>& scratch, int& outWidth, int& outHeight) const noexcept
@@ -240,16 +246,22 @@ bool HdrLuminanceReducer::readbackHistogram(int maxSamples, std::vector<float>& 
 	const size_t total_pixels = static_cast<size_t>(target->width) * target->height;
 	scratch.resize(total_pixels * 4);
 
-	GLint prev_fbo = 0;
-	qglGetIntegerv(GL_FRAMEBUFFER_BINDING, &prev_fbo);
-	qglBindFramebuffer(GL_FRAMEBUFFER, target->fbo);
-	if (qglReadBuffer)
-		qglReadBuffer(kColorAttachment);
-	qglReadPixels(0, 0, target->width, target->height, GL_RGBA, GL_FLOAT, scratch.data());
-	restoreFramebuffer(prev_fbo);
+        GLint prev_fbo = 0;
+        GLint prev_read_buffer = 0;
+        qglGetIntegerv(GL_FRAMEBUFFER_BINDING, &prev_fbo);
+        if (qglReadBuffer)
+                qglGetIntegerv(GL_READ_BUFFER, &prev_read_buffer);
 
-	outWidth = target->width;
-	outHeight = target->height;
+        qglBindFramebuffer(GL_FRAMEBUFFER, target->fbo);
+        if (qglReadBuffer)
+                qglReadBuffer(kColorAttachment);
+        qglReadPixels(0, 0, target->width, target->height, GL_RGBA, GL_FLOAT, scratch.data());
+        restoreFramebuffer(prev_fbo);
+        if (qglReadBuffer)
+                qglReadBuffer(prev_read_buffer);
+
+        outWidth = target->width;
+        outHeight = target->height;
 	return true;
 }
 


### PR DESCRIPTION
## Summary
- save and restore GL_READ_BUFFER when sampling HDR luminance FBOs
- apply the same framebuffer/read-buffer preservation to the histogram fallback path

## Testing
- not run (GL runtime not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_690a7aeff11483289c810b63165ef65d