### PR TITLE
Mark refs directory as vendored

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -61,3 +61,5 @@
 #*.PDF   diff=astextplain
 #*.rtf   diff=astextplain
 #*.RTF   diff=astextplain
+
+refs/** linguist-vendored


### PR DESCRIPTION
## Summary
- configure Linguist to treat the refs directory as vendored content

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910b097352c8328a42a41f670d6dafb)