### PR TITLE
Add runtime toggle for renderer FBO features

### DIFF
--- a/src/refresh/gl.hpp
+++ b/src/refresh/gl.hpp
@@ -494,6 +494,7 @@ extern cvar_t *gl_md5_distance;
 extern cvar_t *gl_damageblend_frac;
 extern cvar_t *r_skipUnderWaterFX;
 extern cvar_t *r_shadows;
+extern cvar_t *r_fbo;
 extern cvar_t *r_postProcessing;
 extern cvar_t *r_bloom;
 extern cvar_t *r_bloomBlurRadius;
@@ -1248,6 +1249,7 @@ void GL_InitImages(void);
 void GL_ShutdownImages(void);
 
 bool GL_InitFramebuffers(void);
+void GL_DisableFramebuffers(void);
 
 extern cvar_t *gl_intensity;
 

--- a/src/refresh/postprocess/crt.cpp
+++ b/src/refresh/postprocess/crt.cpp
@@ -74,10 +74,17 @@ namespace {
         }
 } // namespace
 
+/*
+=============
+R_CRTEnabled
+
+Determines whether CRT post-processing is active.
+=============
+*/
 [[nodiscard]] bool R_CRTEnabled() noexcept
 {
-        return gl_static.use_shaders && r_postProcessing && r_postProcessing->integer &&
-                r_crtmode && r_crtmode->integer == 1;
+	return gl_static.use_shaders && r_postProcessing && r_postProcessing->integer &&
+		r_fbo && r_fbo->integer && r_crtmode && r_crtmode->integer == 1;
 }
 
 glStateBits_t R_CRTPrepare(glStateBits_t bits, int viewportWidth, int viewportHeight)


### PR DESCRIPTION
## Summary
- add an r_fbo cvar that lets the renderer bypass framebuffer-based post processing when disabled
- release framebuffer, bloom, HDR, and motion history resources whenever the toggle is turned off and skip FBO setup while disabled
- guard CRT, motion blur history bindings, and other post-process flags so they ignore FBO features when the toggle is off

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69137e6c25108328aa98ec5042e7386e)