### PR TITLE
Avoid alpha faces in shadow atlas rendering

### DIFF
--- a/src/refresh/gl.hpp
+++ b/src/refresh/gl.hpp
@@ -282,6 +282,7 @@ typedef struct {
     std::array<bool, R_MOTION_BLUR_HISTORY_FRAMES> motion_history_valid;
     int             motion_blur_history_index;
     int             motion_blur_history_count;
+	bool		rendering_shadows;
 } glRefdef_t;
 
 typedef enum {

--- a/src/refresh/shadow.cpp
+++ b/src/refresh/shadow.cpp
@@ -377,6 +377,10 @@ void render_shadow_views()
 	if (g_render_views.empty())
 		return;
 
+	const bool rendering_shadows = true;
+	const bool prev_rendering_shadows = glr.rendering_shadows;
+	glr.rendering_shadows = rendering_shadows;
+
 	GLint prev_draw_buffer = GL_BACK;
 	GLint prev_read_buffer = GL_BACK;
 	GLint prev_fbo = 0;
@@ -474,7 +478,8 @@ void render_shadow_views()
 		GL_DrawEntities(glr.ents.opaque);
 		// Shadow atlas rendering is depth-only; skip the alpha entity lists so we
 		// don't reintroduce blended passes that produce incorrect shadows.
-		GL_DrawAlphaFaces();
+		if (!rendering_shadows)
+			GL_DrawAlphaFaces();
 		GL_DrawDebugObjects();
 
 		GL_Flush3D();
@@ -506,6 +511,7 @@ void render_shadow_views()
 	qglViewport(prev_viewport[0], prev_viewport[1], prev_viewport[2], prev_viewport[3]);
 	qglColorMask(prev_color_mask[0], prev_color_mask[1], prev_color_mask[2], prev_color_mask[3]);
 	qglDepthMask(prev_depth_mask);
+	glr.rendering_shadows = prev_rendering_shadows;
 }
 
 } // namespace

--- a/src/refresh/tess.cpp
+++ b/src/refresh/tess.cpp
@@ -919,8 +919,11 @@ void GL_AddSolidFace(mface_t *face)
 
 void GL_AddAlphaFace(mface_t *face)
 {
-    // draw back-to-front
-    face->entity = glr.ent;
-    face->next = faces_alpha;
-    faces_alpha = face;
+	if (glr.rendering_shadows)
+		return;
+
+	// draw back-to-front
+	face->entity = glr.ent;
+	face->next = faces_alpha;
+	faces_alpha = face;
 }


### PR DESCRIPTION
## Summary
- skip drawing alpha faces while rendering shadow-map views and restore state afterwards
- prevent world alpha surfaces from being queued when rendering the shadow atlas by tracking a rendering_shadows flag

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69188ba591288328b3fc48611b4f30c5)