### PR TITLE
Default IT_FONT paths to TrueType by default

### DIFF
--- a/doc/client.asciidoc
+++ b/doc/client.asciidoc
@@ -412,7 +412,7 @@ con_scale::
     depending on current display resolution). Set to 1 to disable scaling.
 
 con_font::
-    Font used for drawing console text. Default value is "conchars".
+    Font used for drawing console text. Builds with FreeType default to "/fonts/RobotoMono-Regular.ttf"; legacy builds fall back to "conchars.pcx". When no extension is provided, the renderer assumes ".ttf" and attempts to load a TrueType font. Specify ".pcx" explicitly to use classic bitmap fonts.
 
 con_background::
     Image used as console background. Default value is "conback".
@@ -504,7 +504,7 @@ scr_alpha::
     value is 1.
 
 scr_font::
-    Font used for drawing HUD text. Default value is "conchars".
+    Font used for drawing HUD text. FreeType builds default to "/fonts/RobotoMono-Regular.ttf" while legacy builds use "conchars.pcx". Fonts without an extension are treated as TrueType files and automatically gain the ".ttf" suffix; append ".pcx" for the classic bitmap font.
 
 scr_font_size::
     Pixel height for FreeType screen fonts. Defaults to 16 and scales automatically with ``scr_scale`` when left at the

--- a/src/client/cgame.cpp
+++ b/src/client/cgame.cpp
@@ -36,7 +36,7 @@ static cvar_t* scr_font;
 
 namespace {
 
-        constexpr const char* CG_LEGACY_FONT = "conchars";
+        constexpr const char* CG_LEGACY_FONT = "conchars.pcx";
 
         static bool CG_BuildFontLookupPath(const char* font_name, char* buffer, size_t size)
         {
@@ -54,7 +54,7 @@ namespace {
                 if (!len || len >= quake_path.size())
                         return false;
 
-                len = COM_DefaultExtension(quake_path.data(), ".pcx", quake_path.size());
+                len = COM_DefaultExtension(quake_path.data(), ".ttf", quake_path.size());
                 if (len >= quake_path.size())
                         return false;
 

--- a/src/client/console.cpp
+++ b/src/client/console.cpp
@@ -262,7 +262,7 @@ namespace {
 #if USE_FREETYPE
 		font_ = Cvar_Get("con_font", "/fonts/RobotoMono-Regular.ttf", 0);
 #else
-		font_ = Cvar_Get("con_font", "conchars", 0);
+		font_ = Cvar_Get("con_font", "conchars.pcx", 0);
 #endif
 		font_->changed = [](cvar_t* self) {
 			if (cls.ref_initialized)
@@ -913,7 +913,7 @@ namespace {
 				registeredFont_ = SCR_RegisterFontPath(font_->default_string);
 			}
 			if (!registeredFont_)
-				registeredFont_ = SCR_RegisterFontPath("conchars");
+				registeredFont_ = SCR_RegisterFontPath("conchars.pcx");
 			if (!registeredFont_)
 				Com_Error(ERR_FATAL, "%s", Com_GetLastError());
 		}

--- a/src/client/font.cpp
+++ b/src/client/font.cpp
@@ -28,7 +28,7 @@ static const ftfont_t* SCR_FTFontForHandle(qhandle_t handle);
 #endif
 
 namespace {
-	constexpr const char* SCR_LEGACY_FONT = "conchars";
+        constexpr const char* SCR_LEGACY_FONT = "conchars.pcx";
 	constexpr char SCR_PATH_SEPARATOR_UNIX = '/';
 	constexpr char SCR_PATH_SEPARATOR_WINDOWS = '\x5c';
 }

--- a/src/client/ui/ui.cpp
+++ b/src/client/ui/ui.cpp
@@ -607,7 +607,7 @@ void UI_Init(void)
 
     UI_ModeChanged();
 
-    uis.fontHandle = SCR_RegisterFontPath("conchars");
+    uis.fontHandle = SCR_RegisterFontPath("conchars.pcx");
     uis.cursorHandle = R_RegisterPic("ch1");
     R_GetPicSize(&uis.cursorWidth, &uis.cursorHeight, uis.cursorHandle);
 

--- a/src/client/ui/worr.menu.json
+++ b/src/client/ui/worr.menu.json
@@ -1,6 +1,6 @@
 {
   "background": "black",
-  "font": "conchars",
+  "font": "conchars.pcx",
   "cursor": "ch1",
   "weapon": "w_railgun.md2",
   "colors": {

--- a/src/refresh/images.cpp
+++ b/src/refresh/images.cpp
@@ -2307,7 +2307,9 @@ qhandle_t R_RegisterImage(const char* name, imagetype_t type, imageflags_t flags
 
 	existing_ext = COM_FileExtension(fullname);
 	if (!*existing_ext) {
-		if (type != IT_SKIN && type != IT_SPRITE)
+		if (type == IT_FONT)
+			len = COM_DefaultExtension(fullname, ".ttf", sizeof(fullname));
+		else if (type != IT_SKIN && type != IT_SPRITE)
 			len = COM_DefaultExtension(fullname, ".pcx", sizeof(fullname));
 		else
 			len = strlen(fullname);

--- a/src/refresh/texture.cpp
+++ b/src/refresh/texture.cpp
@@ -1603,7 +1603,7 @@ void GL_InitImages(void)
     GL_InitCubemaps();
 
 #if USE_DEBUG
-    r_charset = R_RegisterFont("conchars");
+    r_charset = R_RegisterFont("conchars.pcx");
 #endif
 
     GL_ShowErrors(__func__);


### PR DESCRIPTION
## Summary
- append .ttf to IT_FONT registrations when no extension is supplied so FreeType fonts are loaded immediately
- switch legacy font fallbacks and UI defaults to reference conchars.pcx explicitly
- document the new default for console and HUD font cvars

## Testing
- ninja -C build *(fails: no build.ninja)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69175af7fd0c83289a95c21aac35cbd1)