### PR TITLE
Add Q2Game directory fallback when loading fonts

### DIFF
--- a/src/common/files.cpp
+++ b/src/common/files.cpp
@@ -1587,6 +1587,15 @@ static int64_t expand_open_file_read(file_t *file, const char *name)
 	}
 
 	ret = open_file_read(file, normalized.data(), namelen);
+	if (ret == Q_ERR(ENOENT) && prefer_q2game) {
+		std::array<char, MAX_QPATH> q2game_path{};
+		size_t pref_len = Q_concat(q2game_path.data(), q2game_path.size(), "Q2Game/", normalized.data());
+		if (pref_len < q2game_path.size()) {
+			int64_t alt = open_file_read(file, q2game_path.data(), pref_len);
+			if (alt != Q_ERR(ENOENT))
+				return alt;
+		}
+	}
 	if (ret == Q_ERR(ENOENT)) {
 		// expand soft symlinks
 		if (expand_links(&fs_soft_links, normalized.data(), &namelen)) {
@@ -1599,6 +1608,15 @@ static int64_t expand_open_file_read(file_t *file, const char *name)
 					return ret;
 			}
 			ret = open_file_read(file, normalized.data(), namelen);
+			if (ret == Q_ERR(ENOENT) && prefer_q2game) {
+				std::array<char, MAX_QPATH> q2game_path{};
+				size_t pref_len = Q_concat(q2game_path.data(), q2game_path.size(), "Q2Game/", normalized.data());
+				if (pref_len < q2game_path.size()) {
+					int64_t alt = open_file_read(file, q2game_path.data(), pref_len);
+					if (alt != Q_ERR(ENOENT))
+						return alt;
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- fall back to loading font assets from the Q2Game directory when the standard search path misses them

## Testing
- ninja -C build *(fails: build.ninja is missing in this workspace)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912741046ac83288a320cdf2895421d)