### PR TITLE
Skip alpha entity lists in shadow atlas rendering

### DIFF
--- a/src/refresh/shadow.cpp
+++ b/src/refresh/shadow.cpp
@@ -469,9 +469,9 @@ void render_shadow_views()
 		GL_ClassifyEntities();
 		GL_DrawEntities(glr.ents.bmodels);
 		GL_DrawEntities(glr.ents.opaque);
-		GL_DrawEntities(glr.ents.alpha_back);
+		// Shadow atlas rendering is depth-only; skip the alpha entity lists so we
+		// don't reintroduce blended passes that produce incorrect shadows.
 		GL_DrawAlphaFaces();
-		GL_DrawEntities(glr.ents.alpha_front);
 		GL_DrawDebugObjects();
 
 		GL_Flush3D();


### PR DESCRIPTION
## Summary
- avoid rendering the alpha entity lists while populating the shadow atlas so only depth-relevant geometry is drawn
- add a comment explaining the intent to prevent translucent rendering regressions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691889f251dc8328946966f940a0d515)