### PR TITLE
Align post-process sampling with viewport bounds

### DIFF
--- a/src/refresh/gl.hpp
+++ b/src/refresh/gl.hpp
@@ -255,6 +255,12 @@ typedef struct {
     uint64_t        ppl_dlight_bits;
     int             framebuffer_width;
     int             framebuffer_height;
+    int             framebuffer_viewport_width;
+    int             framebuffer_viewport_height;
+    float           framebuffer_u_min;
+    float           framebuffer_v_min;
+    float           framebuffer_u_max;
+    float           framebuffer_v_max;
     float           view_znear;
     float           view_zfar;
     bool            framebuffer_ok;

--- a/src/refresh/postprocess/bloom.cpp
+++ b/src/refresh/postprocess/bloom.cpp
@@ -5,7 +5,8 @@
 #include "../qgl.hpp"
 #include "crt.hpp"
 
-extern void GL_PostProcess(glStateBits_t bits, int x, int y, int w, int h);
+extern void GL_PostProcess(glStateBits_t bits, int x, int y, int w, int h,
+	float u_min, float v_min, float u_max, float v_max);
 
 BloomEffect g_bloom_effect;
 
@@ -54,8 +55,9 @@ namespace {
 		}
 
 		qglBindFramebuffer(GL_FRAMEBUFFER, 0);
-		GL_PostProcess(bits, ctx.viewportX, ctx.viewportY, ctx.viewportWidth, ctx.viewportHeight);
-	}
+		GL_PostProcess(bits, ctx.viewportX, ctx.viewportY, ctx.viewportWidth, ctx.viewportHeight,
+			ctx.sceneUMin, ctx.sceneVMin, ctx.sceneUMax, ctx.sceneVMax);
+}
 
 }
 
@@ -379,7 +381,8 @@ void BloomEffect::render(const BloomRenderContext& ctx)
 	gls.u_block_dirty = true;
 	GL_ForceTexture(TMU_TEXTURE, ctx.bloomTexture);
 	qglBindFramebuffer(GL_FRAMEBUFFER, framebuffers_[DownsampleFbo]);
-	GL_PostProcess(GLS_BLUR_BOX, 0, 0, downsampleWidth_, downsampleHeight_);
+	GL_PostProcess(GLS_BLUR_BOX, 0, 0, downsampleWidth_, downsampleHeight_,
+			ctx.sceneUMin, ctx.sceneVMin, ctx.sceneUMax, ctx.sceneVMax);
 	if (GL_ShowErrors("Bloom pass"))
 		bloomFailed = true;
 
@@ -392,7 +395,8 @@ void BloomEffect::render(const BloomRenderContext& ctx)
 		GL_ForceTexture(TMU_TEXTURE, textures_[Downsample]);
 		GL_ForceTexture(TMU_LIGHTMAP, ctx.sceneTexture);
 		qglBindFramebuffer(GL_FRAMEBUFFER, framebuffers_[BrightPassFbo]);
-		GL_PostProcess(GLS_BLOOM_BRIGHTPASS, 0, 0, downsampleWidth_, downsampleHeight_);
+		GL_PostProcess(GLS_BLOOM_BRIGHTPASS, 0, 0, downsampleWidth_, downsampleHeight_,
+			ctx.sceneUMin, ctx.sceneVMin, ctx.sceneUMax, ctx.sceneVMax);
 		if (GL_ShowErrors("Bloom pass"))
 			bloomFailed = true;
 	}
@@ -408,7 +412,8 @@ void BloomEffect::render(const BloomRenderContext& ctx)
 				gls.u_block_dirty = true;
 				GL_ForceTexture(TMU_TEXTURE, currentTexture);
 				qglBindFramebuffer(GL_FRAMEBUFFER, framebuffers_[BlurFbo0 + axis]);
-				GL_PostProcess(blurMode, 0, 0, downsampleWidth_, downsampleHeight_);
+			GL_PostProcess(blurMode, 0, 0, downsampleWidth_, downsampleHeight_,
+			ctx.sceneUMin, ctx.sceneVMin, ctx.sceneUMax, ctx.sceneVMax);
 				if (GL_ShowErrors("Bloom pass")) {
 					bloomFailed = true;
 					break;

--- a/src/refresh/postprocess/bloom.hpp
+++ b/src/refresh/postprocess/bloom.hpp
@@ -11,6 +11,10 @@ struct BloomRenderContext {
 	int viewportY;
 	int viewportWidth;
 	int viewportHeight;
+	float sceneUMin;
+	float sceneVMin;
+	float sceneUMax;
+	float sceneVMax;
 	bool waterwarp;
 	bool depthOfField;
 	bool showDebug;
@@ -28,10 +32,10 @@ public:
 	void initialize();
 	void shutdown();
 
-        bool resize(int sceneWidth, int sceneHeight);
-        void render(const BloomRenderContext& ctx);
+	bool resize(int sceneWidth, int sceneHeight);
+	void render(const BloomRenderContext& ctx);
 
-        [[nodiscard]] bool isInitialized() const noexcept { return initialized_; }
+	[[nodiscard]] bool isInitialized() const noexcept { return initialized_; }
 
 private:
 	enum TextureSlot : size_t {
@@ -50,23 +54,23 @@ private:
 		FramebufferCount
 	};
 
-        void destroyTextures();
-        void destroyFramebuffers();
-        void ensureInitialized();
-        void allocateTexture(GLuint tex, int width, int height, GLenum internalFormat, GLenum format, GLenum type) const;
-        bool attachFramebuffer(GLuint fbo, GLuint texture, int width, int height, const char* name) const;
+	void destroyTextures();
+	void destroyFramebuffers();
+	void ensureInitialized();
+	void allocateTexture(GLuint tex, int width, int height, GLenum internalFormat, GLenum format, GLenum type) const;
+	bool attachFramebuffer(GLuint fbo, GLuint texture, int width, int height, const char* name) const;
 
-        GLuint textures_[TextureCount];
-        GLuint framebuffers_[FramebufferCount];
-        int sceneWidth_;
-        int sceneHeight_;
-        int downsampleWidth_;
-        int downsampleHeight_;
-        GLenum postprocessInternalFormat_;
-        GLenum postprocessFormat_;
-        GLenum postprocessType_;
-        bool initialized_;
-        bool resizeErrorLogged_;
+	GLuint textures_[TextureCount];
+	GLuint framebuffers_[FramebufferCount];
+	int sceneWidth_;
+	int sceneHeight_;
+	int downsampleWidth_;
+	int downsampleHeight_;
+	GLenum postprocessInternalFormat_;
+	GLenum postprocessFormat_;
+	GLenum postprocessType_;
+	bool initialized_;
+	bool resizeErrorLogged_;
 };
 
 extern BloomEffect g_bloom_effect;

--- a/src/refresh/postprocess/hdr_luminance.hpp
+++ b/src/refresh/postprocess/hdr_luminance.hpp
@@ -13,7 +13,8 @@ public:
 	bool resize(int width, int height) noexcept;
 
 	bool available() const noexcept { return !levels_.empty(); }
-	bool reduce(GLuint sceneTexture, int width, int height) noexcept;
+	bool reduce(GLuint sceneTexture, int textureWidth, int textureHeight,
+	int viewportWidth, int viewportHeight) noexcept;
 
 	bool readbackAverage(float* rgba) const noexcept;
 	bool readbackHistogram(int maxSamples, std::vector<float>& scratch, int& outWidth, int& outHeight) const noexcept;


### PR DESCRIPTION
## Summary
- track scene framebuffer viewport dimensions and UV bounds so post-processing samples only rendered pixels
- plumb viewport-aware UV limits through bloom, DOF, and composite passes plus the HDR luminance reducer
- update HDR auto-exposure and histogram gathering to accept texture/viewport sizes and fall back to viewport readbacks when GPU reduction is unavailable

## Testing
- `ninja -C build` *(fails: `build.ninja` missing in repo)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916618dca348328874dacacc1c1ebad)