### PR TITLE
Add smooth bloom knee control to brightpass shader

### DIFF
--- a/src/refresh/gl.hpp
+++ b/src/refresh/gl.hpp
@@ -499,6 +499,7 @@ extern cvar_t *r_bloom;
 extern cvar_t *r_bloomBlurRadius;
 extern cvar_t *r_bloomBlurFalloff;
 extern cvar_t *r_bloomBrightThreshold;
+extern cvar_t *r_bloomKnee;
 extern cvar_t *r_bloomIntensity;
 extern cvar_t *r_bloomScale;
 extern cvar_t *r_bloomKernel;

--- a/src/refresh/main.cpp
+++ b/src/refresh/main.cpp
@@ -87,6 +87,7 @@ cvar_t *r_bloom;
 cvar_t *r_bloomBlurRadius;
 cvar_t *r_bloomBlurFalloff;
 cvar_t *r_bloomBrightThreshold;
+cvar_t *r_bloomKnee;
 cvar_t *r_bloomIntensity;
 cvar_t *r_bloomScale;
 cvar_t *r_bloomKernel;
@@ -1894,7 +1895,8 @@ static void GL_Register(void)
     r_bloom = Cvar_Get("r_bloom", "1", CVAR_ARCHIVE);
     r_bloomBlurRadius = Cvar_Get("r_bloomBlurRadius", "12", CVAR_ARCHIVE);
     r_bloomBlurFalloff = Cvar_Get("r_bloomBlurFalloff", "0.75", CVAR_ARCHIVE);
-    r_bloomBrightThreshold = Cvar_Get("r_bloomBrightThreshold", "0.75", CVAR_ARCHIVE);
+	r_bloomBrightThreshold = Cvar_Get("r_bloomBrightThreshold", "0.75", CVAR_ARCHIVE);
+	r_bloomKnee = Cvar_Get("r_bloomKnee", "0.25", CVAR_ARCHIVE);
     r_bloomIntensity = Cvar_Get("r_bloomIntensity", "0.05", CVAR_ARCHIVE);
     r_bloomScale = Cvar_Get("r_bloomScale", "4.0", CVAR_ARCHIVE);
     r_bloomKernel = Cvar_Get("r_bloomKernel", "0", CVAR_ARCHIVE);

--- a/src/refresh/postprocess/bloom.cpp
+++ b/src/refresh/postprocess/bloom.cpp
@@ -254,23 +254,26 @@ void BloomEffect::render(const BloomRenderContext& ctx)
 
         const float invW = 1.0f / downsampleWidth_;
         const float invH = 1.0f / downsampleHeight_;
-        const float blurScale = (std::max)(r_bloomBlurScale->value, 0.0f);
+		const float blurScale = (std::max)(r_bloomBlurScale->value, 0.0f);
+		const float bloomKnee = Cvar_ClampValue(r_bloomKnee, 0.0f, 5.0f);
         const bool useBlur = blurScale > 0.0f;
         const int passes = (std::max)(static_cast<int>(Cvar_ClampValue(r_bloomPasses, 1.0f, 8.0f)), 1);
         const int kernelMode = static_cast<int>(Cvar_ClampValue(r_bloomKernel, 0.0f, 1.0f));
         const glStateBits_t blurMode = kernelMode == 0 ? GLS_BLUR_GAUSS : GLS_BLUR_BOX;
 
-        gls.u_block.bbr_params[0] = invW;
-        gls.u_block.bbr_params[1] = invH;
-        gls.u_block.bbr_params[2] = 0.0f;
+		gls.u_block.bbr_params[0] = invW;
+		gls.u_block.bbr_params[1] = invH;
+		gls.u_block.bbr_params[2] = 0.0f;
+		gls.u_block.bbr_params[3] = 0.0f;
         gls.u_block_dirty = true;
         GL_ForceTexture(TMU_TEXTURE, ctx.bloomTexture);
         qglBindFramebuffer(GL_FRAMEBUFFER, framebuffers_[DownsampleFbo]);
         GL_PostProcess(GLS_BLUR_BOX, 0, 0, downsampleWidth_, downsampleHeight_);
 
-        gls.u_block.bbr_params[0] = invW;
-        gls.u_block.bbr_params[1] = invH;
-        gls.u_block.bbr_params[2] = (std::max)(r_bloomBrightThreshold->value, 0.0f);
+		gls.u_block.bbr_params[0] = invW;
+		gls.u_block.bbr_params[1] = invH;
+		gls.u_block.bbr_params[2] = (std::max)(r_bloomBrightThreshold->value, 0.0f);
+		gls.u_block.bbr_params[3] = bloomKnee;
         gls.u_block_dirty = true;
         GL_ForceTexture(TMU_TEXTURE, textures_[Downsample]);
         GL_ForceTexture(TMU_LIGHTMAP, ctx.sceneTexture);

--- a/src/refresh/shader.cpp
+++ b/src/refresh/shader.cpp
@@ -1520,14 +1520,15 @@ static void write_fragment_shader(sizebuf_t *buf, glStateBits_t bits)
         else
             GLSL(vec4 diffuse = texture(u_texture, tc);)
 
-        if (bits & GLS_BLOOM_BRIGHTPASS) {
-            GLSL(vec4 scene = texture(u_scene, tc);)
-            GLSL(float luminance = dot(scene.rgb, bloom_luminance);)
-            GLSL(float threshold = u_bbr_params.z;)
-            GLSL(luminance = max(0.0, luminance - threshold);)
-            GLSL(diffuse.rgb *= sign(luminance);)
-            GLSL(diffuse.a = 1.0;)
-        }
+		if (bits & GLS_BLOOM_BRIGHTPASS) {
+			GLSL(vec4 scene = texture(u_scene, tc);)
+			GLSL(float luminance = dot(scene.rgb, bloom_luminance);)
+			GLSL(float threshold = u_bbr_params.z;)
+			GLSL(float knee = max(u_bbr_params.w, 0.0001);)
+			GLSL(float weight = smoothstep(0.0, knee, luminance - threshold);)
+			GLSL(diffuse.rgb *= weight;)
+			GLSL(diffuse.a = weight;)
+		}
     }
 
     if (bits & GLS_ALPHATEST_ENABLE)


### PR DESCRIPTION
## Summary
- add an `r_bloomKnee` cvar and expose it through the bloom uniform block
- update the bloom brightpass shader to use a smoothstep-based knee instead of a hard sign gate
- populate the knee parameter when running the bloom passes so artists can tune the threshold rolloff

## Testing
- not run (HDR/SDR inspection requires the full renderer)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69131db30e988328b5e3353a670f171e)