### PR TITLE
Call setup_3d when rendering shadow views

### DIFF
--- a/src/refresh/shadow.cpp
+++ b/src/refresh/shadow.cpp
@@ -459,6 +459,9 @@ void render_shadow_views()
 		glr.view_zfar = view.far_plane;
 		glr.view_proj_valid = Matrix_Invert(glr.view_proj_matrix, glr.inv_view_proj_matrix);
 
+		if (gl_backend->setup_3d)
+			gl_backend->setup_3d();
+
 		gl_backend->load_matrix(GL_PROJECTION, view.proj_matrix, gl_identity);
 		GL_ForceMatrix(gl_identity, view.view_matrix);
 


### PR DESCRIPTION
## Summary
- call the backend's setup_3d hook for each shadow view so uniforms match the light-specific state

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69188a03f6a883288dcf4eca2de250a9)