### PR TITLE
Load Q2Game.ktx pack contents

### DIFF
--- a/src/common/files.cpp
+++ b/src/common/files.cpp
@@ -3833,25 +3833,37 @@ static void add_builtin_content(void)
 static void add_game_kpf(unsigned mode, const char *dir)
 {
 #if USE_ZLIB
+    static const char *const kpf_filenames[] = {
+        "Q2Game.kpf",
+        "Q2Game.ktx",
+    };
+
     std::array<char, MAX_OSPATH> path;
-    pack_t *pack;
-    searchpath_t *search;
+    bool added_pack = false;
 
-    if (Q_snprintf(path.data(), path.size(), "%s/Q2Game.kpf", dir) >= path.size())
-        return;
+    for (const char *filename : kpf_filenames) {
+        pack_t *pack;
+        searchpath_t *search;
 
-    pack = load_zip_file(path.data());
-    if (!pack)
-        return;
+        if (Q_snprintf(path.data(), path.size(), "%s/%s", dir, filename) >= path.size())
+            continue;
 
-    ensure_game_kpf_symlink();
+        pack = load_zip_file(path.data());
+        if (!pack)
+            continue;
 
-    search = FS_Malloc(sizeof(*search));
-    search->mode = mode;
-    search->filename[0] = 0;
-    search->pack = pack_get(pack);
-    search->next = fs_searchpaths;
-    fs_searchpaths = search;
+        if (!added_pack) {
+            ensure_game_kpf_symlink();
+            added_pack = true;
+        }
+
+        search = FS_Malloc(sizeof(*search));
+        search->mode = mode;
+        search->filename[0] = 0;
+        search->pack = pack_get(pack);
+        search->next = fs_searchpaths;
+        fs_searchpaths = search;
+    }
 #endif
 }
 

--- a/src/refresh/draw.cpp
+++ b/src/refresh/draw.cpp
@@ -1187,9 +1187,11 @@ void SCR_LoadKFont(kfont_t *font, const char *filename)
     }
 
     const char *packBaseName = COM_SkipPath(source.pack_path);
-    if (!packBaseName || Q_stricmp(packBaseName, "Q2Game.kpf")) {
+    const bool isExpectedPack = packBaseName
+            && (!Q_stricmp(packBaseName, "Q2Game.kpf") || !Q_stricmp(packBaseName, "Q2Game.ktx"));
+    if (!isExpectedPack) {
         FS_CloseFile(handle);
-        Com_Printf("SCR: KFont '%s' must be provided by Q2Game.kpf (found '%s')\n",
+        Com_Printf("SCR: KFont '%s' must be provided by Q2Game.kpf or Q2Game.ktx (found '%s')\n",
                 normalized.c_str(), source.pack_path);
         return;
     }


### PR DESCRIPTION
## Summary
- allow the filesystem to load either Q2Game.kpf or Q2Game.ktx from the base and home directories
- share the existing pack symlink once either archive is discovered so assets in the .ktx bundle are visible to lookups

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690a931c84188328a32f644d4bd3c189