### PR TITLE
Fix FreeType cache type and Windows macro collisions

### DIFF
--- a/src/client/client.hpp
+++ b/src/client/client.hpp
@@ -1217,7 +1217,7 @@ typedef struct {
 #if USE_FREETYPE
 struct scr_freetype_font_entry_t {
 	std::vector<uint8_t> buffer;
-	ftfont_t             renderInfo;
+	ref_freetype_font_t  renderInfo;
 };
 
 struct scr_freetype_cache_t {

--- a/src/client/screen.cpp
+++ b/src/client/screen.cpp
@@ -26,6 +26,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <string>
 #include <utility>
 
+#if defined(_WIN32)
+#undef min
+#undef max
+#endif
+
 static cvar_t* scr_viewsize;
 static cvar_t* scr_showpause;
 #if USE_DEBUG


### PR DESCRIPTION
## Summary
- use the concrete ref_freetype_font_t type for cached FreeType render info so MSVC sees a complete definition
- undefine Windows min/max macros in screen.cpp to prevent macro substitution when querying std::numeric_limits

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690a8c27720c8328aff542ce5abd6b6e