### PR TITLE
Add forward declaration for GL_StretchPic_

### DIFF
--- a/src/refresh/draw.cpp
+++ b/src/refresh/draw.cpp
@@ -250,6 +250,11 @@ static FtFont *Ft_FontForImage(const image_t *image)
     return it->second.get();
 }
 
+static inline void GL_StretchPic_(
+    float x, float y, float w, float h,
+    float s1, float t1, float s2, float t2,
+    color_t color, int texnum, int flags);
+
 static int Ft_DrawString(FtFont &font, int x, int y, int scale, int flags,
                          size_t maxlen, const char *s, color_t color)
 {


### PR DESCRIPTION
## Summary
- add a forward declaration for GL_StretchPic_ so FreeType string rendering helpers can reference it before the full definition

## Testing
- meson compile -C build *(fails: /workspace/WORR/build is not a Meson build directory in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_690a8fff914c832883c5e7fc534f27d8