### PR TITLE
Preserve framebuffer binding around framebuffer status checks

### DIFF
--- a/src/refresh/texture.cpp
+++ b/src/refresh/texture.cpp
@@ -1193,22 +1193,32 @@ static void GL_InitDepthTexture(int w, int h)
     qglTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 }
 
+/*
+=============
+GL_CheckFramebufferStatus
+
+Validates the currently bound framebuffer and restores the previous binding.
+=============
+*/
 static bool GL_CheckFramebufferStatus(bool check, const char *name)
 {
-    GL_ShowErrors(__func__);
+	GL_ShowErrors(__func__);
 
-    if (!check)
-        return true;
+	GLint framebuffer = 0;
+	qglGetIntegerv(GL_FRAMEBUFFER_BINDING, &framebuffer);
 
-    GLenum status = qglCheckFramebufferStatus(GL_FRAMEBUFFER);
-    if (status == GL_FRAMEBUFFER_COMPLETE)
-        return true;
+	if (!check)
+		return true;
 
-    qglBindFramebuffer(GL_FRAMEBUFFER, 0);
-    if (gl_showerrors->integer)
-        Com_EPrintf("%s framebuffer status %#x\n", name, status);
+	GLenum status = qglCheckFramebufferStatus(GL_FRAMEBUFFER);
+	if (status != GL_FRAMEBUFFER_COMPLETE) {
+		qglBindFramebuffer(GL_FRAMEBUFFER, 0);
+		if (gl_showerrors->integer)
+			Com_EPrintf("%s framebuffer status %#x\n", name, status);
+	}
 
-    return false;
+	qglBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
+	return status == GL_FRAMEBUFFER_COMPLETE;
 }
 
 /*


### PR DESCRIPTION
## Summary
- capture the currently bound framebuffer before validating completeness
- restore the saved framebuffer after status checks to keep caller state intact
- document `GL_CheckFramebufferStatus` with a function header comment

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918c9192db88328a672a5ac1dc3e5c4)