### PR TITLE
Prevent framebuffer teardown when world is hidden

### DIFF
--- a/src/refresh/main.cpp
+++ b/src/refresh/main.cpp
@@ -1604,7 +1604,6 @@ static pp_flags_t GL_BindFramebuffer(void)
 	const bool fbo_enabled = !r_fbo || r_fbo->integer;
 	const bool fbo_disabled = r_fbo && !r_fbo->integer;
 	const bool post_processing_requested = gl_static.use_shaders && post_processing_enabled && fbo_enabled;
-	const bool post_processing_disabled = !post_processing_requested || !world_visible;
 	const bool had_framebuffer = glr.framebuffer_ok;
 	const bool had_framebuffer_resources = had_framebuffer || glr.framebuffer_width > 0 || glr.framebuffer_height > 0 || glr.motion_history_textures_ready;
 	const GLenum prev_internal_format = gl_static.postprocess_internal_format;
@@ -1621,7 +1620,7 @@ static pp_flags_t GL_BindFramebuffer(void)
 		scene_target_w > 0 && scene_target_h > 0;
 	const bool motion_blur_enabled = motion_blur_requested;
 
-	if (post_processing_disabled) {
+	if (!post_processing_requested) {
 		glr.motion_blur_enabled = false;
 		GL_UpdateBloomEffect(false, scene_target_w, scene_target_h);
 		HDR_DisableFramebufferResources();
@@ -1629,6 +1628,14 @@ static pp_flags_t GL_BindFramebuffer(void)
 		GL_ClearBloomStateFlags();
 		if (fbo_disabled && had_framebuffer_resources)
 			GL_ReleaseFramebufferResources();
+		return PP_NONE;
+	}
+
+	if (!world_visible) {
+		if (glr.framebuffer_bound)
+			qglBindFramebuffer(GL_FRAMEBUFFER, 0);
+		glr.framebuffer_bound = false;
+		glr.motion_blur_enabled = false;
 		return PP_NONE;
 	}
 
@@ -1730,12 +1737,19 @@ static pp_flags_t GL_BindFramebuffer(void)
 		}
 	}
 
-	if (!flags || !glr.framebuffer_ok) {
+	if (!glr.framebuffer_ok) {
 		glr.motion_blur_enabled = false;
 		HDR_DisableFramebufferResources();
 		HDR_UpdatePostprocessFormats();
 		GL_UpdateBloomEffect(false, scene_target_w, scene_target_h);
 		GL_ClearBloomStateFlags();
+		return PP_NONE;
+	}
+
+	if (!flags) {
+		if (glr.framebuffer_bound)
+			qglBindFramebuffer(GL_FRAMEBUFFER, 0);
+		glr.framebuffer_bound = false;
 		return PP_NONE;
 	}
 


### PR DESCRIPTION
## Summary
- keep post-process framebuffer resources intact when the world model is hidden by returning early without tearing them down
- only release HDR/bloom assets when post-processing is disabled or framebuffer allocation fails, and keep existing resources ready for reuse

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69165453e7ac8328934357ec06be049c)