### PR TITLE
Defer text backend activation until media registration

### DIFF
--- a/src/client/client.hpp
+++ b/src/client/client.hpp
@@ -1289,6 +1289,7 @@ void    SCR_Shutdown(void);
 void    SCR_InitFontSystem(void);
 void    SCR_ShutdownFontSystem(void);
 void    SCR_RefreshFontCvar(void);
+void    SCR_ApplyTextBackend(void);
 void    SCR_UpdateScreen(void);
 void    SCR_SizeUp(void);
 void    SCR_SizeDown(void);

--- a/src/client/font.cpp
+++ b/src/client/font.cpp
@@ -698,12 +698,41 @@ static void scr_font_changed(cvar_t* self)
 		return;
 	}
 }
+/*
+=============
+SCR_RefreshFontCvar
+
+Refreshes the currently configured screen font from the associated cvar.
+=============
+*/
 void SCR_RefreshFontCvar(void)
 {
 	if (scr_font)
 		scr_font_changed(scr_font);
 }
 
+/*
+=============
+SCR_ApplyTextBackend
+
+Ensures the active text backend matches the configured cvar value.
+=============
+*/
+void SCR_ApplyTextBackend(void)
+{
+#if USE_FREETYPE
+	if (scr_text_backend)
+		scr_text_backend_changed(scr_text_backend);
+#endif
+}
+
+/*
+=============
+SCR_InitFontSystem
+
+Initializes font-related configuration cvars and callbacks.
+=============
+*/
 void SCR_InitFontSystem(void)
 {
 #if USE_FREETYPE
@@ -719,7 +748,6 @@ void SCR_InitFontSystem(void)
 	if (scr_text_backend) {
 		scr_text_backend->changed = scr_text_backend_changed;
 		scr_text_backend->generator = scr_text_backend_g;
-		scr_text_backend_changed(scr_text_backend);
 	}
 #endif
 }

--- a/src/client/screen.cpp
+++ b/src/client/screen.cpp
@@ -1210,9 +1210,10 @@ void SCR_RegisterMedia(void)
 	if (cgame)
 		cgame->TouchPics();
 
-        SCR_LoadKFont(&scr.kfont, "/fonts/qconfont.kfont");
+	SCR_LoadKFont(&scr.kfont, "/fonts/qconfont.kfont");
 
-        SCR_RefreshFontCvar();
+	SCR_RefreshFontCvar();
+	SCR_ApplyTextBackend();
 
 }
 


### PR DESCRIPTION
## Summary
- add SCR_ApplyTextBackend helper so the text backend is activated after fonts and fallbacks are ready
- call the helper from SCR_RegisterMedia after loading the kfont fallback and refreshing the font cvar
- document font helper functions with headers while keeping initialization wiring intact

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69132c47c5848328b3dc5e453ca60304)