### PR TITLE
Fix FreeType font prefix check build failure

### DIFF
--- a/src/client/screen.cpp
+++ b/src/client/screen.cpp
@@ -195,7 +195,7 @@ static bool SCR_LoadFreeTypeFont(const std::string& cacheKey, const std::string&
 	if (!fontPath.empty() && (fontPath.front() == '/' || fontPath.front() == '\\'))
 		preferQ2Game = true;
 	if (!preferQ2Game && !normalizedFontPath.empty() &&
-	    !Q_stricmpn(normalizedFontPath.c_str(), "fonts/", CONST_STR_LEN("fonts/")))
+	    !Q_stricmpn(normalizedFontPath.c_str(), CONST_STR_LEN("fonts/")))
 		preferQ2Game = true;
 
 	if (preferQ2Game && !q2FontPath.empty() && q2FontPath.front() != '/')


### PR DESCRIPTION
## Summary
- adjust the FreeType font prefix comparison to use the CONST_STR_LEN helper without duplicating the literal
- prevent passing a fourth argument to Q_stricmpn so the Windows build completes

## Testing
- meson compile -C builddir *(fails: `/workspace/WORR/builddir` is not a Meson build directory)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69107eb88dc48328a3fecfc934f08ced)