### PR TITLE
Ensure fragment shaders always define uniform block

### DIFF
--- a/src/refresh/shader.cpp
+++ b/src/refresh/shader.cpp
@@ -1400,10 +1400,9 @@ static void write_fragment_shader(sizebuf_t *buf, glStateBits_t bits)
         return;
     }
 
-    write_header(buf, bits);
+	write_header(buf, bits);
 
-    if (bits & GLS_UNIFORM_MASK)
-        write_block(buf, bits);
+	write_block(buf, bits);
 
     if (bits & GLS_TONEMAP_ENABLE)
         write_tonemap_block(buf);


### PR DESCRIPTION
## Summary
- always emit the global uniform block when generating fragment shaders

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914b76b8ff883288c65c2d57223c2e5)