### PR TITLE
Add helper to load fonts via absolute resource paths

### DIFF
--- a/src/client/cgame.cpp
+++ b/src/client/cgame.cpp
@@ -70,12 +70,12 @@ namespace {
                 if (!name || !*name)
                         return 0;
 
-                qhandle_t handle = R_RegisterFont(name);
+                qhandle_t handle = SCR_RegisterFontPath(name);
                 if (handle)
                         return handle;
 
                 if (Q_stricmp(name, CG_LEGACY_FONT))
-                        return R_RegisterFont(CG_LEGACY_FONT);
+                        return SCR_RegisterFontPath(CG_LEGACY_FONT);
 
                 return 0;
         }
@@ -83,11 +83,11 @@ namespace {
 
 static void scr_font_changed(cvar_t* self)
 {
-        scr.font_pic = R_RegisterFont(self->string);
+        scr.font_pic = SCR_RegisterFontPath(self->string);
 
         if (!scr.font_pic && strcmp(self->string, self->default_string)) {
                 Cvar_Reset(self);
-                scr.font_pic = R_RegisterFont(self->default_string);
+                scr.font_pic = SCR_RegisterFontPath(self->default_string);
         }
 
         if (!scr.font_pic && Q_stricmp(self->default_string, CG_LEGACY_FONT)) {

--- a/src/client/client.hpp
+++ b/src/client/client.hpp
@@ -1304,6 +1304,7 @@ void    SCR_DrawStringMultiStretch(int x, int y, int scale, int flags, size_t ma
 void    SCR_DrawGlyph(int x, int y, int scale, int flags, unsigned char glyph, color_t color);
 
 qhandle_t SCR_DefaultFontHandle(void);
+qhandle_t SCR_RegisterFontPath(const char* name);
 int     SCR_FontLineHeight(int scale, qhandle_t font);
 int     SCR_MeasureString(int scale, int flags, size_t maxlen, const char* s, qhandle_t font);
 

--- a/src/client/console.cpp
+++ b/src/client/console.cpp
@@ -906,14 +906,14 @@ namespace {
 
 	void Console::registerMedia()
 	{
-		registeredFont_ = R_RegisterFont(font_->string);
+		registeredFont_ = SCR_RegisterFontPath(font_->string);
 		if (!registeredFont_) {
 			if (strcmp(font_->string, font_->default_string)) {
 				Cvar_Reset(font_);
-				registeredFont_ = R_RegisterFont(font_->default_string);
+				registeredFont_ = SCR_RegisterFontPath(font_->default_string);
 			}
 			if (!registeredFont_)
-				registeredFont_ = R_RegisterFont("conchars");
+				registeredFont_ = SCR_RegisterFontPath("conchars");
 			if (!registeredFont_)
 				Com_Error(ERR_FATAL, "%s", Com_GetLastError());
 		}

--- a/src/client/screen.cpp
+++ b/src/client/screen.cpp
@@ -1935,6 +1935,17 @@ namespace {
 	}
 } // namespace
 
+qhandle_t SCR_RegisterFontPath(const char* name)
+{
+	if (!name || !*name)
+		return 0;
+	if (name[0] == '/' || name[0] == '\\')
+		return R_RegisterFont(name);
+	if (strpbrk(name, "/\\"))
+		return R_RegisterFont(va("/%s", name));
+	return R_RegisterFont(name);
+}
+
 static void scr_font_changed(cvar_t* self)
 {
 	if (!cls.ref_initialized) {
@@ -1962,7 +1973,7 @@ static void scr_font_changed(cvar_t* self)
 			attemptedLegacy = true;
 
 		lastAttempt = candidate;
-		qhandle_t handle = R_RegisterFont(candidate);
+		qhandle_t handle = SCR_RegisterFontPath(candidate);
 		if (handle) {
 			scr.font_pic = handle;
 			loadedName = candidate;
@@ -1972,7 +1983,7 @@ static void scr_font_changed(cvar_t* self)
 
 	if (!scr.font_pic && !attemptedLegacy) {
 		lastAttempt = SCR_LEGACY_FONT;
-		scr.font_pic = R_RegisterFont(SCR_LEGACY_FONT);
+		scr.font_pic = SCR_RegisterFontPath(SCR_LEGACY_FONT);
 		if (scr.font_pic)
 			loadedName = SCR_LEGACY_FONT;
 		attemptedLegacy = true;

--- a/src/client/ui/script.cpp
+++ b/src/client/ui/script.cpp
@@ -1221,7 +1221,7 @@ void UI_LoadScript(void)
         } else if (!Json_Strcmp(&parser, "font")) {
             Json_Next(&parser);
             char *font = Json_CopyStringUI(&parser);
-            uis.fontHandle = R_RegisterFont(font);
+            uis.fontHandle = SCR_RegisterFontPath(font);
             Z_Free(font);
         } else if (!Json_Strcmp(&parser, "cursor")) {
             Json_Next(&parser);

--- a/src/client/ui/ui.cpp
+++ b/src/client/ui/ui.cpp
@@ -607,7 +607,7 @@ void UI_Init(void)
 
     UI_ModeChanged();
 
-    uis.fontHandle = R_RegisterFont("conchars");
+    uis.fontHandle = SCR_RegisterFontPath("conchars");
     uis.cursorHandle = R_RegisterPic("ch1");
     R_GetPicSize(&uis.cursorWidth, &uis.cursorHeight, uis.cursorHandle);
 


### PR DESCRIPTION
## Summary
- add `SCR_RegisterFontPath` so font registrations respect leading-slash paths like other images
- update console, UI, and client-game font loading sites to route through the helper for consistent lookup

## Testing
- ninja -C build *(fails: build.ninja not generated in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691254ab9008832886f9a138481173d4)