### PR TITLE
Preserve framebuffer binding when initializing FBOs

### DIFF
--- a/src/refresh/main.cpp
+++ b/src/refresh/main.cpp
@@ -1900,8 +1900,17 @@ static pp_flags_t GL_BindFramebuffer(void)
 		gl_dof_quality->modified_count != gl_dof_quality_modified ||
 		r_motionBlur->modified_count != r_motionBlur_modified ||
 		hdr_prev != gl_static.hdr.active) {
+		const bool scene_fbo_was_bound = glr.framebuffer_bound;
+		GLint prev_framebuffer_binding = 0;
+		if (scene_fbo_was_bound && qglGetIntegerv)
+			qglGetIntegerv(GL_FRAMEBUFFER_BINDING, &prev_framebuffer_binding);
+
 		glr.framebuffer_ok = GL_InitFramebuffers();
-	glr.framebuffer_resources_resident = glr.framebuffer_ok;
+		if (scene_fbo_was_bound) {
+			const GLuint restore_framebuffer = prev_framebuffer_binding > 0 ? static_cast<GLuint>(prev_framebuffer_binding) : FBO_SCENE;
+			qglBindFramebuffer(GL_FRAMEBUFFER, restore_framebuffer);
+		}
+		glr.framebuffer_resources_resident = glr.framebuffer_ok;
 		if (glr.framebuffer_ok) {
 			glr.framebuffer_width  = scene_target_w;
 			glr.framebuffer_height = scene_target_h;


### PR DESCRIPTION
## Summary
- save and restore the currently bound framebuffer while GL_InitFramebuffers rebuilds post-process attachments
- funnel early exits in GL_InitFramebuffers through a cleanup path so the saved binding is always restored
- update GL_BindFramebuffer to preserve an existing scene FBO bind when triggering a framebuffer reinitialization

## Testing
- not run (not provided)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918c91ae40483289b31079c7089a098)