### PR TITLE
Handle framebuffer allocation failures

### DIFF
--- a/src/refresh/main.cpp
+++ b/src/refresh/main.cpp
@@ -1571,8 +1571,19 @@ static pp_flags_t GL_BindFramebuffer(void)
 			if (!GL_UpdateBloomEffect(bloom_ready, drawable_w, drawable_h))
 				flags = static_cast<pp_flags_t>(flags & ~PP_BLOOM);
 		}
-		if (flags & PP_BLOOM)
-			gl_backend->update_blur();
+		if (glr.framebuffer_ok) {
+			if (flags & PP_BLOOM)
+				gl_backend->update_blur();
+		} else {
+			if (flags & PP_HDR) {
+				const bool formats_changed = gl_static.hdr.active;
+				gl_static.hdr.active = false;
+				if (formats_changed)
+					HDR_UpdatePostprocessFormats();
+			}
+
+			flags = PP_NONE;
+		}
 	}
 
 	if (!flags || !glr.framebuffer_ok)


### PR DESCRIPTION
## Summary
- verify framebuffer generation results and disable post-processing when allocation fails
- bail out of GL_InitFramebuffers early if any FBO identifier is missing, with diagnostics
- ensure HDR/bloom setup respects framebuffer availability when initialization fails

## Testing
- ninja -C WORR/build *(fails: build.ninja is missing)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69137e71dbb08328810821b525a39753)