### PR TITLE
Fix freetype subproject zlib handling

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -495,6 +495,7 @@ if freetype_opt.disabled()
 else
   freetype = dependency('freetype2',
     required:        false,
+    fallback:        ['freetype2', 'freetype_dep'],
     default_options: fallback_opt,
   )
 

--- a/subprojects/packagefiles/freetype2/meson.build
+++ b/subprojects/packagefiles/freetype2/meson.build
@@ -9,7 +9,10 @@ cmake_opts.add_cmake_defines({
   'CMAKE_DISABLE_FIND_PACKAGE_PNG': 'ON',
 })
 
-zlib_dep = dependency('zlib', required: false)
+zlib_dep = dependency('zlib',
+  required: false,
+  fallback: ['zlib-ng', 'zlib_ng_dep'],
+)
 cmake_opts.add_cmake_defines({
   'CMAKE_DISABLE_FIND_PACKAGE_ZLIB': zlib_dep.found() ? 'OFF' : 'ON',
 })


### PR DESCRIPTION
## Summary
- make the main build explicitly fall back to the freetype2 subproject when pkg-config lookup fails
- ensure the freetype2 package files depend on the existing zlib-ng wrap instead of ambiguous wrap names

## Testing
- meson setup build --wipe *(fails: wrap-redirect /workspace/WORR/subprojects/ffmpeg/subprojects/nasm.wrap filename does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_690a8286b6588328a44b802abea686ce