### PR TITLE
Restore active texture unit after bloom rendering

### DIFF
--- a/src/refresh/postprocess/bloom.cpp
+++ b/src/refresh/postprocess/bloom.cpp
@@ -239,6 +239,7 @@ void BloomEffect::render(const BloomRenderContext& ctx)
 	const GLuint prevTexture = gls.texnums[TMU_TEXTURE];
 	const GLuint prevLightmap = gls.texnums[TMU_LIGHTMAP];
 	const GLuint prevGlowmap = gls.texnums[TMU_GLOWMAP];
+	const glTmu_t prevActiveTmu = gls.server_tmu;
 
 	const auto restoreState = [&]() {
 		if (prevFbo >= 0)
@@ -247,6 +248,7 @@ void BloomEffect::render(const BloomRenderContext& ctx)
 		GL_ForceTexture(TMU_TEXTURE, prevTexture);
 		GL_ForceTexture(TMU_LIGHTMAP, prevLightmap);
 		GL_ForceTexture(TMU_GLOWMAP, prevGlowmap);
+		GL_ActiveTexture(prevActiveTmu);
 	};
 
 	if (ctx.viewportWidth <= 0 || ctx.viewportHeight <= 0) {


### PR DESCRIPTION
## Summary
- cache the previously active texture unit when entering bloom rendering
- restore the cached unit after rebinding the saved textures so later operations target the intended TMU

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915b76abb788328ac6c2569013ba62d)