### PR TITLE
Skip alpha face rendering during shadow maps

### DIFF
--- a/src/refresh/gl.hpp
+++ b/src/refresh/gl.hpp
@@ -1299,6 +1299,7 @@ void GL_Flush3D(void);
 void GL_AddAlphaFace(mface_t *face);
 void GL_AddSolidFace(mface_t *face);
 void GL_DrawAlphaFaces(void);
+bool GL_SetAlphaFaceRendering(bool enable);
 void GL_DrawSolidFaces(void);
 void GL_ClearSolidFaces(void);
 void GL_ClassifyEntities(void);

--- a/src/refresh/shadow.cpp
+++ b/src/refresh/shadow.cpp
@@ -377,6 +377,9 @@ void render_shadow_views()
 	if (g_render_views.empty())
 		return;
 
+	const bool rendering_shadows = true;
+	const bool prev_alpha_faces_enabled = GL_SetAlphaFaceRendering(!rendering_shadows);
+
 	GLint prev_draw_buffer = GL_BACK;
 	GLint prev_read_buffer = GL_BACK;
 	GLint prev_fbo = 0;
@@ -470,12 +473,15 @@ void render_shadow_views()
 		GL_DrawEntities(glr.ents.bmodels);
 		GL_DrawEntities(glr.ents.opaque);
 		GL_DrawEntities(glr.ents.alpha_back);
-		GL_DrawAlphaFaces();
+		if (!rendering_shadows)
+			GL_DrawAlphaFaces();
 		GL_DrawEntities(glr.ents.alpha_front);
 		GL_DrawDebugObjects();
 
 		GL_Flush3D();
 	}
+
+	GL_SetAlphaFaceRendering(prev_alpha_faces_enabled);
 
 	glr.fd = saved_fd;
 	for (int i = 0; i < 3; ++i)

--- a/src/refresh/tess.cpp
+++ b/src/refresh/tess.cpp
@@ -95,6 +95,7 @@ tesselator_t tess;
 static mface_t  *faces_head[FACE_HASH_SIZE];
 static mface_t  **faces_next[FACE_HASH_SIZE];
 static mface_t  *faces_alpha;
+static bool s_alpha_faces_enabled = true;
 
 void GL_Flush2D(void)
 {
@@ -919,8 +920,27 @@ void GL_AddSolidFace(mface_t *face)
 
 void GL_AddAlphaFace(mface_t *face)
 {
-    // draw back-to-front
-    face->entity = glr.ent;
-    face->next = faces_alpha;
-    faces_alpha = face;
+	if (!s_alpha_faces_enabled)
+		return;
+
+	// draw back-to-front
+	face->entity = glr.ent;
+	face->next = faces_alpha;
+	faces_alpha = face;
+}
+
+/*
+=============
+GL_SetAlphaFaceRendering
+
+Enables or disables queuing and drawing of alpha faces, returning the previous state.
+=============
+*/
+bool GL_SetAlphaFaceRendering(bool enable)
+{
+	bool previous = s_alpha_faces_enabled;
+	s_alpha_faces_enabled = enable;
+	if (!enable)
+		faces_alpha = NULL;
+	return previous;
 }


### PR DESCRIPTION
## Summary
- add a helper to toggle alpha face queuing and clear the queue when disabled
- disable alpha face drawing while rendering shadow-map views
- expose the new helper to other translation units

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691889ece7a48328bc359bdb99bf2b18)