### PR TITLE
Fix MSVC build issues in tess and HDR luminance

### DIFF
--- a/src/refresh/postprocess/hdr_luminance.cpp
+++ b/src/refresh/postprocess/hdr_luminance.cpp
@@ -10,12 +10,12 @@ namespace {
 
 /*
 =============
-restoreFramebuffer
+restoreFramebufferBinding
 
 Restores the previous framebuffer binding if a valid value is provided.
 =============
 */
-static void restoreFramebuffer(GLint previous)
+static void restoreFramebufferBinding(GLint previous)
 {
 	if (previous >= 0)
 		qglBindFramebuffer(GL_FRAMEBUFFER, static_cast<GLuint>(previous));
@@ -80,7 +80,7 @@ static bool attachFramebuffer(GLuint fbo, GLuint texture, int width, int height)
 	qglBindTexture(GL_TEXTURE_2D, prev_texture);
 	gls.texnums[TMU_TEXTURE] = prev_texture;
 	GL_ActiveTexture(prev_active_tmu);
-	restoreFramebuffer(prev_fbo);
+	restoreFramebufferBinding(prev_fbo);
 
 	if (status != GL_FRAMEBUFFER_COMPLETE) {
 		if (gl_showerrors->integer)
@@ -357,7 +357,7 @@ bool HdrLuminanceReducer::reduce(GLuint sceneTexture, int width, int height) noe
 	++level_index;
 	}
 
-	restoreFramebuffer(prev_fbo);
+	restoreFramebufferBinding(prev_fbo);
 	GL_ForceTexture(TMU_TEXTURE, sceneTexture);
 	GL_ActiveTexture(previous_tmu);
 	qglViewport(viewport[0], viewport[1], viewport[2], viewport[3]);
@@ -403,7 +403,7 @@ bool HdrLuminanceReducer::readbackAverage(float* rgba) const noexcept
 	if (qglReadBuffer)
 	qglReadBuffer(kColorAttachment);
 	qglReadPixels(0, 0, level.width, level.height, GL_RGBA, GL_FLOAT, rgba);
-	restoreFramebuffer(prev_fbo);
+	restoreFramebufferBinding(prev_fbo);
 	if (qglReadBuffer)
 	qglReadBuffer(prev_read_buffer);
 	return true;
@@ -448,7 +448,7 @@ bool HdrLuminanceReducer::readbackHistogram(int maxSamples, std::vector<float>& 
 	if (qglReadBuffer)
 	qglReadBuffer(kColorAttachment);
 	qglReadPixels(0, 0, target->width, target->height, GL_RGBA, GL_FLOAT, scratch.data());
-	restoreFramebuffer(prev_fbo);
+	restoreFramebufferBinding(prev_fbo);
 	if (qglReadBuffer)
 	qglReadBuffer(prev_read_buffer);
 

--- a/src/refresh/tess.cpp
+++ b/src/refresh/tess.cpp
@@ -423,12 +423,17 @@ void GL_DrawBeams(void)
         else
             color.u32 = d_8to24table[ent->skinnum & 0xff];
 		float alpha = static_cast<float>(color.a) * ent->alpha;
-		alpha = std::clamp(alpha, 0.0f, 255.0f);
+		if (alpha < 0.0f)
+			alpha = 0.0f;
+		else if (alpha > 255.0f)
+			alpha = 255.0f;
 		color.a = static_cast<uint8_t>(alpha);
 
 		const int frameWidth = static_cast<int>(static_cast<int16_t>(ent->frame));
-		const int clampedWidth = std::min(std::abs(frameWidth), MAX_BEAM_WIDTH);
-		width = static_cast<float>(clampedWidth) * scale;
+		int absWidth = frameWidth >= 0 ? frameWidth : -frameWidth;
+		if (absWidth > MAX_BEAM_WIDTH)
+			absWidth = MAX_BEAM_WIDTH;
+		width = static_cast<float>(absWidth) * scale;
 
         if (ent->flags & RF_GLOW)
             GL_DrawLightningBeam(segs[0], segs[1], color, width);


### PR DESCRIPTION
## Summary
- clamp beam alpha and width manually in the beam renderer to avoid MSVC macro collisions
- rename the HDR luminance framebuffer restore helper to a unique identifier used across the reducer

## Testing
- `ninja -C build` *(fails: build.ninja is missing in the provided build directory)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916451a3c6c8328a940306cc83795da)