### PR TITLE
Guard bloom MRT usage when glDrawBuffers unavailable

### DIFF
--- a/src/refresh/gl.hpp
+++ b/src/refresh/gl.hpp
@@ -292,6 +292,7 @@ typedef enum {
     QGL_CAP_LINE_SMOOTH                 = BIT(12),
     QGL_CAP_BUFFER_TEXTURE              = BIT(13),
     QGL_CAP_SHADER_STORAGE              = BIT(14),
+    QGL_CAP_DRAW_BUFFERS                = BIT(15),
     QGL_CAP_SKELETON_MASK               = QGL_CAP_BUFFER_TEXTURE | QGL_CAP_SHADER_STORAGE,
 } glcap_t;
 

--- a/src/refresh/main.cpp
+++ b/src/refresh/main.cpp
@@ -1550,7 +1550,7 @@ static pp_flags_t GL_BindFramebuffer(void)
 	if ((glr.fd.rdflags & RDF_UNDERWATER) && !r_skipUnderWaterFX->integer)
 		flags |= PP_WATERWARP;
 
-	if (r_bloom->integer)
+	if (r_bloom->integer && (gl_config.caps & QGL_CAP_DRAW_BUFFERS) && qglDrawBuffers)
 		flags |= PP_BLOOM;
 
 	if (dof_active)
@@ -1628,7 +1628,11 @@ static pp_flags_t GL_BindFramebuffer(void)
 
 	static const GLenum scene_draw_buffers[] = { GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT1 };
 	const GLsizei scene_draw_buffer_count = (flags & PP_BLOOM) ? 2 : 1;
-	qglDrawBuffers(scene_draw_buffer_count, scene_draw_buffers);
+	if (qglDrawBuffers) {
+		qglDrawBuffers(scene_draw_buffer_count, scene_draw_buffers);
+	} else if (qglDrawBuffer) {
+		qglDrawBuffer(GL_COLOR_ATTACHMENT0);
+	}
 	if (qglReadBuffer)
 		qglReadBuffer(GL_COLOR_ATTACHMENT0);
 
@@ -1636,10 +1640,18 @@ static pp_flags_t GL_BindFramebuffer(void)
 		if (flags & PP_BLOOM) {
 			static const GLenum buffers[2] = { GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT1 };
 			static const vec4_t black = { 0, 0, 0, 1 };
-			qglDrawBuffers(2, buffers);
+			if (qglDrawBuffers) {
+				qglDrawBuffers(2, buffers);
+			} else if (qglDrawBuffer) {
+				qglDrawBuffer(GL_COLOR_ATTACHMENT0);
+			}
 			qglClearBufferfv(GL_COLOR, 0, gl_static.clearcolor);
 			qglClearBufferfv(GL_COLOR, 1, black);
-			qglDrawBuffers(scene_draw_buffer_count, scene_draw_buffers);
+			if (qglDrawBuffers) {
+				qglDrawBuffers(scene_draw_buffer_count, scene_draw_buffers);
+			} else if (qglDrawBuffer) {
+				qglDrawBuffer(GL_COLOR_ATTACHMENT0);
+			}
 		} else {
 			qglClear(GL_COLOR_BUFFER_BIT);
 		}

--- a/src/refresh/mesh.cpp
+++ b/src/refresh/mesh.cpp
@@ -698,7 +698,7 @@ static void draw_alias_mesh(const uint16_t *indices, int num_indices,
     if (skin->texnum2)
         state |= GLS_GLOWMAP_ENABLE;
 
-    if (glr.framebuffer_bound && r_bloom->integer) {
+	if (glr.framebuffer_bound && r_bloom->integer && (gl_config.caps & QGL_CAP_DRAW_BUFFERS) && qglDrawBuffers) {
         state |= GLS_BLOOM_GENERATE;
         if (glr.ent->flags & RF_SHELL_MASK)
             state |= GLS_BLOOM_SHELL;

--- a/src/refresh/qgl.cpp
+++ b/src/refresh/qgl.cpp
@@ -60,6 +60,7 @@ static constexpr glfunction_t kGl11Functions[] = {
     QGL_FN(DepthMask),
     QGL_FN(Disable),
     QGL_FN(DrawArrays),
+    QGL_FN(DrawBuffer),
     QGL_FN(DrawElements),
     QGL_FN(Enable),
     QGL_FN(Finish),
@@ -382,6 +383,7 @@ static const glsection_t sections[] = {
     {
         .ver_gl = QGL_VER(2, 0),
         .ver_es = QGL_VER(2, 0),
+        .caps = QGL_CAP_DRAW_BUFFERS,
         .functions = kGl20Functions
     },
 

--- a/src/refresh/qgl.hpp
+++ b/src/refresh/qgl.hpp
@@ -126,6 +126,7 @@ QGLAPI GLuint (APIENTRYP qglCreateProgram)(void);
 QGLAPI GLuint (APIENTRYP qglCreateShader)(GLenum type);
 QGLAPI void (APIENTRYP qglDeleteProgram)(GLuint program);
 QGLAPI void (APIENTRYP qglDeleteShader)(GLuint shader);
+QGLAPI void (APIENTRYP qglDrawBuffer)(GLenum buf);
 QGLAPI void (APIENTRYP qglDrawBuffers)(GLsizei n, const GLenum *bufs);
 QGLAPI void (APIENTRYP qglDisableVertexAttribArray)(GLuint index);
 QGLAPI void (APIENTRYP qglEnableVertexAttribArray)(GLuint index);

--- a/src/refresh/shader.cpp
+++ b/src/refresh/shader.cpp
@@ -1993,14 +1993,18 @@ static void shader_state_bits(glStateBits_t bits)
         gls.u_block_dirty = true;
     }
 
-    if (diff & GLS_BLOOM_GENERATE && glr.framebuffer_bound) {
-        static constexpr GLenum bloom_targets[] = {
-            GL_COLOR_ATTACHMENT0,
-            GL_COLOR_ATTACHMENT1,
-        };
-        int n = (bits & GLS_BLOOM_GENERATE) ? 2 : 1;
-        qglDrawBuffers(n, bloom_targets);
-    }
+	if (diff & GLS_BLOOM_GENERATE && glr.framebuffer_bound) {
+		static constexpr GLenum bloom_targets[] = {
+			GL_COLOR_ATTACHMENT0,
+			GL_COLOR_ATTACHMENT1,
+		};
+		int n = (bits & GLS_BLOOM_GENERATE) ? 2 : 1;
+		if (qglDrawBuffers) {
+			qglDrawBuffers(n, bloom_targets);
+		} else if (qglDrawBuffer) {
+			qglDrawBuffer(GL_COLOR_ATTACHMENT0);
+		}
+	}
 }
 
 static void shader_array_bits(glArrayBits_t bits)

--- a/src/refresh/shadow.cpp
+++ b/src/refresh/shadow.cpp
@@ -359,7 +359,11 @@ void render_shadow_views()
 
 	qglBindFramebuffer(GL_FRAMEBUFFER, gl_static.shadow.framebuffer);
 	const GLenum no_buffers = GL_NONE;
-	qglDrawBuffers(1, &no_buffers);
+	if (qglDrawBuffers) {
+		qglDrawBuffers(1, &no_buffers);
+	} else if (qglDrawBuffer) {
+		qglDrawBuffer(GL_NONE);
+	}
 	if (has_read_buffer)
 		qglReadBuffer(GL_NONE);
 	qglColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
@@ -446,7 +450,11 @@ void render_shadow_views()
 
 	qglBindFramebuffer(GL_FRAMEBUFFER, prev_fbo);
 	GLenum prev_draw_buffer_enum = static_cast<GLenum>(prev_draw_buffer);
-	qglDrawBuffers(1, &prev_draw_buffer_enum);
+	if (qglDrawBuffers) {
+		qglDrawBuffers(1, &prev_draw_buffer_enum);
+	} else if (qglDrawBuffer) {
+		qglDrawBuffer(prev_draw_buffer_enum);
+	}
 	if (has_read_buffer)
 		qglReadBuffer(prev_read_buffer);
 	qglViewport(prev_viewport[0], prev_viewport[1], prev_viewport[2], prev_viewport[3]);

--- a/src/refresh/sky.cpp
+++ b/src/refresh/sky.cpp
@@ -334,7 +334,7 @@ void R_DrawSkyBox(void)
 
     glStateBits_t bits = GLS_TEXTURE_REPLACE | glr.fog_bits_sky;
 
-    if (glr.framebuffer_bound && r_bloom->integer)
+	if (glr.framebuffer_bound && r_bloom->integer && (gl_config.caps & QGL_CAP_DRAW_BUFFERS) && qglDrawBuffers)
         bits |= GLS_BLOOM_GENERATE;
 
     GL_BindArrays(VA_SPRITE);

--- a/src/refresh/tess.cpp
+++ b/src/refresh/tess.cpp
@@ -214,7 +214,7 @@ static void GL_FlushBeamSegments(void)
     else
         array |= GLA_TC;
 
-    if (glr.framebuffer_bound && r_bloom->integer)
+	if (glr.framebuffer_bound && r_bloom->integer && (gl_config.caps & QGL_CAP_DRAW_BUFFERS) && qglDrawBuffers)
         state |= GLS_BLOOM_GENERATE | GLS_BLOOM_SHELL;
 
     GL_BindTexture(TMU_TEXTURE, texnum);
@@ -691,7 +691,7 @@ void GL_Flush3D(void)
         array |= GLA_NORMAL;
     }
 
-    if (glr.framebuffer_bound && r_bloom->integer)
+	if (glr.framebuffer_bound && r_bloom->integer && (gl_config.caps & QGL_CAP_DRAW_BUFFERS) && qglDrawBuffers)
         state |= GLS_BLOOM_GENERATE;
 
     if (!(state & GLS_TEXTURE_REPLACE))


### PR DESCRIPTION
## Summary
- add a draw-buffer capability flag and load the legacy `glDrawBuffer` entry point so the renderer can fall back when multi-target draws are unavailable
- gate bloom activation and framebuffer draw-buffer updates on multi-target draw support, falling back to a single attachment when necessary
- avoid unguarded `glDrawBuffers` usage across shader state and shadow rendering to keep the renderer stable on contexts without MRT support

## Testing
- `ninja -C build` *(fails: build.ninja not present in repository)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915bfc28c948328898dff3292a8631b)