### PR TITLE
Allow loading FreeType fonts from filesystem

### DIFF
--- a/src/client/screen.cpp
+++ b/src/client/screen.cpp
@@ -247,13 +247,7 @@ static bool SCR_LoadFreeTypeFont(const std::string& cacheKey, const std::string&
                 return false;
         }
 
-        if (!source.from_pack) {
-                FS_CloseFile(fileHandle);
-                Com_Printf("SCR: font '%s' not loaded from a pack file\n", displayFontPath.c_str());
-                return false;
-        }
-
-        if (!source.from_builtin) {
+        if (source.from_pack && !source.from_builtin) {
                 const char* packBaseName = COM_SkipPath(source.pack_path);
                 const bool isExpectedPack = packBaseName
                         && (!Q_stricmp(packBaseName, "Q2Game.kpf"));


### PR DESCRIPTION
## Summary
- allow FreeType font loading to proceed even when the font comes from the filesystem instead of a pack file
- retain the validation that packed fonts originate from Q2Game.kpf

## Testing
- Not run (build files not configured in container)


------
https://chatgpt.com/codex/tasks/task_e_690d32352e8c83289efd700dd62131e7