### PR TITLE
Fix motion blur history readiness checks

### DIFF
--- a/src/refresh/gl.hpp
+++ b/src/refresh/gl.hpp
@@ -257,6 +257,7 @@ typedef struct {
     bool            view_proj_valid;
     bool            motion_blur_enabled;
     bool            motion_blur_ready;
+    bool            motion_history_textures_ready;
     float           motion_blur_scale;
     float           motion_blur_min_velocity;
     float           motion_blur_min_velocity_pixels;

--- a/src/refresh/main.cpp
+++ b/src/refresh/main.cpp
@@ -1241,6 +1241,14 @@ static void R_ClearMotionBlurHistory(void)
 
 static void R_BindMotionHistoryTextures(void)
 {
+    if (!glr.motion_history_textures_ready) {
+        for (int i = 0; i < R_MOTION_BLUR_HISTORY_FRAMES; ++i) {
+            glTmu_t tmu = static_cast<glTmu_t>(TMU_HISTORY0 + i);
+            GL_ForceTexture(tmu, TEXNUM_BLACK);
+        }
+        return;
+    }
+
     for (int i = 0; i < R_MOTION_BLUR_HISTORY_FRAMES; ++i) {
         glTmu_t tmu = static_cast<glTmu_t>(TMU_HISTORY0 + i);
         GLuint tex = TEXNUM_BLACK;
@@ -1257,6 +1265,8 @@ static void R_BindMotionHistoryTextures(void)
 static void R_StoreMotionBlurHistory(void)
 {
     if (!glr.motion_blur_enabled || !glr.view_proj_valid)
+        return;
+    if (!glr.motion_history_textures_ready)
         return;
     if (glr.fd.width <= 0 || glr.fd.height <= 0)
         return;

--- a/src/refresh/state.cpp
+++ b/src/refresh/state.cpp
@@ -341,6 +341,8 @@ void GL_Setup3D(void)
 
             motion_ready = (max_ndc_velocity >= min_ndc_threshold) || (max_pixel_velocity >= min_pixel_threshold);
         }
+        if (!glr.motion_history_textures_ready)
+            motion_ready = false;
         glr.motion_blur_ready = motion_ready;
 
         if (glr.view_proj_valid) {
@@ -382,7 +384,7 @@ void GL_Setup3D(void)
         int history_indices[R_MOTION_BLUR_HISTORY_FRAMES] = { 0, 0, 0 };
         int valid_history = 0;
 
-        if (glr.motion_blur_enabled && glr.view_proj_valid && glr.motion_blur_history_count > 0) {
+        if (glr.motion_blur_enabled && glr.view_proj_valid && glr.motion_history_textures_ready && glr.motion_blur_history_count > 0) {
             const int max_frames = (std::min)(glr.motion_blur_history_count, R_MOTION_BLUR_HISTORY_FRAMES);
             for (int i = 0; i < max_frames; ++i) {
                 int slot = (glr.motion_blur_history_index + R_MOTION_BLUR_HISTORY_FRAMES - glr.motion_blur_history_count + i) % R_MOTION_BLUR_HISTORY_FRAMES;

--- a/src/refresh/texture.cpp
+++ b/src/refresh/texture.cpp
@@ -1315,12 +1315,21 @@ bool GL_InitFramebuffers(void)
 
     CHECK_FB(dof_half_w, "FBO_BOKEH_GATHER");
 
+    glr.motion_history_textures_ready = false;
+
+    const bool motion_history_expected = motion_blur_active && scene_w > 0 && scene_h > 0;
+
     for (int i = 0; i < R_MOTION_BLUR_HISTORY_FRAMES; ++i) {
         qglBindFramebuffer(GL_FRAMEBUFFER, FBO_MOTION_HISTORY(i));
         GLuint tex = (motion_blur_active && scene_w && scene_h) ? TEXNUM_PP_MOTION_HISTORY(i) : GL_NONE;
         qglFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, tex, 0);
-        CHECK_FB(motion_blur_active && scene_w && scene_h, "FBO_MOTION_HISTORY");
+        if (!GL_CheckFramebufferStatus(motion_history_expected, "FBO_MOTION_HISTORY"))
+            return false;
+        if (motion_history_expected && gl_showerrors->integer)
+            Com_DPrintf("FBO_MOTION_HISTORY(%d) complete (%dx%d)\n", i, scene_w, scene_h);
     }
+
+    glr.motion_history_textures_ready = motion_history_expected;
 
     qglBindFramebuffer(GL_FRAMEBUFFER, 0);
 


### PR DESCRIPTION
## Summary
- track when motion blur history textures are available so the renderer can gate sampling
- log FBO_MOTION_HISTORY completeness while creating framebuffers to aid GPU debugging
- skip binding or storing motion history when the textures are unavailable to avoid sampling garbage

## Testing
- ninja -C build *(fails: build.ninja missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_690a7ca6500083289ed5d4318ecdc7cc