### PR TITLE
Handle root-relative sound asset paths

### DIFF
--- a/src/client/download.cpp
+++ b/src/client/download.cpp
@@ -693,23 +693,28 @@ void CL_RequestNextDownload(void)
             }
         }
 
-        if (allow_download_sounds->integer) {
-            for (i = 1; i < cl.csr.max_sounds; i++) {
-                name = cl.configstrings[cl.csr.sounds + i];
-                if (!name[0]) {
-                    break;
-                }
-                if (name[0] == '*') {
-                    continue;
-                }
-                if (name[0] == '#') {
-                    len = Q_strlcpy(fn, name + 1, sizeof(fn));
-                } else {
-                    len = Q_concat(fn, sizeof(fn), "sound/", name);
-                }
-                check_file_len(fn, len, DL_OTHER);
-            }
-        }
+		if (allow_download_sounds->integer) {
+			for (i = 1; i < cl.csr.max_sounds; i++) {
+				name = cl.configstrings[cl.csr.sounds + i];
+				if (!name[0]) {
+					break;
+				}
+				if (name[0] == '*') {
+					continue;
+				}
+				if (name[0] == '#') {
+					len = FS_NormalizePathBuffer(fn, name + 1, sizeof(fn));
+				} else if (name[0] == '/' || name[0] == '\\') {
+					len = FS_NormalizePathBuffer(fn, name + 1, sizeof(fn));
+				} else {
+					len = Q_concat(fn, sizeof(fn), "sound/", name);
+					if (len < sizeof(fn)) {
+						len = FS_NormalizePath(fn);
+					}
+				}
+				check_file_len(fn, len, DL_OTHER);
+			}
+		}
 
         if (allow_download_pics->integer) {
             for (i = 1; i < cl.csr.max_images; i++) {

--- a/src/client/sound/SoundSystem.cpp
+++ b/src/client/sound/SoundSystem.cpp
@@ -173,51 +173,53 @@ void SoundSystem::BeginRegistration()
 
 qhandle_t SoundSystem::RegisterSound(const char *name)
 {
-    char buffer[MAX_QPATH];
-    size_t len;
+	char buffer[MAX_QPATH];
+	size_t len;
 
-    if (s_started == SoundBackend::Not) {
-        return 0;
-    }
+	if (s_started == SoundBackend::Not) {
+		return 0;
+	}
 
-    Q_assert(name);
+	Q_assert(name);
 
-    if (!*name) {
-        return 0;
-    }
+	if (!*name) {
+		return 0;
+	}
 
-    if (*name == '*') {
-        len = Q_strlcpy(buffer, name, MAX_QPATH);
-    } else if (*name == '#') {
-        len = FS_NormalizePathBuffer(buffer, name + 1, MAX_QPATH);
-    } else {
-        len = Q_concat(buffer, MAX_QPATH, "sound/", name);
-        if (len < MAX_QPATH) {
-            len = FS_NormalizePath(buffer);
-        }
-    }
+	if (*name == '*') {
+		len = Q_strlcpy(buffer, name, MAX_QPATH);
+	} else if (*name == '#') {
+		len = FS_NormalizePathBuffer(buffer, name + 1, MAX_QPATH);
+	} else if (*name == '/' || *name == '\\') {
+		len = FS_NormalizePathBuffer(buffer, name + 1, MAX_QPATH);
+	} else {
+		len = Q_concat(buffer, MAX_QPATH, "sound/", name);
+		if (len < MAX_QPATH) {
+			len = FS_NormalizePath(buffer);
+		}
+	}
 
-    if (len >= MAX_QPATH) {
-        Com_DPrintf("%s: oversize name\n", __func__);
-        return 0;
-    }
+	if (len >= MAX_QPATH) {
+		Com_DPrintf("%s: oversize name\n", __func__);
+		return 0;
+	}
 
-    if (len == 0) {
-        Com_DPrintf("%s: empty name\n", __func__);
-        return 0;
-    }
+	if (len == 0) {
+		Com_DPrintf("%s: empty name\n", __func__);
+		return 0;
+	}
 
-    sfx_t *sfx = FindOrAllocateSfx(buffer, len);
-    if (!sfx) {
-        Com_DPrintf("%s: out of slots\n", __func__);
-        return 0;
-    }
+	sfx_t *sfx = FindOrAllocateSfx(buffer, len);
+	if (!sfx) {
+		Com_DPrintf("%s: out of slots\n", __func__);
+		return 0;
+	}
 
-    if (!registering_) {
-        LoadSound(sfx);
-    }
+	if (!registering_) {
+		LoadSound(sfx);
+	}
 
-    return static_cast<qhandle_t>((sfx - known_sfx_.data()) + 1);
+	return static_cast<qhandle_t>((sfx - known_sfx_.data()) + 1);
 }
 
 sfx_t *SoundSystem::RegisterSexedSound(int entnum, const char *base)


### PR DESCRIPTION
## Summary
- normalize leading-slash sound names during registration so they match image handling
- update download checks to normalize root-relative sound paths before queuing

## Testing
- `ninja -C build test` *(fails: build.ninja not generated in repository)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69125b6b25408328bb72768344849621)