### PR TITLE
Fix GL state tracking in disable routines

### DIFF
--- a/src/refresh/legacy.cpp
+++ b/src/refresh/legacy.cpp
@@ -159,33 +159,49 @@ static void legacy_load_matrix(GLenum mode, const GLfloat *matrix, const GLfloat
     qglMultMatrixf(matrix);
 }
 
+/*
+=============
+legacy_disable_state
+
+Resets legacy backend bindings and disables active client arrays.
+=============
+*/
 static void legacy_disable_state(void)
 {
-    if (qglActiveTexture && qglClientActiveTexture) {
-        qglActiveTexture(GL_TEXTURE1);
-        qglBindTexture(GL_TEXTURE_2D, 0);
-        qglDisable(GL_TEXTURE_2D);
-        qglClientActiveTexture(GL_TEXTURE1);
-        qglDisableClientState(GL_TEXTURE_COORD_ARRAY);
+	if (qglActiveTexture && qglClientActiveTexture) {
+		qglActiveTexture(GL_TEXTURE1);
+		gls.server_tmu = TMU_LIGHTMAP;
+		qglBindTexture(GL_TEXTURE_2D, 0);
+		gls.texnums[TMU_LIGHTMAP] = 0;
+		qglDisable(GL_TEXTURE_2D);
+		qglClientActiveTexture(GL_TEXTURE1);
+		gls.client_tmu = TMU_LIGHTMAP;
+		qglDisableClientState(GL_TEXTURE_COORD_ARRAY);
 
-        qglActiveTexture(GL_TEXTURE0);
-        qglBindTexture(GL_TEXTURE_2D, 0);
-        qglEnable(GL_TEXTURE_2D);
-        qglClientActiveTexture(GL_TEXTURE0);
-        qglDisableClientState(GL_TEXTURE_COORD_ARRAY);
-    } else {
-        qglBindTexture(GL_TEXTURE_2D, 0);
-        qglEnable(GL_TEXTURE_2D);
-        qglDisableClientState(GL_TEXTURE_COORD_ARRAY);
-    }
+		qglActiveTexture(GL_TEXTURE0);
+		gls.server_tmu = TMU_TEXTURE;
+		qglBindTexture(GL_TEXTURE_2D, 0);
+		gls.texnums[TMU_TEXTURE] = 0;
+		qglEnable(GL_TEXTURE_2D);
+		qglClientActiveTexture(GL_TEXTURE0);
+		gls.client_tmu = TMU_TEXTURE;
+		qglDisableClientState(GL_TEXTURE_COORD_ARRAY);
+	} else {
+		qglBindTexture(GL_TEXTURE_2D, 0);
+		gls.texnums[TMU_TEXTURE] = 0;
+		qglEnable(GL_TEXTURE_2D);
+		qglDisableClientState(GL_TEXTURE_COORD_ARRAY);
+		gls.server_tmu = TMU_TEXTURE;
+		gls.client_tmu = TMU_TEXTURE;
+	}
 
-    qglDisableClientState(GL_VERTEX_ARRAY);
-    qglDisableClientState(GL_COLOR_ARRAY);
+	qglDisableClientState(GL_VERTEX_ARRAY);
+	qglDisableClientState(GL_COLOR_ARRAY);
 
-    if (gl_static.warp_program) {
-        qglBindProgramARB(GL_FRAGMENT_PROGRAM_ARB, 0);
-        qglDisable(GL_FRAGMENT_PROGRAM_ARB);
-    }
+	if (gl_static.warp_program) {
+		qglBindProgramARB(GL_FRAGMENT_PROGRAM_ARB, 0);
+		qglDisable(GL_FRAGMENT_PROGRAM_ARB);
+	}
 }
 
 static void legacy_clear_state(void)

--- a/src/refresh/shader.cpp
+++ b/src/refresh/shader.cpp
@@ -2310,21 +2310,37 @@ gls.u_cluster_params.params2[2] = 0.0f;
 gls.u_cluster_params.params2[3] = 0.0f;
 }
 
+/*
+=============
+shader_disable_state
+
+Resets shader backend bindings and disables all vertex attribute arrays.
+=============
+*/
 static void shader_disable_state(void)
 {
-    qglActiveTexture(GL_TEXTURE2);
-    qglBindTexture(GL_TEXTURE_2D, 0);
+	qglActiveTexture(GL_TEXTURE2);
+	gls.server_tmu = TMU_GLOWMAP;
+	qglBindTexture(GL_TEXTURE_2D, 0);
+	gls.texnums[TMU_GLOWMAP] = 0;
 
-    qglActiveTexture(GL_TEXTURE1);
-    qglBindTexture(GL_TEXTURE_2D, 0);
+	qglActiveTexture(GL_TEXTURE1);
+	gls.server_tmu = TMU_LIGHTMAP;
+	qglBindTexture(GL_TEXTURE_2D, 0);
+	gls.texnums[TMU_LIGHTMAP] = 0;
 
-    qglActiveTexture(GL_TEXTURE0);
-    qglBindTexture(GL_TEXTURE_2D, 0);
+	qglActiveTexture(GL_TEXTURE0);
+	gls.server_tmu = TMU_TEXTURE;
+	qglBindTexture(GL_TEXTURE_2D, 0);
+	gls.texnums[TMU_TEXTURE] = 0;
 
-    qglBindTexture(GL_TEXTURE_CUBE_MAP, 0);
+	qglBindTexture(GL_TEXTURE_CUBE_MAP, 0);
+	gls.texnumcube = 0;
 
-    for (int i = 0; i < VERT_ATTR_COUNT; i++)
-        qglDisableVertexAttribArray(i);
+	for (int i = 0; i < VERT_ATTR_COUNT; i++)
+		qglDisableVertexAttribArray(i);
+
+	gls.client_tmu = TMU_TEXTURE;
 }
 
 static void shader_clear_state(void)


### PR DESCRIPTION
## Summary
- ensure the shader backend disable helper clears tracked texture bindings and resets the active TMU bookkeeping
- update the legacy disable helper to reset tracked TMU/texture state and document the routine

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691639ade0408328b0d58e88536f2f47)