### PR TITLE
Add pkg-config-free fallback for FreeType detection

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -488,10 +488,42 @@ if sdl2.found()
   config.set('USE_SDL', 'USE_CLIENT')
 endif
 
-freetype = dependency('freetype2',
-  required:        get_option('freetype'),
-  default_options: fallback_opt,
-)
+freetype_opt = get_option('freetype')
+
+if freetype_opt.disabled()
+  freetype = disabler()
+else
+  freetype = dependency('freetype2',
+    required:        false,
+    default_options: fallback_opt,
+  )
+
+  if not freetype.found()
+    ft_include_dir = []
+    ft_have_inc = false
+    foreach dir : ['/usr/include/freetype2', '/usr/local/include/freetype2']
+      inc = include_directories(dir)
+      if c_compiler.has_header('ft2build.h', include_directories: inc)
+        ft_include_dir = inc
+        ft_have_inc = true
+        break
+      endif
+    endforeach
+
+    ft_lib = c_compiler.find_library('freetype', required: false)
+
+    if ft_lib.found() and ft_have_inc
+      freetype = declare_dependency(
+        dependencies: [ft_lib],
+        include_directories: [ft_include_dir],
+      )
+    endif
+  endif
+
+  if freetype_opt.enabled() and not freetype.found()
+    error('Freetype support requested, but neither pkg-config nor fallback detection succeeded')
+  endif
+endif
 
 config.set10('USE_FREETYPE', freetype.found())
 


### PR DESCRIPTION
## Summary
- add a manual FreeType detection path that works without pkg-config
- keep honoring the freetype feature option and report a clear error when enabled but not found

## Testing
- meson setup --reconfigure build *(fails: wrap-redirect /workspace/WORR/subprojects/ffmpeg/subprojects/nasm.wrap filename does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_690a7d2ed3688328973f31162e68715f