### PR TITLE
Handle HDR luminance resource allocation failures

### DIFF
--- a/src/refresh/postprocess/hdr_luminance.hpp
+++ b/src/refresh/postprocess/hdr_luminance.hpp
@@ -7,6 +7,7 @@
 class HdrLuminanceReducer {
 public:
 	HdrLuminanceReducer() noexcept = default;
+	~HdrLuminanceReducer() noexcept;
 
 	void shutdown() noexcept;
 	bool resize(int width, int height) noexcept;


### PR DESCRIPTION
## Summary
- ensure the HDR luminance reducer cleans up partially initialized resources during destruction
- validate texture and framebuffer handle generation during resize and log/abort when allocation fails

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915bfc1631c8328abf5c95224dd2b5a)