### PR TITLE
Use refdef viewport for final composite rectangle

### DIFF
--- a/src/refresh/main.cpp
+++ b/src/refresh/main.cpp
@@ -1191,11 +1191,11 @@ static void R_GetFinalCompositeRect(int *x, int *y, int *w, int *h)
 {
 	if (!x || !y || !w || !h)
 		return;
-	
-	*x = 0;
-	*y = 0;
-	*w = r_config.width;
-	*h = r_config.height;
+
+	*x = glr.fd.x;
+	*y = glr.fd.y;
+	*w = glr.fd.width;
+	*h = glr.fd.height;
 }
 
 static void GL_BokehViewport(int w, int h)


### PR DESCRIPTION
## Summary
- derive the final composite rectangle from the current refdef viewport
- ensure post-processing stages receive accurate viewport coordinates

## Testing
- not run (not available in container)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69163fde03048328a08e62ed50b6052c)