### PR TITLE
Handle conchars warning regardless of extension

### DIFF
--- a/src/refresh/images.cpp
+++ b/src/refresh/images.cpp
@@ -1931,11 +1931,18 @@ static bool need_override_image(imagetype_t type, imageformat_t fmt)
 
 #endif // USE_PNG || USE_JPG || USE_TGA
 
+/*
+=============
+print_error
+
+Logs image load failures, downgrading severity for known exceptions.
+=============
+*/
 static void print_error(const char* name, imageflags_t flags, int err)
 {
-	constexpr imageflags_t IGNORE_FLAGS = static_cast<imageflags_t>(-1);
-	const char* msg;
-	print_type_t level = PRINT_ERROR;
+        constexpr imageflags_t IGNORE_FLAGS = static_cast<imageflags_t>(-1);
+        const char* msg;
+        print_type_t level = PRINT_ERROR;
 
 	switch (err) {
 	case Q_ERR_INVALID_FORMAT:
@@ -1948,7 +1955,9 @@ static void print_error(const char* name, imageflags_t flags, int err)
 		}
 		else if (enum_has(flags, IF_PERMANENT) && !enum_has(flags, IF_OPTIONAL)) {
 			// ugly hack for console code
-			if (strcmp(name, "pics/conchars.pcx"))
+			char stripped[MAX_QPATH];
+			COM_StripExtension(stripped, name, sizeof(stripped));
+			if (!strcmp(stripped, "pics/conchars"))
 				level = PRINT_WARNING;
 		}
 		else if (COM_DEVELOPER >= 2) {


### PR DESCRIPTION
## Summary
- add a function header for `print_error`
- strip the file extension before matching `pics/conchars` so alternative formats still trigger the warning

## Testing
- meson setup build *(fails: wrap-redirect /workspace/WORR/subprojects/freetype-2.13.3/subprojects/zlib.wrap filename does not exist)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69175b1c0f408328b8710b7e219cc309)