### PR TITLE
Improve diagnostics and defaults for FreeType font loading

### DIFF
--- a/src/client/cgame.cpp
+++ b/src/client/cgame.cpp
@@ -150,7 +150,11 @@ static cgame_q2pro_extended_support_ext_t cgame_q2pro_extended_support = CGX_Cre
 void CG_Init(void)
 {
 	scr_alpha = Cvar_Get("scr_alpha", "1", 0);
-        scr_font = Cvar_Get("scr_font", "/fonts/RobotoMono-Regular.ttf", 0);
+#if USE_FREETYPE
+	scr_font = Cvar_Get("scr_font", "/fonts/RobotoMono-Regular.ttf", 0);
+#else
+	scr_font = Cvar_Get("scr_font", CG_LEGACY_FONT, 0);
+#endif
 	scr_font->changed = scr_font_changed;
 	scr_font_changed(scr_font);
 }

--- a/src/client/console.cpp
+++ b/src/client/console.cpp
@@ -259,7 +259,11 @@ namespace {
 				Console::instance().checkResize();
 			};
 
+#if USE_FREETYPE
 		font_ = Cvar_Get("con_font", "/fonts/RobotoMono-Regular.ttf", 0);
+#else
+		font_ = Cvar_Get("con_font", "conchars", 0);
+#endif
 		font_->changed = [](cvar_t* self) {
 			if (cls.ref_initialized)
 				Console::instance().registerMedia();


### PR DESCRIPTION
## Summary
- surface detailed FreeType failure reasons when loading TTF fonts and report them back through the fatal screen error
- default console and screen font cvars to the legacy bitmap font when FreeType support is not available
- keep TTF loading optional while providing clearer feedback for missing libraries

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69108090b5688328ac47711c109b367e)