### PR TITLE
Clamp GL frustum near plane to avoid invalid projections

### DIFF
--- a/src/refresh/gl.hpp
+++ b/src/refresh/gl.hpp
@@ -62,6 +62,7 @@ typedef uint64_t glStateBits_t;
 
 inline constexpr int R_MOTION_BLUR_HISTORY_FRAMES = 3;
 inline constexpr int R_MOTION_BLUR_GRID_SIZE = 20;
+inline constexpr float GL_MINIMUM_ZNEAR = 0.001f;
 
 static_assert(R_MOTION_BLUR_HISTORY_FRAMES == 3, "Update motion blur history macros when changing frame count");
 

--- a/src/refresh/main.cpp
+++ b/src/refresh/main.cpp
@@ -2085,6 +2085,21 @@ static void gl_drawsky_changed(cvar_t *self)
         CL_SetSky();
 }
 
+/*
+=============
+gl_znear_changed
+
+Clamps the near clip plane cvar to a supported minimum.
+=============
+*/
+static void gl_znear_changed(cvar_t *self)
+{
+	const float clamped = (std::max)(self->value, GL_MINIMUM_ZNEAR);
+	if (clamped != self->value)
+		Cvar_SetValue(self, clamped, FROM_CODE);
+}
+
+
 static void gl_novis_changed(cvar_t *self)
 {
     glr.viewcluster1 = glr.viewcluster2 = -2;
@@ -2213,6 +2228,7 @@ static void GL_Register(void)
 
     // development variables
     gl_znear = Cvar_Get("gl_znear", "2", CVAR_CHEAT);
+    gl_znear->changed = gl_znear_changed;
     gl_drawworld = Cvar_Get("gl_drawworld", "1", CVAR_CHEAT);
     gl_drawentities = Cvar_Get("gl_drawentities", "1", CVAR_CHEAT);
     gl_drawsky = Cvar_Get("gl_drawsky", "1", 0);

--- a/src/refresh/state.cpp
+++ b/src/refresh/state.cpp
@@ -233,24 +233,35 @@ void GL_Setup2D(void)
     gl_backend->load_matrix(GL_MODELVIEW, gl_identity, gl_identity);
 }
 
+/*
+=============
+GL_Frustum
+
+Builds the projection matrix for the current view frustum.
+=============
+*/
 void GL_Frustum(GLfloat fov_x, GLfloat fov_y, GLfloat reflect_x)
 {
-    mat4_t matrix;
+	mat4_t matrix;
 
-    float znear = gl_znear->value, zfar;
+	float znear = (std::max)(gl_znear->value, GL_MINIMUM_ZNEAR);
+	float zfar;
 
-    if (glr.fd.rdflags & RDF_NOWORLDMODEL)
-        zfar = 2048;
-    else
-        zfar = gl_static.world.size * 2;
+	if (glr.fd.rdflags & RDF_NOWORLDMODEL) {
+		zfar = 2048.0f;
+	} else {
+		zfar = gl_static.world.size * 2.0f;
+	}
 
-    glr.view_znear = znear;
-    glr.view_zfar = zfar;
+	zfar = (std::max)(zfar, znear + 1.0f);
 
-    Matrix_Frustum(fov_x, fov_y, reflect_x, znear, zfar, matrix);
-    for (int i = 0; i < 16; ++i)
-        glr.projmatrix[i] = matrix[i];
-    gl_backend->load_matrix(GL_PROJECTION, matrix, gl_identity);
+	glr.view_znear = znear;
+	glr.view_zfar = zfar;
+
+	Matrix_Frustum(fov_x, fov_y, reflect_x, znear, zfar, matrix);
+	for (int i = 0; i < 16; ++i)
+		glr.projmatrix[i] = matrix[i];
+	gl_backend->load_matrix(GL_PROJECTION, matrix, gl_identity);
 }
 
 static void GL_RotateForViewer(void)


### PR DESCRIPTION
## Summary
- clamp the near clip plane to a safe minimum before constructing the projection matrix
- ensure the far plane always exceeds the sanitized near plane and cache the safe values
- sanitize the `gl_znear` cvar via a change callback so future frames reuse valid data

## Testing
- ninja -C build *(fails: build.ninja missing)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69163b4f12188328a386e25ccf623f16)