### PR TITLE
Adjust medium shadow atlas layout

### DIFF
--- a/doc/client.asciidoc
+++ b/doc/client.asciidoc
@@ -889,9 +889,9 @@ r_shadows::
     Enables real-time shadow maps for dynamic lights when the shader rendering
     backend is active. Default value is 1 (enabled).
       - 0 — disabled (use legacy planar shadows only)
-      - 1 — low quality atlas (4096x4096 with 256x256 tiles)
-      - 2 — balanced quality atlas (8192x4096 with 512x256 tiles)
-      - 3 — high quality atlas (8192x8192 with 512x512 tiles)
+      - 1 — low quality atlas (4096x4096 with 256x256 tiles, up to 256 views)
+      - 2 — balanced quality atlas (8192x4096 with 512x512 tiles, up to 128 views)
+      - 3 — high quality atlas (8192x8192 with 512x512 tiles, up to 256 views)
 
 gl_shadow_filter::
     Selects filtering technique for ‘r_shadows’ shadow maps. Default value is

--- a/src/refresh/shadow.cpp
+++ b/src/refresh/shadow.cpp
@@ -18,7 +18,7 @@ struct shadow_quality_config_t {
 
 constexpr std::array<shadow_quality_config_t, 3> kShadowQualityLevels = {{
 	{ 4096, 4096, 16, 16 },
-	{ 8192, 4096, 16, 16 },
+	{ 8192, 4096, 16, 8 },
 	{ 8192, 8192, 16, 16 },
 }};
 


### PR DESCRIPTION
## Summary
- increase the medium shadow atlas tile height to provide 512×512 tiles while keeping atlas dimensions
- document the resulting per-quality atlas capacities and tile sizes in the client guide

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910b44587a483288e2c2355869d5903)