### PR TITLE
Ensure scene FBO has an active draw buffer

### DIFF
--- a/src/refresh/main.cpp
+++ b/src/refresh/main.cpp
@@ -1626,6 +1626,9 @@ static pp_flags_t GL_BindFramebuffer(void)
 	qglBindFramebuffer(GL_FRAMEBUFFER, FBO_SCENE);
 	glr.framebuffer_bound = true;
 
+	static const GLenum scene_draw_buffers[] = { GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT1 };
+	qglDrawBuffers(1, scene_draw_buffers);
+
 	if (gl_clear->integer) {
 		if (flags & PP_BLOOM) {
 			static const GLenum buffers[2] = { GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT1 };


### PR DESCRIPTION
## Summary
- set the scene framebuffer draw buffer to color attachment 0 whenever it is bound
- keep the existing clear path for bloom while ensuring color writes are enabled for HDR/CRT passes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69138a0f2fb8832890f11ac6cf142543)