### PR TITLE
Fix dedicated build freetype guard and resolve GL_StretchPic overload

### DIFF
--- a/inc/refresh/refresh.hpp
+++ b/inc/refresh/refresh.hpp
@@ -41,7 +41,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define UI_MULTILINE (1u << 9)
 #endif
 
-#if USE_FREETYPE
+#if USE_FREETYPE && defined(USE_REF) && USE_REF
 #include <ft2build.h>
 #include FT_FREETYPE_H
 struct ref_freetype_font_t {

--- a/src/refresh/draw.cpp
+++ b/src/refresh/draw.cpp
@@ -34,6 +34,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <vector>
 #endif
 
+static inline void GL_StretchPic_(
+    float x, float y, float w, float h,
+    float s1, float t1, float s2, float t2,
+    color_t color, int texnum, int flags);
+
 drawStatic_t draw;
 
 #if USE_FREETYPE
@@ -249,11 +254,6 @@ static FtFont *Ft_FontForImage(const image_t *image)
         return nullptr;
     return it->second.get();
 }
-
-static inline void GL_StretchPic_(
-    float x, float y, float w, float h,
-    float s1, float t1, float s2, float t2,
-    color_t color, int texnum, int flags);
 
 static int Ft_DrawString(FtFont &font, int x, int y, int scale, int flags,
                          size_t maxlen, const char *s, color_t color)


### PR DESCRIPTION
## Summary
- guard FreeType includes so dedicated-only builds do not require the FreeType headers
- move the GL_StretchPic_ forward declaration out of the anonymous namespace to eliminate the duplicate overload seen by MSVC

## Testing
- meson setup builddir *(fails: wrap-redirect /workspace/WORR/subprojects/ffmpeg/subprojects/nasm.wrap filename does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_690a911d876c83288b9f839d169f7da0