### PR TITLE
Implement configurable clustered shadow filtering

### DIFF
--- a/src/refresh/gl.hpp
+++ b/src/refresh/gl.hpp
@@ -483,6 +483,8 @@ extern cvar_t *gl_modulate_entities;
 extern cvar_t *gl_glowmap_intensity;
 extern cvar_t *gl_flarespeed;
 extern cvar_t *gl_fontshadow;
+extern cvar_t *gl_shadow_filter;
+extern cvar_t *gl_shadow_filter_radius;
 extern cvar_t *gl_shaders;
 #if USE_MD5
 extern cvar_t *gl_md5_load;
@@ -874,6 +876,7 @@ typedef enum {
     TMU_TEXTURE,
     TMU_LIGHTMAP,
     TMU_GLOWMAP,
+    TMU_SHADOW_ATLAS,
     TMU_HISTORY0,
     TMU_HISTORY1,
     TMU_HISTORY2,
@@ -1005,15 +1008,11 @@ typedef struct {
     glDlight_t     lights[MAX_DLIGHTS];
 } glUniformDlights_t;
 
-typedef struct {
-    float           cluster_min_z;
-    float           cluster_zslice_factor;
-    int32_t         cluster_enabled;
-    int32_t         shadow_enabled;
-    int32_t         show_overdraw;
-    int32_t         show_normals;
-    vec2_t          _pad_cluster;
-} glClusterParams_t;
+struct alignas(16) glClusterParams_t {
+    vec4_t          params0;
+    vec4_t          params1;
+    vec4_t          shadow_atlas;
+};
 
 typedef struct {
     glTmu_t             client_tmu;

--- a/src/refresh/main.cpp
+++ b/src/refresh/main.cpp
@@ -69,6 +69,8 @@ cvar_t *gl_modulate_entities;
 cvar_t *gl_glowmap_intensity;
 cvar_t *gl_flarespeed;
 cvar_t *gl_fontshadow;
+cvar_t *gl_shadow_filter;
+cvar_t *gl_shadow_filter_radius;
 cvar_t *gl_shaders;
 #if USE_MD5
 cvar_t *gl_md5_load;
@@ -1872,10 +1874,12 @@ static void GL_Register(void)
     gl_dlight_falloff = Cvar_Get("gl_dlight_falloff", "1", 0);
     gl_modulate_entities = Cvar_Get("gl_modulate_entities", "1", 0);
     gl_modulate_entities->changed = gl_modulate_entities_changed;
-    gl_glowmap_intensity = Cvar_Get("gl_glowmap_intensity", "1", 0);
-    gl_flarespeed = Cvar_Get("gl_flarespeed", "8", 0);
-    gl_fontshadow = Cvar_Get("gl_fontshadow", "0", 0);
-    gl_shaders = Cvar_Get("gl_shaders", "1", CVAR_FILES);
+	gl_glowmap_intensity = Cvar_Get("gl_glowmap_intensity", "1", 0);
+	gl_flarespeed = Cvar_Get("gl_flarespeed", "8", 0);
+	gl_fontshadow = Cvar_Get("gl_fontshadow", "0", 0);
+	gl_shadow_filter = Cvar_Get("gl_shadow_filter", "1", CVAR_ARCHIVE);
+	gl_shadow_filter_radius = Cvar_Get("gl_shadow_filter_radius", "1.5", CVAR_ARCHIVE);
+	gl_shaders = Cvar_Get("gl_shaders", "1", CVAR_FILES);
 #if USE_MD5
     gl_md5_load = Cvar_Get("gl_md5_load", "1", CVAR_FILES);
     gl_md5_use = Cvar_Get("gl_md5_use", "1", 0);


### PR DESCRIPTION
## Summary
- implement atlas-aware ComputeShadow shader logic with selectable filtering techniques
- expose renderer cvars for shadow filtering mode and radius while expanding clustered uniform data
- update CPU-side bindings to upload new cluster parameters and bind the shadow atlas sampler

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fc45a40fc8328bc01f56b18b9d46c)