### PR TITLE
Ensure bloom shutdown when post-processing disabled

### DIFF
--- a/src/refresh/main.cpp
+++ b/src/refresh/main.cpp
@@ -1586,6 +1586,7 @@ static pp_flags_t GL_BindFramebuffer(void)
 	const bool fbo_enabled = !r_fbo || r_fbo->integer;
 	const bool fbo_disabled = r_fbo && !r_fbo->integer;
 	const bool post_processing_requested = gl_static.use_shaders && post_processing_enabled && fbo_enabled;
+	const bool post_processing_disabled = !post_processing_requested || !world_visible;
 	const bool had_framebuffer = glr.framebuffer_ok;
 	const bool had_framebuffer_resources = had_framebuffer || glr.framebuffer_width > 0 || glr.framebuffer_height > 0 || glr.motion_history_textures_ready;
 	const GLenum prev_internal_format = gl_static.postprocess_internal_format;
@@ -1598,11 +1599,11 @@ static pp_flags_t GL_BindFramebuffer(void)
 		glr.fd.width > 0 && glr.fd.height > 0 && drawable_w > 0 && drawable_h > 0;
 	const bool motion_blur_enabled = motion_blur_requested;
 
-	if (!post_processing_requested || !world_visible) {
+	if (post_processing_disabled) {
 		glr.motion_blur_enabled = false;
+		GL_UpdateBloomEffect(false, drawable_w, drawable_h);
 		HDR_DisableFramebufferResources();
 		HDR_UpdatePostprocessFormats();
-		GL_UpdateBloomEffect(false, drawable_w, drawable_h);
 		GL_ClearBloomStateFlags();
 		if (fbo_disabled && had_framebuffer_resources)
 			GL_ReleaseFramebufferResources();


### PR DESCRIPTION
## Summary
- ensure the bloom buffers are explicitly torn down when post-processing is disabled or the world is hidden by consolidating the early return logic

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69163fdd48708328864cead2b1445c4e)