### PR TITLE
Implement dynamic shadow atlas rendering

### DIFF
--- a/inc/refresh/refresh.hpp
+++ b/inc/refresh/refresh.hpp
@@ -400,6 +400,7 @@ bool    R_ShadowAtlasAllocateView(const shadow_view_parameters_t &params,
                                   shadow_view_assignment_t *out_assignment);
 size_t  R_ShadowAtlasViewCount(void);
 const shadow_view_assignment_t *R_ShadowAtlasViews(void);
+void    R_RenderShadowViews(void);
 
 void    R_SetClipRect(const clipRect_t *clip);
 float   R_ClampScale(cvar_t *var);

--- a/src/refresh/gl.hpp
+++ b/src/refresh/gl.hpp
@@ -209,6 +209,11 @@ typedef struct {
         GLuint                                                      framebuffer;
         int                                                         width;
         int                                                         height;
+        int                                                         quality;
+        int                                                         tiles_per_row;
+        int                                                         tiles_per_column;
+        int                                                         tile_width;
+        int                                                         tile_height;
         size_t                                                      view_count;
         std::array<shadow_view_assignment_t, MAX_SHADOW_VIEWS>       assignments;
     } shadow;
@@ -486,6 +491,7 @@ extern cvar_t *gl_md5_distance;
 #endif
 extern cvar_t *gl_damageblend_frac;
 extern cvar_t *r_skipUnderWaterFX;
+extern cvar_t *r_shadows;
 extern cvar_t *r_postProcessing;
 extern cvar_t *r_bloom;
 extern cvar_t *r_bloomBlurRadius;

--- a/src/refresh/main.cpp
+++ b/src/refresh/main.cpp
@@ -1457,10 +1457,13 @@ void R_RenderFrame(const refdef_t *fd)
 
     glr.drawframe++;
 
-    glr.fd = *fd;
+	glr.fd = *fd;
 
-    if (r_shadows && r_shadows->integer > 0)
-        R_ShadowAtlasBeginFrame();
+	if (r_shadows && r_shadows->integer > 0)
+		R_ShadowAtlasBeginFrame();
+	if (gl_static.use_shaders && r_shadows && r_shadows->integer > 0)
+		R_RenderShadowViews();
+
 
     const bool viewport_changed = glr.motion_blur_viewport_width != glr.fd.width ||
         glr.motion_blur_viewport_height != glr.fd.height;

--- a/src/refresh/shader.cpp
+++ b/src/refresh/shader.cpp
@@ -1868,7 +1868,7 @@ static void shader_load_uniforms(void)
 static void shader_load_lights(void)
 {
     gls.u_cluster_params.cluster_enabled = gl_clustered_shading ? gl_clustered_shading->integer : 0;
-    gls.u_cluster_params.shadow_enabled = gls.u_cluster_params.cluster_enabled;
+	gls.u_cluster_params.shadow_enabled = (gls.u_cluster_params.cluster_enabled && gl_static.shadow.view_count > 0) ? 1 : 0;
     gls.u_cluster_params.show_overdraw = gl_cluster_show_overdraw ? gl_cluster_show_overdraw->integer : 0;
     gls.u_cluster_params.show_normals = gl_cluster_show_normals ? gl_cluster_show_normals->integer : 0;
 

--- a/src/refresh/shadow.cpp
+++ b/src/refresh/shadow.cpp
@@ -1,178 +1,579 @@
+
 #include "gl.hpp"
 
 #include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstring>
+#include <vector>
 
 namespace {
 
-constexpr int kShadowAtlasWidth = 8192;
-constexpr int kShadowAtlasHeight = 4096;
-constexpr int kShadowTilesPerRow = 16;
-constexpr int kShadowTilesPerColumn = 16;
+struct shadow_quality_config_t {
+	int		width;
+	int		height;
+	int		tiles_per_row;
+	int		tiles_per_column;
+};
+
+constexpr std::array<shadow_quality_config_t, 3> kShadowQualityLevels = {{
+	{ 4096, 4096, 16, 16 },
+	{ 8192, 4096, 16, 16 },
+	{ 8192, 8192, 16, 16 },
+}};
+
 constexpr size_t kMaxShadowViews = MAX_SHADOW_VIEWS;
+constexpr float kDefaultShadowBias = 0.001f;
+constexpr float kMinShadowRadius = 16.0f;
+constexpr float kMinNearPlane = 0.25f;
+constexpr float kNearPlaneFraction = 0.05f;
+constexpr float kMaxNearPlaneFraction = 0.5f;
+
+struct face_orientation_t {
+	std::array<float, 3>	forward;
+	std::array<float, 3>	up;
+};
+
+constexpr std::array<face_orientation_t, 6> kCubemapFaceOrientations = {{
+	{ { 1.0f,  0.0f,  0.0f }, { 0.0f, -1.0f,  0.0f } },
+	{ { -1.0f, 0.0f,  0.0f }, { 0.0f, -1.0f,  0.0f } },
+	{ { 0.0f,  1.0f,  0.0f }, { 0.0f,  0.0f,  1.0f } },
+	{ { 0.0f, -1.0f,  0.0f }, { 0.0f,  0.0f, -1.0f } },
+	{ { 0.0f,  0.0f,  1.0f }, { 0.0f, -1.0f,  0.0f } },
+	{ { 0.0f,  0.0f, -1.0f }, { 0.0f, -1.0f,  0.0f } },
+}};
+
+struct shadow_render_view_t {
+	shadow_view_assignment_t	assignment;
+	mat4_t					view_matrix;
+	mat4_t					proj_matrix;
+	vec3_t					axis[3];
+	vec3_t					origin;
+	float					fov_x;
+	float					fov_y;
+	float					near_plane;
+	float					far_plane;
+};
+
+std::vector<shadow_render_view_t> g_render_views;
 
 bool has_required_gl_capabilities()
 {
-    return qglGenTextures && qglDeleteTextures && qglBindTexture &&
-           qglTexParameteri && qglTexImage2D && qglGenFramebuffers &&
-           qglDeleteFramebuffers && qglBindFramebuffer &&
-           qglFramebufferTexture2D && qglCheckFramebufferStatus;
+	return qglGenTextures && qglDeleteTextures && qglBindTexture &&
+		qglTexParameteri && qglTexImage2D && qglGenFramebuffers &&
+		qglDeleteFramebuffers && qglBindFramebuffer &&
+		qglFramebufferTexture2D && qglCheckFramebufferStatus;
 }
 
 void destroy_resources()
 {
-    auto &shadow = gl_static.shadow;
+	auto &shadow = gl_static.shadow;
 
-    if (shadow.framebuffer && qglDeleteFramebuffers) {
-        qglDeleteFramebuffers(1, &shadow.framebuffer);
-        shadow.framebuffer = 0;
-    }
+	if (shadow.framebuffer && qglDeleteFramebuffers) {
+		qglDeleteFramebuffers(1, &shadow.framebuffer);
+		shadow.framebuffer = 0;
+	}
 
-    if (shadow.texture && qglDeleteTextures) {
-        qglDeleteTextures(1, &shadow.texture);
-        shadow.texture = 0;
-    }
+	if (shadow.texture && qglDeleteTextures) {
+		qglDeleteTextures(1, &shadow.texture);
+		shadow.texture = 0;
+	}
 
-    shadow.supported = false;
-    shadow.view_count = 0;
+	shadow.supported = false;
+	shadow.width = 0;
+	shadow.height = 0;
+	shadow.tiles_per_row = 0;
+	shadow.tiles_per_column = 0;
+	shadow.tile_width = 0;
+	shadow.tile_height = 0;
+	shadow.view_count = 0;
+	shadow.quality = -1;
+}
+
+int choose_quality_level()
+{
+	int quality = 1;
+	if (r_shadows)
+		quality = r_shadows->integer;
+	quality = std::clamp(quality, 1, static_cast<int>(kShadowQualityLevels.size()));
+	return quality - 1;
+}
+
+void apply_quality_layout(int quality_index)
+{
+	auto &shadow = gl_static.shadow;
+	const auto &config = kShadowQualityLevels[quality_index];
+
+	shadow.width = config.width;
+	shadow.height = config.height;
+	shadow.tiles_per_row = config.tiles_per_row;
+	shadow.tiles_per_column = config.tiles_per_column;
+	shadow.tile_width = shadow.tiles_per_row ? shadow.width / shadow.tiles_per_row : 0;
+	shadow.tile_height = shadow.tiles_per_column ? shadow.height / shadow.tiles_per_column : 0;
+	shadow.quality = quality_index;
 }
 
 void reset_frame_state()
 {
-    auto &shadow = gl_static.shadow;
-    shadow.view_count = 0;
+	auto &shadow = gl_static.shadow;
+	shadow.view_count = 0;
+	shadow.tile_width = shadow.tiles_per_row ? shadow.width / shadow.tiles_per_row : 0;
+	shadow.tile_height = shadow.tiles_per_column ? shadow.height / shadow.tiles_per_column : 0;
 
-    for (auto &assignment : shadow.assignments) {
-        assignment.valid = false;
-        assignment.atlas_index = -1;
-        assignment.face = -1;
-        assignment.resolution = 0;
-    }
+	for (auto &assignment : shadow.assignments) {
+		assignment.valid = false;
+		assignment.atlas_index = -1;
+		assignment.face = -1;
+		assignment.resolution = 0;
+		for (int i = 0; i < 4; ++i) {
+			assignment.parameters.viewport_rect[i] = 0.0f;
+			assignment.parameters.source_position[i] = 0.0f;
+		}
+	}
 }
 
 void configure_texture_parameters(GLuint texture)
 {
-    qglBindTexture(GL_TEXTURE_2D, texture);
-    qglTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    qglTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    qglTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    qglTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	qglBindTexture(GL_TEXTURE_2D, texture);
+	qglTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+	qglTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	qglTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+	qglTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 #ifdef GL_TEXTURE_COMPARE_MODE
-    qglTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_NONE);
+	qglTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_NONE);
 #endif
-    qglBindTexture(GL_TEXTURE_2D, 0);
+	qglBindTexture(GL_TEXTURE_2D, 0);
+}
+
+float compute_light_bias(const shadow_light_submission_t &light)
+{
+	if (light.bias > 0.0f)
+		return light.bias;
+	return kDefaultShadowBias;
+}
+
+float compute_light_shade(const shadow_light_submission_t &light)
+{
+	return std::max(light.intensity, 0.0f);
+}
+
+float compute_shadow_far_plane(const shadow_light_submission_t &light)
+{
+	return std::max(light.radius, kMinShadowRadius);
+}
+
+float compute_shadow_near_plane(float far_plane)
+{
+	float near_plane = std::max(far_plane * kNearPlaneFraction, kMinNearPlane);
+	if (near_plane >= far_plane)
+		near_plane = far_plane * kMaxNearPlaneFraction;
+	return std::max(near_plane, kMinNearPlane);
+}
+
+void build_axis_from_direction(const vec3_t forward_in, const vec3_t up_hint, vec3_t out_axis[3])
+{
+	vec3_t forward;
+	VectorCopy(forward_in, forward);
+	if (VectorNormalize(forward) == 0.0f) {
+		forward[0] = 0.0f;
+		forward[1] = 0.0f;
+		forward[2] = 1.0f;
+	}
+
+	vec3_t up;
+	VectorCopy(up_hint, up);
+	if (VectorNormalize(up) == 0.0f) {
+		up[0] = 0.0f;
+		up[1] = 0.0f;
+		up[2] = 1.0f;
+	}
+
+	if (std::fabs(DotProduct(forward, up)) > 0.99f) {
+		vec3_t fallback = { 0.0f, 0.0f, 1.0f };
+		if (std::fabs(DotProduct(forward, fallback)) > 0.99f) {
+			fallback[0] = 1.0f;
+			fallback[1] = 0.0f;
+			fallback[2] = 0.0f;
+		}
+		VectorCopy(fallback, up);
+		VectorNormalize(up);
+	}
+
+	vec3_t left;
+	CrossProduct(up, forward, left);
+	if (VectorNormalize(left) == 0.0f) {
+		left[0] = 1.0f;
+		left[1] = 0.0f;
+		left[2] = 0.0f;
+	}
+
+	vec3_t corrected_up;
+	CrossProduct(forward, left, corrected_up);
+	VectorNormalize(corrected_up);
+
+	VectorCopy(forward, out_axis[0]);
+	VectorCopy(left, out_axis[1]);
+	VectorCopy(corrected_up, out_axis[2]);
+}
+
+void build_axis_from_orientation(const face_orientation_t &orientation, vec3_t out_axis[3])
+{
+	vec3_t forward;
+	vec3_t up;
+	forward[0] = orientation.forward[0];
+	forward[1] = orientation.forward[1];
+	forward[2] = orientation.forward[2];
+	up[0] = orientation.up[0];
+	up[1] = orientation.up[1];
+	up[2] = orientation.up[2];
+	build_axis_from_direction(forward, up, out_axis);
+}
+
+void store_shadow_item(const shadow_view_assignment_t &assignment)
+{
+	if (assignment.atlas_index < 0)
+		return;
+	const size_t index = static_cast<size_t>(assignment.atlas_index);
+	if (index >= gls.shadow_items.size())
+		return;
+
+	glShadowItem_t &item = gls.shadow_items[index];
+	std::memcpy(item.volume_matrix, assignment.parameters.view_projection, sizeof(mat4_t));
+	for (int i = 0; i < 4; ++i) {
+		item.viewport_rect[i] = assignment.parameters.viewport_rect[i];
+		item.source_position[i] = assignment.parameters.source_position[i];
+	}
+	item.bias = assignment.parameters.bias;
+	item.shade_amount = assignment.parameters.shade_amount;
+}
+
+int compute_view_resolution(const shadow_light_submission_t &light)
+{
+	const int base_resolution = std::min(gl_static.shadow.tile_width, gl_static.shadow.tile_height);
+	if (base_resolution <= 0)
+		return 0;
+	int resolution = light.resolution > 0 ? light.resolution : base_resolution;
+	resolution = std::clamp(resolution, 1, base_resolution);
+	return resolution;
+}
+
+bool append_shadow_view(const shadow_light_submission_t &light, const vec3_t axis[3], float fov,
+	float near_plane, float far_plane, int face)
+{
+	mat4_t view_matrix;
+	Matrix_FromOriginAxis(light.origin, axis, view_matrix);
+
+	mat4_t proj_matrix;
+	Matrix_Frustum(fov, fov, 1.0f, near_plane, far_plane, proj_matrix);
+
+	mat4_t view_projection;
+	Matrix_Multiply(proj_matrix, view_matrix, view_projection);
+
+	shadow_view_parameters_t params{};
+	std::memcpy(params.view_projection, view_projection, sizeof(mat4_t));
+	for (int i = 0; i < 4; ++i) {
+		params.viewport_rect[i] = 0.0f;
+		params.source_position[i] = 0.0f;
+	}
+	params.source_position[0] = light.origin[0];
+	params.source_position[1] = light.origin[1];
+	params.source_position[2] = light.origin[2];
+	params.source_position[3] = far_plane;
+	params.bias = compute_light_bias(light);
+	params.shade_amount = compute_light_shade(light);
+
+	const int resolution = compute_view_resolution(light);
+	shadow_view_assignment_t assignment{};
+	if (!R_ShadowAtlasAllocateView(params, face, resolution, &assignment))
+		return false;
+
+	shadow_render_view_t view{};
+	view.assignment = assignment;
+	std::memcpy(view.view_matrix, view_matrix, sizeof(mat4_t));
+	std::memcpy(view.proj_matrix, proj_matrix, sizeof(mat4_t));
+	for (int i = 0; i < 3; ++i)
+		VectorCopy(axis[i], view.axis[i]);
+	VectorCopy(light.origin, view.origin);
+	view.fov_x = fov;
+	view.fov_y = fov;
+	view.near_plane = near_plane;
+	view.far_plane = far_plane;
+
+	g_render_views.push_back(view);
+	store_shadow_item(assignment);
+	return true;
+}
+
+void render_shadow_views()
+{
+	if (g_render_views.empty())
+		return;
+
+	GLint prev_draw_buffer = GL_BACK;
+	GLint prev_read_buffer = GL_BACK;
+	GLint prev_fbo = 0;
+	GLint prev_viewport[4] = { 0, 0, 0, 0 };
+	GLboolean prev_color_mask[4] = { GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE };
+	GLboolean prev_depth_mask = GL_TRUE;
+
+	qglGetIntegerv(GL_DRAW_BUFFER, &prev_draw_buffer);
+	qglGetIntegerv(GL_READ_BUFFER, &prev_read_buffer);
+	qglGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &prev_fbo);
+	qglGetIntegerv(GL_VIEWPORT, prev_viewport);
+	qglGetBooleanv(GL_COLOR_WRITEMASK, prev_color_mask);
+	qglGetBooleanv(GL_DEPTH_WRITEMASK, &prev_depth_mask);
+
+	const bool prev_framebuffer_bound = glr.framebuffer_bound;
+
+	qglBindFramebuffer(GL_FRAMEBUFFER, gl_static.shadow.framebuffer);
+	qglDrawBuffer(GL_NONE);
+	qglReadBuffer(GL_NONE);
+	qglColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
+	qglDepthMask(GL_TRUE);
+
+	refdef_t saved_fd = glr.fd;
+	mat4_t saved_viewmatrix;
+	mat4_t saved_projmatrix;
+	vec3_t saved_viewaxis[3];
+	std::memcpy(saved_viewmatrix, glr.viewmatrix, sizeof(mat4_t));
+	std::memcpy(saved_projmatrix, glr.projmatrix, sizeof(mat4_t));
+	for (int i = 0; i < 3; ++i)
+		VectorCopy(glr.viewaxis[i], saved_viewaxis[i]);
+
+	glr.framebuffer_bound = true;
+
+	for (const auto &view : g_render_views) {
+		const float *rect = view.assignment.parameters.viewport_rect;
+		const GLint viewport_x = static_cast<GLint>(rect[0]);
+		const GLint viewport_y = static_cast<GLint>(rect[1]);
+		const GLsizei viewport_w = static_cast<GLsizei>(rect[2] - rect[0]);
+		const GLsizei viewport_h = static_cast<GLsizei>(rect[3] - rect[1]);
+		if (viewport_w <= 0 || viewport_h <= 0)
+			continue;
+
+		qglViewport(viewport_x, viewport_y, viewport_w, viewport_h);
+		qglClear(GL_DEPTH_BUFFER_BIT);
+
+		glr.fd = saved_fd;
+		VectorCopy(view.origin, glr.fd.vieworg);
+		glr.fd.width = viewport_w;
+		glr.fd.height = viewport_h;
+		glr.fd.fov_x = view.fov_x;
+		glr.fd.fov_y = view.fov_y;
+
+		for (int axis_index = 0; axis_index < 3; ++axis_index)
+			VectorCopy(view.axis[axis_index], glr.viewaxis[axis_index]);
+
+		std::memcpy(glr.viewmatrix, view.view_matrix, sizeof(mat4_t));
+		std::memcpy(glr.projmatrix, view.proj_matrix, sizeof(mat4_t));
+		Matrix_Multiply(glr.projmatrix, glr.viewmatrix, glr.view_proj_matrix);
+		glr.view_znear = view.near_plane;
+		glr.view_zfar = view.far_plane;
+		glr.view_proj_valid = Matrix_Invert(glr.view_proj_matrix, glr.inv_view_proj_matrix);
+
+		gl_backend->load_matrix(GL_PROJECTION, view.proj_matrix, gl_identity);
+		GL_ForceMatrix(gl_identity, view.view_matrix);
+
+		GL_ClearSolidFaces();
+		if (!(glr.fd.rdflags & RDF_NOWORLDMODEL) && gl_drawworld->integer)
+			GL_DrawWorld();
+
+		GL_ClassifyEntities();
+		GL_DrawEntities(glr.ents.bmodels);
+		GL_DrawEntities(glr.ents.opaque);
+		GL_DrawEntities(glr.ents.alpha_back);
+		GL_DrawAlphaFaces();
+		GL_DrawEntities(glr.ents.alpha_front);
+		GL_DrawDebugObjects();
+
+		GL_Flush3D();
+	}
+
+glr.fd = saved_fd;
+for (int i = 0; i < 3; ++i)
+VectorCopy(saved_viewaxis[i], glr.viewaxis[i]);
+std::memcpy(glr.viewmatrix, saved_viewmatrix, sizeof(mat4_t));
+std::memcpy(glr.projmatrix, saved_projmatrix, sizeof(mat4_t));
+glr.framebuffer_bound = prev_framebuffer_bound;
+glr.view_proj_valid = false;
+gl_backend->load_matrix(GL_PROJECTION, glr.projmatrix, gl_identity);
+GL_ForceMatrix(gl_identity, glr.viewmatrix);
+
+qglBindFramebuffer(GL_FRAMEBUFFER, prev_fbo);
+	qglDrawBuffer(prev_draw_buffer);
+	qglReadBuffer(prev_read_buffer);
+	qglViewport(prev_viewport[0], prev_viewport[1], prev_viewport[2], prev_viewport[3]);
+	qglColorMask(prev_color_mask[0], prev_color_mask[1], prev_color_mask[2], prev_color_mask[3]);
+	qglDepthMask(prev_depth_mask);
 }
 
 } // namespace
 
 bool R_ShadowAtlasInit(void)
 {
-    auto &shadow = gl_static.shadow;
+	destroy_resources();
 
-    shadow.width = kShadowAtlasWidth;
-    shadow.height = kShadowAtlasHeight;
+	if (!has_required_gl_capabilities())
+		return false;
 
-    if (!has_required_gl_capabilities()) {
-        destroy_resources();
-        return false;
-    }
+	const int quality_index = choose_quality_level();
+	apply_quality_layout(quality_index);
 
-    destroy_resources();
+	qglGenTextures(1, &gl_static.shadow.texture);
+	if (!gl_static.shadow.texture)
+		return false;
 
-    qglGenTextures(1, &shadow.texture);
-    if (!shadow.texture) {
-        destroy_resources();
-        return false;
-    }
+	qglBindTexture(GL_TEXTURE_2D, gl_static.shadow.texture);
+	qglTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT24,
+		gl_static.shadow.width, gl_static.shadow.height, 0, GL_DEPTH_COMPONENT,
+		GL_UNSIGNED_INT, nullptr);
+	configure_texture_parameters(gl_static.shadow.texture);
 
-    qglBindTexture(GL_TEXTURE_2D, shadow.texture);
-    qglTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT24,
-                  shadow.width, shadow.height, 0, GL_DEPTH_COMPONENT,
-                  GL_UNSIGNED_INT, nullptr);
-    configure_texture_parameters(shadow.texture);
+	qglGenFramebuffers(1, &gl_static.shadow.framebuffer);
+	if (!gl_static.shadow.framebuffer) {
+		destroy_resources();
+		return false;
+	}
 
-    qglGenFramebuffers(1, &shadow.framebuffer);
-    if (!shadow.framebuffer) {
-        destroy_resources();
-        return false;
-    }
+	qglBindFramebuffer(GL_FRAMEBUFFER, gl_static.shadow.framebuffer);
+	qglFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+		GL_TEXTURE_2D, gl_static.shadow.texture, 0);
 
-    qglBindFramebuffer(GL_FRAMEBUFFER, shadow.framebuffer);
-    qglFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
-                            GL_TEXTURE_2D, shadow.texture, 0);
+	const GLenum status = qglCheckFramebufferStatus(GL_FRAMEBUFFER);
+	qglBindFramebuffer(GL_FRAMEBUFFER, 0);
 
-    GLenum status = qglCheckFramebufferStatus(GL_FRAMEBUFFER);
-    qglBindFramebuffer(GL_FRAMEBUFFER, 0);
+	if (status != GL_FRAMEBUFFER_COMPLETE) {
+		destroy_resources();
+		return false;
+	}
 
-    if (status != GL_FRAMEBUFFER_COMPLETE) {
-        destroy_resources();
-        return false;
-    }
+	gl_static.shadow.supported = true;
+	reset_frame_state();
 
-    shadow.supported = true;
-    reset_frame_state();
-
-    return true;
+	return true;
 }
 
 void R_ShadowAtlasShutdown(void)
 {
-    destroy_resources();
+	destroy_resources();
 }
 
 void R_ShadowAtlasBeginFrame(void)
 {
-    if (!gl_static.shadow.supported)
-        return;
+	if (!has_required_gl_capabilities())
+		return;
 
-    reset_frame_state();
+	const int desired_quality = choose_quality_level();
+	if (gl_static.shadow.quality != desired_quality) {
+		if (!R_ShadowAtlasInit())
+			return;
+	}
+
+	if (!gl_static.shadow.supported)
+		return;
+
+	reset_frame_state();
 }
 
 bool R_ShadowAtlasAllocateView(const shadow_view_parameters_t &params,
-                               int face, int resolution,
-                               shadow_view_assignment_t *out_assignment)
+	int face, int resolution,
+	shadow_view_assignment_t *out_assignment)
 {
-    auto &shadow = gl_static.shadow;
+	auto &shadow = gl_static.shadow;
 
-    if (!shadow.supported)
-        return false;
+	if (!shadow.supported)
+		return false;
 
-    if (shadow.view_count >= kMaxShadowViews)
-        return false;
+	const size_t max_tiles = static_cast<size_t>(shadow.tiles_per_row) * static_cast<size_t>(shadow.tiles_per_column);
+	if (shadow.view_count >= kMaxShadowViews || shadow.view_count >= max_tiles)
+		return false;
 
-    const size_t index = shadow.view_count++;
-    const int tile_width = shadow.width / kShadowTilesPerRow;
-    const int tile_height = shadow.height / kShadowTilesPerColumn;
-    const int column = static_cast<int>(index % kShadowTilesPerRow);
-    const int row = static_cast<int>(index / kShadowTilesPerRow);
-    const float x0 = static_cast<float>(column * tile_width);
-    const float y0 = static_cast<float>(row * tile_height);
-    const float x1 = x0 + static_cast<float>(tile_width);
-    const float y1 = y0 + static_cast<float>(tile_height);
+	const size_t index = shadow.view_count++;
+	const int tile_width = shadow.tile_width;
+	const int tile_height = shadow.tile_height;
+	if (tile_width <= 0 || tile_height <= 0)
+		return false;
 
-    shadow_view_assignment_t assignment{};
-    assignment.parameters = params;
-    Vector4Set(assignment.parameters.viewport_rect, x0, y0, x1, y1);
-    Vector4Set(assignment.cube_face_offset, x0, y0,
-               static_cast<float>(tile_width), static_cast<float>(tile_height));
-    assignment.atlas_index = static_cast<int>(index);
-    assignment.face = face;
-    assignment.resolution = resolution;
-    assignment.valid = true;
+	const int column = static_cast<int>(index % shadow.tiles_per_row);
+	const int row = static_cast<int>(index / shadow.tiles_per_row);
+	const float x0 = static_cast<float>(column * tile_width);
+	const float y0 = static_cast<float>(row * tile_height);
+	const float x1 = x0 + static_cast<float>(tile_width);
+	const float y1 = y0 + static_cast<float>(tile_height);
 
-    shadow.assignments[index] = assignment;
+	shadow_view_assignment_t assignment{};
+	assignment.parameters = params;
+	assignment.parameters.viewport_rect[0] = x0;
+	assignment.parameters.viewport_rect[1] = y0;
+	assignment.parameters.viewport_rect[2] = x1;
+	assignment.parameters.viewport_rect[3] = y1;
+	assignment.cube_face_offset[0] = x0;
+	assignment.cube_face_offset[1] = y0;
+	assignment.cube_face_offset[2] = static_cast<float>(tile_width);
+	assignment.cube_face_offset[3] = static_cast<float>(tile_height);
+	assignment.atlas_index = static_cast<int>(index);
+	assignment.face = face;
+	assignment.resolution = resolution > 0 ? std::min(resolution, std::min(tile_width, tile_height)) : std::min(tile_width, tile_height);
+	assignment.valid = true;
 
-    if (out_assignment)
-        *out_assignment = assignment;
+	shadow.assignments[index] = assignment;
 
-    return true;
+	if (out_assignment)
+		*out_assignment = assignment;
+
+	return true;
 }
 
 size_t R_ShadowAtlasViewCount(void)
 {
-    return gl_static.shadow.view_count;
+	return gl_static.shadow.view_count;
 }
 
 const shadow_view_assignment_t *R_ShadowAtlasViews(void)
 {
-    return gl_static.shadow.assignments.data();
+	return gl_static.shadow.assignments.data();
+}
+
+void R_RenderShadowViews(void)
+{
+	if (!gl_static.use_shaders)
+		return;
+
+	if (!gl_static.shadow.supported)
+		return;
+
+	std::memset(gls.shadow_items.data(), 0, gls.shadow_items.size() * sizeof(glShadowItem_t));
+	g_render_views.clear();
+	g_render_views.reserve(std::min(kMaxShadowViews, gls.shadow_items.size()));
+
+	size_t light_count = 0;
+	const shadow_light_submission_t *lights = R_GetQueuedShadowLights(&light_count);
+	if (!lights || !light_count)
+		return;
+
+	for (size_t i = 0; i < light_count; ++i) {
+		const shadow_light_submission_t &light = lights[i];
+		if (!light.casts_shadow)
+			continue;
+
+		const float far_plane = compute_shadow_far_plane(light);
+		const float near_plane = compute_shadow_near_plane(far_plane);
+
+		if (light.lighttype == shadow_light_type_point) {
+			for (size_t face_index = 0; face_index < kCubemapFaceOrientations.size(); ++face_index) {
+				vec3_t axis[3];
+				build_axis_from_orientation(kCubemapFaceOrientations[face_index], axis);
+				if (!append_shadow_view(light, axis, 90.0f, near_plane, far_plane, static_cast<int>(face_index)))
+					break;
+			}
+		} else if (light.lighttype == shadow_light_type_cone && light.coneangle > 0.0f) {
+			vec3_t up = { 0.0f, 0.0f, 1.0f };
+			vec3_t axis[3];
+			build_axis_from_direction(light.direction, up, axis);
+			const float fov = std::clamp(light.coneangle, 5.0f, 170.0f);
+			append_shadow_view(light, axis, fov, near_plane, far_plane, -1);
+		}
+	}
+
+	render_shadow_views();
 }


### PR DESCRIPTION
## Summary
- add a quality-driven shadow atlas layout and expose the per-frame renderer entry point
- render queued point and spot lights into the atlas and populate shadow uniform data
- gate clustered shadow uploads on actual atlas content and hook the pass into the main frame loop

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fc074a55c8328b437c5894c55cfc8)