### PR TITLE
Fix missing prototypes for HDR and shader cleanup

### DIFF
--- a/src/refresh/postprocess/hdr_luminance.cpp
+++ b/src/refresh/postprocess/hdr_luminance.cpp
@@ -10,6 +10,19 @@ namespace {
 
 /*
 =============
+restoreFramebuffer
+
+Restores the previous framebuffer binding if a valid value is provided.
+=============
+*/
+static void restoreFramebuffer(GLint previous)
+{
+	if (previous >= 0)
+		qglBindFramebuffer(GL_FRAMEBUFFER, static_cast<GLuint>(previous));
+}
+
+/*
+=============
 setupTexture
 
 Configures texture parameters and storage for HDR luminance reduction levels.
@@ -77,19 +90,6 @@ static bool attachFramebuffer(GLuint fbo, GLuint texture, int width, int height)
 
 	return true;
 }
-
-/*
-=============
-restoreFramebuffer
-
-Restores the previous framebuffer binding if a valid value is provided.
-=============
-*/
-static void restoreFramebuffer(GLint previous)
-	{
-		if (previous >= 0)
-			qglBindFramebuffer(GL_FRAMEBUFFER, static_cast<GLuint>(previous));
-	}
 
 /*
 =============

--- a/src/refresh/shader.cpp
+++ b/src/refresh/shader.cpp
@@ -71,6 +71,8 @@ static cvar_t *gl_cluster_show_normals;
 
 extern const glbackend_t backend_legacy;
 
+static void shader_shutdown(void);
+
 q_printf(2, 3)
 static void shader_printf(sizebuf_t *buf, const char *fmt, ...)
 {


### PR DESCRIPTION
## Summary
- define restoreFramebuffer before use in the HDR luminance post-process module to satisfy the compiler
- declare shader_shutdown before it is called so the GLSL backend build succeeds

## Testing
- `ninja -C build` *(fails: ninja: error: loading 'build.ninja': No such file or directory)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916442e83e08328afffb0f198d7418c)