### PR TITLE
Fix image fallback name restoration during format search

### DIFF
--- a/src/refresh/images.cpp
+++ b/src/refresh/images.cpp
@@ -1895,11 +1895,22 @@ static int load_image_data(image_t* image, imageformat_t fmt, bool need_dimensio
 	const size_t baselen = image->baselen;
 	const bool had_extension = image->name[baselen] == '.';
 	char original_ext[4] = { 0 };
+	char original_name[sizeof(image->name)] = { 0 };
+	char base_name[sizeof(image->name)] = { 0 };
+	bool have_base_name = false;
 	bool stripped = false;
 	int ret;
 
 	if (had_extension)
 		memcpy(original_ext, image->name + baselen + 1, sizeof(original_ext));
+
+	Q_strlcpy(original_name, image->name, sizeof(original_name));
+
+	if (baselen < sizeof(base_name)) {
+		memcpy(base_name, image->name, baselen);
+		base_name[baselen] = '\0';
+		have_base_name = true;
+	}
 
 #if USE_PNG || USE_JPG || USE_TGA
 	bool need_fallback = true;
@@ -1963,7 +1974,11 @@ static int load_image_data(image_t* image, imageformat_t fmt, bool need_dimensio
 
 	if (ret < 0) {
 		if (ret == Q_ERR(ENOENT) || ret == Q_ERR_INVALID_PATH) {
-			memcpy(image->name, base_name, baselen + 1);
+			if (have_base_name) {
+				memcpy(image->name, base_name, baselen + 1);
+			} else {
+				Q_strlcpy(image->name, original_name, sizeof(image->name));
+			}
 		} else if (had_extension) {
 			Q_strlcpy(image->name, original_name, sizeof(image->name));
 		}


### PR DESCRIPTION
## Summary
- capture the original image name and base name when loading assets so they can be restored after fallback attempts
- guard against reading past buffers by tracking when the base name copy is valid

## Testing
- `meson compile -C build` *(fails: wrap-redirect subprojects/freetype-2.13.3/subprojects/zlib.wrap filename does not exist)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913ad21c7f8832896041acec365abd1)