### PR TITLE
Ensure freetype wrap uses Meson zlib dependency

### DIFF
--- a/subprojects/packagefiles/freetype2/meson.build
+++ b/subprojects/packagefiles/freetype2/meson.build
@@ -13,6 +13,9 @@ zlib_dep = dependency('zlib',
   required: false,
   fallback: ['zlib-ng', 'zlib_ng_dep'],
 )
+if zlib_dep.found()
+  cmake_opts.add_cmake_dep('ZLIB', zlib_dep)
+endif
 cmake_opts.add_cmake_defines({
   'CMAKE_DISABLE_FIND_PACKAGE_ZLIB': zlib_dep.found() ? 'OFF' : 'ON',
 })


### PR DESCRIPTION
## Summary
- add a guard to pass Meson's zlib dependency into the FreeType CMake subproject
- keep CMAKE_DISABLE_FIND_PACKAGE_ZLIB in sync with whether Meson resolved zlib

## Testing
- meson setup build --reconfigure *(fails: wrap-redirect /workspace/WORR/subprojects/ffmpeg/subprojects/nasm.wrap filename does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_690a8756b3888328a43725456ec05e23