### PR TITLE
Fix try_image_format loader invocation

### DIFF
--- a/src/refresh/images.cpp
+++ b/src/refresh/images.cpp
@@ -1743,22 +1743,29 @@ static image_t *lookup_image(const char *name,
     return NULL;
 }
 
+/*
+=============
+try_image_format
+
+Attempt to load an image using the given format.
+=============
+*/
 static int try_image_format(imageformat_t fmt, image_t *image, byte **pic)
 {
-    void    *data;
-    int     ret;
+	void	*data;
+	int	ret;
 
-    // load the file
-    ret = FS_LoadFile(image->name, &data);
-    if (!data)
-        return ret;
+	// load the file
+	ret = FS_LoadFile(image->name, &data);
+	if (!data)
+		return ret;
 
-    // decompress the image
-    ret = img_loaders[fmt].load(data, ret, image, pic);
+	// decompress the image
+	ret = img_loaders[fmt].load(static_cast<const byte *>(data), ret, image, pic);
 
-    FS_FreeFile(data);
+	FS_FreeFile(data);
 
-    return ret < 0 ? ret : fmt;
+	return ret < 0 ? ret : fmt;
 }
 
 #if USE_PNG || USE_JPG || USE_TGA


### PR DESCRIPTION
## Summary
- add a function header for `try_image_format` to describe its role
- cast the loaded file data to `const byte*` before invoking the loader to satisfy the interface

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916c7c2f8208328a7436fa2a02b443e)