### PR TITLE
Document dynamic shadow settings and update video menu

### DIFF
--- a/doc/client.asciidoc
+++ b/doc/client.asciidoc
@@ -885,8 +885,33 @@ gl_dotshading::
     truly 3D-ish by simulating diffuse lighting from a fake light source.
     Default value is 1 (enabled).
 
+r_shadows::
+    Enables real-time shadow maps for dynamic lights when the shader rendering
+    backend is active. Default value is 1 (enabled).
+      - 0 — disabled (use legacy planar shadows only)
+      - 1 — low quality atlas (4096x4096 with 256x256 tiles)
+      - 2 — balanced quality atlas (8192x4096 with 512x256 tiles)
+      - 3 — high quality atlas (8192x8192 with 512x512 tiles)
+
+gl_shadow_filter::
+    Selects filtering technique for ‘r_shadows’ shadow maps. Default value is
+    1.
+      - 0 — hard-edged shadows (no filtering)
+      - 1 — percentage-closer filtering with a 3x3 kernel
+      - 2 — percentage-closer filtering with a 5x5 kernel
+      - 3 — percentage-closer filtering with a 7x7 kernel
+      - 4 — exponential falloff filtering
+      - 5 — variance shadow mapping (also used by higher values)
+
+gl_shadow_filter_radius::
+    Controls sample spacing used by filtered shadow map techniques. Larger
+    values increase shadow softness at the cost of additional blurring.
+    Default value is 1.5.
+
 gl_shadows::
-    Enables drawing stencil shadows underneath 3D models. Default value is 0.
+    Enables classic planar “blob” shadows underneath 3D models. These remain in
+    effect regardless of ‘r_shadows’ and serve as a fallback when real-time
+    shadows are disabled. Default value is 2.
       - 0 — disabled
       - 1 — enabled, constant alpha
       - 2 — enabled, alpha fade with distance

--- a/src/client/ui/worr.menu.json
+++ b/src/client/ui/worr.menu.json
@@ -199,7 +199,49 @@
         { "type": "toggle", "label": "entity glowing", "cvar": "cl_noglow", "negate": true, "group": "rendering" },
         {
           "type": "values",
-          "label": "ground shadows",
+          "label": "dynamic shadows",
+          "cvar": "r_shadows",
+          "group": "rendering",
+          "options": [
+            "off",
+            "low",
+            "medium",
+            "high"
+          ]
+        },
+        {
+          "type": "values",
+          "label": "shadow filter",
+          "cvar": "gl_shadow_filter",
+          "group": "rendering",
+          "disableWhen": [
+            { "cvar": "r_shadows", "equals": "0" }
+          ],
+          "options": [
+            "hard",
+            "pcf 3x3",
+            "pcf 5x5",
+            "pcf 7x7",
+            "exponential",
+            "variance"
+          ]
+        },
+        {
+          "type": "range",
+          "label": "shadow softness",
+          "cvar": "gl_shadow_filter_radius",
+          "group": "rendering",
+          "min": 0.5,
+          "max": 4.0,
+          "step": 0.1,
+          "disableWhen": [
+            { "cvar": "r_shadows", "equals": "0" },
+            { "cvar": "gl_shadow_filter", "equals": "0" }
+          ]
+        },
+        {
+          "type": "values",
+          "label": "legacy ground shadows",
           "cvar": "gl_shadows",
           "group": "rendering",
           "options": [


### PR DESCRIPTION
## Summary
- document the new r_shadows quality tiers and associated filtering controls in the client manual
- expose dynamic shadow quality, filtering, and softness options in the video menu alongside the legacy ground shadow toggle

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fd7693dc08328bda8dae85e1dd01b)