### PR TITLE
Fix font lookup to allow Q2Game.ktx pack

### DIFF
--- a/src/refresh/draw.cpp
+++ b/src/refresh/draw.cpp
@@ -1187,9 +1187,11 @@ void SCR_LoadKFont(kfont_t *font, const char *filename)
     }
 
     const char *packBaseName = COM_SkipPath(source.pack_path);
-    if (!packBaseName || Q_stricmp(packBaseName, "Q2Game.kpf")) {
+    const bool isExpectedPack = packBaseName
+            && (!Q_stricmp(packBaseName, "Q2Game.kpf") || !Q_stricmp(packBaseName, "Q2Game.ktx"));
+    if (!isExpectedPack) {
         FS_CloseFile(handle);
-        Com_Printf("SCR: KFont '%s' must be provided by Q2Game.kpf (found '%s')\n",
+        Com_Printf("SCR: KFont '%s' must be provided by Q2Game.kpf or Q2Game.ktx (found '%s')\n",
                 normalized.c_str(), source.pack_path);
         return;
     }


### PR DESCRIPTION
## Summary
- accept Q2Game.ktx as a valid pack source when loading FreeType and KFont assets
- remove the embedded Roboto font resource and rely on the pack-provided files

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690a931c84188328a32f644d4bd3c189