### PR TITLE
Restore q2repro-style image path handling

### DIFF
--- a/src/refresh/images.cpp
+++ b/src/refresh/images.cpp
@@ -2136,14 +2136,18 @@ static image_t* find_or_load_image(const char* name, size_t len,
 	}
 #endif
 
-	if (!freetype_font && !enum_has(flags, IF_SPECIAL)) {
-		// find out original extension
-		int fmtIndex;
-		for (fmtIndex = 0; fmtIndex < IM_MAX; ++fmtIndex) {
-			if (!Q_stricmp(image->name + image->baselen + 1, img_loaders[fmtIndex].ext))
-				break;
+		if (!freetype_font && !enum_has(flags, IF_SPECIAL)) {
+			// find out original extension
+			int fmtIndex;
+			for (fmtIndex = 0; fmtIndex < IM_MAX; ++fmtIndex) {
+				if (!Q_stricmp(image->name + image->baselen + 1, img_loaders[fmtIndex].ext))
+					break;
+			}
+			fmt = fmtIndex < IM_MAX ? static_cast<imageformat_t>(fmtIndex) : IM_MAX;
+			if (fmt == IM_MAX) {
+				fmt = (image_get_type(image) == IT_WALL) ? IM_WAL : IM_PCX;
+			}
 		}
-		fmt = fmtIndex < IM_MAX ? static_cast<imageformat_t>(fmtIndex) : IM_MAX;
 
 		// load the pic from disk
 		pic = NULL;
@@ -2270,8 +2274,6 @@ qhandle_t R_RegisterImage(const char* name, imagetype_t type, imageflags_t flags
 	char		fullname[MAX_QPATH];
 	size_t	len;
 	const char* existing_ext;
-	const char* ext;
-	char		ext_buffer[5]{};
 
 	Q_assert(name);
 
@@ -2284,43 +2286,41 @@ qhandle_t R_RegisterImage(const char* name, imagetype_t type, imageflags_t flags
 		return 0;
 
 	// First, determine the base path (with or without "pics/")
-	if (type == IT_SKIN || type == IT_SPRITE) {
-		// Skins and sprites are always relative to the gamedir root.
-		// A leading slash is conceptually valid but is stripped by normalization.
-		len = FS_NormalizePathBuffer(fullname, name, sizeof(fullname));
-	}
-	else if (*name == '/' || *name == '\\') {
-		// For other types, a leading slash also means relative to gamedir root.
-		// We strip the slash before continuing.
+	if (*name == '/' || *name == '\\') {
+		// A leading slash means the path is relative to the gamedir root.
+		// Strip the slash before normalizing the remainder.
 		len = FS_NormalizePathBuffer(fullname, name + 1, sizeof(fullname));
+	}
+	else if (type == IT_SKIN || type == IT_SPRITE) {
+		// Skins and sprites are always relative to the gamedir root.
+		len = FS_NormalizePathBuffer(fullname, name, sizeof(fullname));
 	}
 	else {
 		// Standard pics are located in the "pics/" subdirectory.
 		len = Q_concat(fullname, sizeof(fullname), "pics/", name);
+		if (len >= sizeof(fullname)) {
+			print_error(name, flags, Q_ERR(ENAMETOOLONG));
+			return 0;
+		}
+		len = FS_NormalizePath(fullname);
 	}
-
 	if (len >= sizeof(fullname)) {
 		print_error(name, flags, Q_ERR(ENAMETOOLONG));
 		return 0;
 	}
 
-	ext = (type == IT_SKIN) ? ".wal" : ".pcx";
 	existing_ext = COM_FileExtension(fullname);
 	if (!*existing_ext) {
-#if USE_PNG || USE_JPG || USE_TGA
-		if (type != IT_SKIN && img_total > 0) {
-			const imageformat_t fmt = img_search[0];
-			ext_buffer[0] = '.';
-			memcpy(ext_buffer + 1, img_loaders[fmt].ext, 4);
-			ext = ext_buffer;
-		}
-#endif
-		len = COM_DefaultExtension(fullname, ext, sizeof(fullname));
+		if (type == IT_WALL)
+			len = COM_DefaultExtension(fullname, ".wal", sizeof(fullname));
+		else if (type != IT_SKIN && type != IT_SPRITE)
+			len = COM_DefaultExtension(fullname, ".pcx", sizeof(fullname));
+		else
+			len = strlen(fullname);
 	}
 	else {
 		len = strlen(fullname);
 	}
-
 	if (len >= sizeof(fullname)) {
 		print_error(fullname, flags, Q_ERR(ENAMETOOLONG));
 		return 0;


### PR DESCRIPTION
## Summary
- normalize absolute image requests by stripping the leading slash before lookup
- stop auto-appending skin/sprite extensions while defaulting walls to .wal and other non-skins to .pcx when missing so PCX/WAL bases persist
- normalize `pics/` paths before applying a default extension to mirror q2repro behaviour
- ensure unknown or missing extensions fall back to PCX for most images and WAL for walls so override dimensions are recovered correctly

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69171af607708328a2d9dbfe36eb71cd)