### PR TITLE
Preserve GL state around bloom rendering

### DIFF
--- a/src/refresh/postprocess/bloom.cpp
+++ b/src/refresh/postprocess/bloom.cpp
@@ -222,86 +222,143 @@ bool BloomEffect::resize(int sceneWidth, int sceneHeight)
         return true;
 }
 
+/*
+=============
+BloomEffect::render
+
+Renders the bloom post-processing passes while preserving the caller state.
+=============
+*/
 void BloomEffect::render(const BloomRenderContext& ctx)
 {
-        if (ctx.viewportWidth <= 0 || ctx.viewportHeight <= 0)
-                return;
+	GLint prevFbo = 0;
+	GLint prevViewport[4] = { 0, 0, 0, 0 };
+	qglGetIntegerv(GL_FRAMEBUFFER_BINDING, &prevFbo);
+	qglGetIntegerv(GL_VIEWPORT, prevViewport);
 
-        const bool canRunDepthOfField = ctx.depthOfField && !ctx.showDebug && ctx.runDepthOfField;
-        if (ctx.sceneTexture == 0) {
-                if (canRunDepthOfField)
-                        ctx.runDepthOfField();
-                CompositeBloom(ctx, ctx.sceneTexture, ctx.showDebug ? ctx.bloomTexture : 0, false);
-                return;
-        }
+	const GLuint prevTexture = gls.texnums[TMU_TEXTURE];
+	const GLuint prevLightmap = gls.texnums[TMU_LIGHTMAP];
+	const GLuint prevGlowmap = gls.texnums[TMU_GLOWMAP];
 
-        const bool bloomReady = initialized_ && downsampleWidth_ > 0 && downsampleHeight_ > 0 && ctx.bloomTexture != 0;
-        const auto runDepthOfField = [&]() {
-                if (canRunDepthOfField)
-                        ctx.runDepthOfField();
-        };
+	const auto restoreState = [&]() {
+		if (prevFbo >= 0)
+			qglBindFramebuffer(GL_FRAMEBUFFER, static_cast<GLuint>(prevFbo));
+		qglViewport(prevViewport[0], prevViewport[1], prevViewport[2], prevViewport[3]);
+		GL_ForceTexture(TMU_TEXTURE, prevTexture);
+		GL_ForceTexture(TMU_LIGHTMAP, prevLightmap);
+		GL_ForceTexture(TMU_GLOWMAP, prevGlowmap);
+	};
 
-        if (!bloomReady) {
-                runDepthOfField();
-                const GLuint colorTexture = (canRunDepthOfField && ctx.dofTexture) ? ctx.dofTexture : ctx.sceneTexture;
-                const GLuint debugTexture = ctx.showDebug ? ctx.bloomTexture : 0;
-                CompositeBloom(ctx, colorTexture, debugTexture, false);
-                return;
-        }
+	if (ctx.viewportWidth <= 0 || ctx.viewportHeight <= 0) {
+		restoreState();
+		return;
+	}
 
-        qglViewport(0, 0, downsampleWidth_, downsampleHeight_);
-        GL_Ortho(0, downsampleWidth_, downsampleHeight_, 0, -1, 1);
+	const bool canRunDepthOfField = ctx.depthOfField && !ctx.showDebug && ctx.runDepthOfField;
+	if (ctx.sceneTexture == 0) {
+		if (canRunDepthOfField)
+			ctx.runDepthOfField();
+		CompositeBloom(ctx, ctx.sceneTexture, ctx.showDebug ? ctx.bloomTexture : 0, false);
+		GL_ShowErrors("Bloom pass");
+		restoreState();
+		return;
+	}
 
-        const float invW = 1.0f / downsampleWidth_;
-        const float invH = 1.0f / downsampleHeight_;
-		const float blurScale = (std::max)(r_bloomBlurScale->value, 0.0f);
-		const float bloomKnee = Cvar_ClampValue(r_bloomKnee, 0.0f, 5.0f);
-        const bool useBlur = blurScale > 0.0f;
-        const int passes = (std::max)(static_cast<int>(Cvar_ClampValue(r_bloomPasses, 1.0f, 8.0f)), 1);
-        const int kernelMode = static_cast<int>(Cvar_ClampValue(r_bloomKernel, 0.0f, 1.0f));
-        const glStateBits_t blurMode = kernelMode == 0 ? GLS_BLUR_GAUSS : GLS_BLUR_BOX;
+	const bool bloomReady = initialized_ && downsampleWidth_ > 0 && downsampleHeight_ > 0 && ctx.bloomTexture != 0;
+	const auto runDepthOfField = [&]() {
+		if (canRunDepthOfField)
+			ctx.runDepthOfField();
+	};
 
-		gls.u_block.bbr_params[0] = invW;
-		gls.u_block.bbr_params[1] = invH;
-		gls.u_block.bbr_params[2] = 0.0f;
-		gls.u_block.bbr_params[3] = 0.0f;
-        gls.u_block_dirty = true;
-        GL_ForceTexture(TMU_TEXTURE, ctx.bloomTexture);
-        qglBindFramebuffer(GL_FRAMEBUFFER, framebuffers_[DownsampleFbo]);
-        GL_PostProcess(GLS_BLUR_BOX, 0, 0, downsampleWidth_, downsampleHeight_);
+	if (!bloomReady) {
+		runDepthOfField();
+		const GLuint colorTexture = (canRunDepthOfField && ctx.dofTexture) ? ctx.dofTexture : ctx.sceneTexture;
+		const GLuint debugTexture = ctx.showDebug ? ctx.bloomTexture : 0;
+		CompositeBloom(ctx, colorTexture, debugTexture, false);
+		GL_ShowErrors("Bloom pass");
+		restoreState();
+		return;
+	}
 
+	bool bloomFailed = false;
+
+	qglViewport(0, 0, downsampleWidth_, downsampleHeight_);
+	GL_Ortho(0, downsampleWidth_, downsampleHeight_, 0, -1, 1);
+
+	const float invW = 1.0f / downsampleWidth_;
+	const float invH = 1.0f / downsampleHeight_;
+	const float blurScale = (std::max)(r_bloomBlurScale->value, 0.0f);
+	const float bloomKnee = Cvar_ClampValue(r_bloomKnee, 0.0f, 5.0f);
+	const bool useBlur = blurScale > 0.0f;
+	const int passes = (std::max)(static_cast<int>(Cvar_ClampValue(r_bloomPasses, 1.0f, 8.0f)), 1);
+	const int kernelMode = static_cast<int>(Cvar_ClampValue(r_bloomKernel, 0.0f, 1.0f));
+	const glStateBits_t blurMode = kernelMode == 0 ? GLS_BLUR_GAUSS : GLS_BLUR_BOX;
+
+	gls.u_block.bbr_params[0] = invW;
+	gls.u_block.bbr_params[1] = invH;
+	gls.u_block.bbr_params[2] = 0.0f;
+	gls.u_block.bbr_params[3] = 0.0f;
+	gls.u_block_dirty = true;
+	GL_ForceTexture(TMU_TEXTURE, ctx.bloomTexture);
+	qglBindFramebuffer(GL_FRAMEBUFFER, framebuffers_[DownsampleFbo]);
+	GL_PostProcess(GLS_BLUR_BOX, 0, 0, downsampleWidth_, downsampleHeight_);
+	if (GL_ShowErrors("Bloom pass"))
+		bloomFailed = true;
+
+	if (!bloomFailed) {
 		gls.u_block.bbr_params[0] = invW;
 		gls.u_block.bbr_params[1] = invH;
 		gls.u_block.bbr_params[2] = (std::max)(r_bloomBrightThreshold->value, 0.0f);
 		gls.u_block.bbr_params[3] = bloomKnee;
-        gls.u_block_dirty = true;
-        GL_ForceTexture(TMU_TEXTURE, textures_[Downsample]);
-        GL_ForceTexture(TMU_LIGHTMAP, ctx.sceneTexture);
-        qglBindFramebuffer(GL_FRAMEBUFFER, framebuffers_[BrightPassFbo]);
-        GL_PostProcess(GLS_BLOOM_BRIGHTPASS, 0, 0, downsampleWidth_, downsampleHeight_);
+		gls.u_block_dirty = true;
+		GL_ForceTexture(TMU_TEXTURE, textures_[Downsample]);
+		GL_ForceTexture(TMU_LIGHTMAP, ctx.sceneTexture);
+		qglBindFramebuffer(GL_FRAMEBUFFER, framebuffers_[BrightPassFbo]);
+		GL_PostProcess(GLS_BLOOM_BRIGHTPASS, 0, 0, downsampleWidth_, downsampleHeight_);
+		if (GL_ShowErrors("Bloom pass"))
+			bloomFailed = true;
+	}
 
-        GLuint currentTexture = textures_[BrightPass];
-        if (useBlur) {
-                const float texelScale = blurScale;
-                for (int pass = 0; pass < passes; ++pass) {
-                        for (int axis = 0; axis < 2; ++axis) {
-                                const bool horizontal = axis == 0;
-                                gls.u_block.bbr_params[0] = horizontal ? invW * texelScale : 0.0f;
-                                gls.u_block.bbr_params[1] = horizontal ? 0.0f : invH * texelScale;
-                                gls.u_block_dirty = true;
-                                GL_ForceTexture(TMU_TEXTURE, currentTexture);
-                                qglBindFramebuffer(GL_FRAMEBUFFER, framebuffers_[BlurFbo0 + axis]);
-                                GL_PostProcess(blurMode, 0, 0, downsampleWidth_, downsampleHeight_);
-                                currentTexture = textures_[Blur0 + axis];
-                        }
-                }
-        }
+	GLuint currentTexture = textures_[BrightPass];
+	if (!bloomFailed && useBlur) {
+		const float texelScale = blurScale;
+		for (int pass = 0; pass < passes && !bloomFailed; ++pass) {
+			for (int axis = 0; axis < 2; ++axis) {
+				const bool horizontal = axis == 0;
+				gls.u_block.bbr_params[0] = horizontal ? invW * texelScale : 0.0f;
+				gls.u_block.bbr_params[1] = horizontal ? 0.0f : invH * texelScale;
+				gls.u_block_dirty = true;
+				GL_ForceTexture(TMU_TEXTURE, currentTexture);
+				qglBindFramebuffer(GL_FRAMEBUFFER, framebuffers_[BlurFbo0 + axis]);
+				GL_PostProcess(blurMode, 0, 0, downsampleWidth_, downsampleHeight_);
+				if (GL_ShowErrors("Bloom pass")) {
+					bloomFailed = true;
+					break;
+				}
+				currentTexture = textures_[Blur0 + axis];
+			}
+		}
+	}
 
-        const GLuint bloomTexture = currentTexture;
+	if (bloomFailed) {
+		runDepthOfField();
+		const GLuint colorTexture = (canRunDepthOfField && ctx.dofTexture) ? ctx.dofTexture : ctx.sceneTexture;
+		const GLuint debugTexture = ctx.showDebug ? ctx.bloomTexture : 0;
+		CompositeBloom(ctx, colorTexture, debugTexture, false);
+		GL_ShowErrors("Bloom pass");
+		restoreState();
+		return;
+	}
 
-        runDepthOfField();
+	const GLuint bloomTexture = currentTexture;
 
-        const GLuint colorTexture = (canRunDepthOfField && ctx.dofTexture) ? ctx.dofTexture : ctx.sceneTexture;
-        CompositeBloom(ctx, colorTexture, bloomTexture, true);
+	runDepthOfField();
+
+	const GLuint colorTexture = (canRunDepthOfField && ctx.dofTexture) ? ctx.dofTexture : ctx.sceneTexture;
+	CompositeBloom(ctx, colorTexture, bloomTexture, true);
+	GL_ShowErrors("Bloom pass");
+	restoreState();
 }
+
+
 


### PR DESCRIPTION
## Summary
- cache and restore framebuffer, viewport, and texture bindings around the bloom render pass
- report GL errors after each bloom post-process stage and fall back to a safe composite if a pass fails
- document the bloom render entry point for clarity

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691320c106bc832886987314ef38d586)