### PR TITLE
Refine zlib handling for Meson subprojects

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -444,11 +444,14 @@ texture_formats = []
 
 fallback_opt = ['default_library=static']
 
-zlib = dependency('zlib',
-  fallback:        'zlib-ng',
-  required:        get_option('zlib'),
-  default_options: fallback_opt + [ 'tests=disabled', 'zlib-compat=true', 'force-sse2=true' ],
-)
+zlib = dependency('zlib', required: get_option('zlib'))
+if not zlib.found()
+  zlib = dependency('zlib-ng',
+    fallback:        ['zlib-ng', 'zlib_ng_dep'],
+    required:        get_option('zlib'),
+    default_options: fallback_opt + [ 'tests=disabled', 'zlib-compat=true', 'force-sse2=true' ],
+  )
+endif
 
 if not zlib.found()
   warning('zlib not found, client will be unable to connect to protocol 35 servers')

--- a/subprojects/packagefiles/curl/meson.build
+++ b/subprojects/packagefiles/curl/meson.build
@@ -209,6 +209,9 @@ else
 endif
 
 zlib = dependency('zlib', required: false)
+if not zlib.found()
+  zlib = dependency('zlib-ng', required: false, fallback: ['zlib-ng', 'zlib_ng_dep'])
+endif
 if zlib.found()
   args += '-DHAVE_LIBZ'
 endif

--- a/subprojects/packagefiles/freetype2/meson.build
+++ b/subprojects/packagefiles/freetype2/meson.build
@@ -9,10 +9,10 @@ cmake_opts.add_cmake_defines({
   'CMAKE_DISABLE_FIND_PACKAGE_PNG': 'ON',
 })
 
-zlib_dep = dependency('zlib',
-  required: false,
-  fallback: ['zlib-ng', 'zlib_ng_dep'],
-)
+zlib_dep = dependency('zlib', required: false)
+if not zlib_dep.found()
+  zlib_dep = dependency('zlib-ng', required: false, fallback: ['zlib-ng', 'zlib_ng_dep'])
+endif
 if zlib_dep.found()
   cmake_opts.add_cmake_dep('ZLIB', zlib_dep)
 endif

--- a/subprojects/zlib-ng.wrap
+++ b/subprojects/zlib-ng.wrap
@@ -10,5 +10,4 @@ source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/zli
 wrapdb_version = 2.2.4-2
 
 [provide]
-zlib = zlib_ng_dep
 zlib-ng = zlib_ng_dep


### PR DESCRIPTION
## Summary
- prefer the system zlib before falling back to the zlib-ng subproject
- update freetype2 and curl packagefiles to request the explicit zlib-ng dependency when needed
- drop the zlib alias from the zlib-ng wrap to avoid wrap provider conflicts

## Testing
- `meson setup builddir -Davcodec=disabled` *(fails: wrap-redirect subprojects/ffmpeg/subprojects/nasm.wrap filename does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_690a8a26d5288328bfcea23125dad40e