### PR TITLE
Fix bloom luminance GLSL declaration

### DIFF
--- a/src/refresh/shader.cpp
+++ b/src/refresh/shader.cpp
@@ -1528,8 +1528,7 @@ static void write_fragment_shader(sizebuf_t *buf, glStateBits_t bits)
         });
     }
 
-    if (bits & (GLS_BLOOM_BRIGHTPASS | GLS_BLOOM_OUTPUT))
-        GLSL(const vec3 bloom_luminance = vec3(0.2125, 0.7154, 0.0721);)
+	GLSL(const vec3 bloom_luminance = vec3(0.2125, 0.7154, 0.0721);)
 
     GLSF("void main() {\n");
     if (bits & GLS_CLASSIC_SKY) {


### PR DESCRIPTION
## Summary
- define the bloom luminance constant for every fragment shader permutation so the GLSL compiler sees it when bloom is disabled

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69142041f1a08328942bf7305f8dac37)