### PR TITLE
Restore active TMU after HDR luminance reduction

### DIFF
--- a/src/refresh/postprocess/hdr_luminance.cpp
+++ b/src/refresh/postprocess/hdr_luminance.cpp
@@ -294,6 +294,7 @@ bool HdrLuminanceReducer::reduce(GLuint sceneTexture, int width, int height) noe
 	qglGetIntegerv(GL_FRAMEBUFFER_BINDING, &prev_fbo);
 	qglGetIntegerv(GL_VIEWPORT, viewport);
 
+	const glTmu_t previous_tmu = gls.server_tmu;
 	GLuint current_texture = sceneTexture;
 	int current_w = width;
 	int current_h = height;
@@ -341,6 +342,7 @@ bool HdrLuminanceReducer::reduce(GLuint sceneTexture, int width, int height) noe
 
 	restoreFramebuffer(prev_fbo);
 	GL_ForceTexture(TMU_TEXTURE, sceneTexture);
+	GL_ActiveTexture(previous_tmu);
 	qglViewport(viewport[0], viewport[1], viewport[2], viewport[3]);
 
 	has_result_ = success;


### PR DESCRIPTION
## Summary
- save the currently active TMU before running the HDR luminance reduction loop
- restore the saved TMU once the pass completes so subsequent multi-texture draws keep their expected state

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69163fde78dc83289b036a728c244f08)