### PR TITLE
Handle bloom resource allocation failures

### DIFF
--- a/src/refresh/postprocess/bloom.cpp
+++ b/src/refresh/postprocess/bloom.cpp
@@ -99,6 +99,13 @@ void BloomEffect::destroyFramebuffers()
 	}
 }
 
+/*
+=============
+BloomEffect::initialize
+
+Generates the bloom textures and framebuffers if they have not been created yet.
+=============
+*/
 void BloomEffect::initialize()
 {
 	if (initialized_)
@@ -106,6 +113,30 @@ void BloomEffect::initialize()
 
 	qglGenTextures(TextureCount, textures_);
 	qglGenFramebuffers(FramebufferCount, framebuffers_);
+
+	bool texturesReady = true;
+	for (GLuint texture : textures_) {
+		if (texture == 0) {
+			texturesReady = false;
+			break;
+		}
+	}
+
+	bool framebuffersReady = true;
+	for (GLuint framebuffer : framebuffers_) {
+		if (framebuffer == 0) {
+			framebuffersReady = false;
+			break;
+		}
+	}
+
+	if (!texturesReady || !framebuffersReady) {
+		destroyTextures();
+		destroyFramebuffers();
+		if (gl_showerrors->integer)
+			Com_EPrintf("BloomEffect: failed to generate bloom resources\n");
+		return;
+	}
 
 	initialized_ = true;
 }


### PR DESCRIPTION
## Summary
- validate bloom texture and framebuffer handle generation before marking the effect initialized
- clean up partial allocations and log a bloom resource error so later passes can skip safely

## Testing
- not run (GPU failure injection requires manual setup)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691641d533a0832890c78af40d960647)