### PR TITLE
Fix texture format list construction

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -465,7 +465,7 @@ png = dependency('libpng',
   default_options: fallback_opt,
 )
 if png.found()
-  texture_formats += 'png'
+  texture_formats.append('png')
 endif
 
 config.set10('USE_ZLIB', zlib.found())
@@ -556,13 +556,13 @@ if jpeg.found()
   endif
   if has_rgba
     client_deps += jpeg
-    texture_formats += 'jpg'
+    texture_formats.append('jpg')
     config.set10('USE_JPG', true)
   endif
 endif
 
 if get_option('tga')
-  texture_formats += 'tga'
+  texture_formats.append('tga')
 endif
 
 openal = dependency('openal',


### PR DESCRIPTION
## Summary
- ensure texture_formats contains complete extension names so PNG/JPG/TGA support is registered correctly

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691572d8e9c083289c5e575dad226dd1)