### PR TITLE
Fix std::min type mismatches in screen rendering

### DIFF
--- a/src/client/screen.cpp
+++ b/src/client/screen.cpp
@@ -676,7 +676,7 @@ void SCR_DrawStringMultiStretch(int x, int y, int scale, int flags, size_t maxle
 			break;
 		}
 
-		len = min(p - s, maxlen);
+                len = std::min<size_t>(static_cast<size_t>(p - s), maxlen);
 		const auto metrics = SCR_TextMetrics(s, len, flags, currentColor);
 		last_x = SCR_DrawStringStretch(x, y, scale, flags, len, s, currentColor, font);
 		last_y = y;
@@ -861,7 +861,7 @@ void SCR_AddNetgraph(void)
 		color = 0xd0;
 	}
 
-	SCR_DebugGraph(min(ping, 30), color);
+        SCR_DebugGraph(std::min<unsigned>(ping, 30u), color);
 }
 
 #define GRAPH_SAMPLES   4096


### PR DESCRIPTION
## Summary
- resolve template argument ambiguity in SCR_DrawStringMultiStretch by comparing size_t values
- clamp the netgraph ping sample with an unsigned std::min call to avoid mixed signed/unsigned types

## Testing
- meson compile -C builddir *(fails: Current directory is not a meson build directory)*

------
https://chatgpt.com/codex/tasks/task_e_690a8f51d610832887c391412e460cb4