### PR TITLE
Fix FreeType CMake fallback dependency export

### DIFF
--- a/subprojects/packagefiles/freetype2/meson.build
+++ b/subprojects/packagefiles/freetype2/meson.build
@@ -18,3 +18,15 @@ cmake_opts.add_cmake_defines({
 })
 
 cmake_proj = cmake.configure('freetype2', options: cmake_opts)
+
+cmake_freetype_dep = cmake_proj.dependency('freetype')
+freetype_dep = declare_dependency(
+  include_directories: cmake_freetype_dep.get_include_dirs(),
+  compile_args: cmake_freetype_dep.get_compile_args(),
+  link_args: cmake_freetype_dep.get_link_args(),
+  link_with: cmake_freetype_dep.libraries,
+  dependencies: cmake_freetype_dep.ext_deps,
+  objects: cmake_freetype_dep.objects,
+  sources: cmake_freetype_dep.get_sources(),
+  extra_files: cmake_freetype_dep.get_extra_files(),
+)


### PR DESCRIPTION
## Summary
- derive the FreeType dependency object from the CMake subproject
- re-export include dirs, compile flags, link flags, libraries, and extra artifacts via declare_dependency

## Testing
- `meson setup build --force-fallback-for=freetype2` *(fails: freetype tarball download blocked by proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_690a8753ca9483288b175b885c62f7bd