### PR TITLE
Preserve framebuffer binding during FBO teardown

### DIFF
--- a/src/refresh/texture.cpp
+++ b/src/refresh/texture.cpp
@@ -1482,11 +1482,15 @@ bool GL_InitFramebuffers(void)
 GL_ReleaseFramebufferResources
 
 Releases post-processing framebuffer textures and associated state so that the
-renderer no longer depends on framebuffer objects.
+renderer no longer depends on framebuffer objects while preserving the
+currently bound framebuffer.
 =============
 */
 void GL_ReleaseFramebufferResources(void)
 {
+	GLint framebuffer_binding = 0;
+
+	qglGetIntegerv(GL_FRAMEBUFFER_BINDING, &framebuffer_binding);
 	GL_ClearErrors();
 	GL_ForceTexture(TMU_TEXTURE, TEXNUM_PP_SCENE);
 	GL_InitPostProcTexture(0, 0);
@@ -1524,7 +1528,7 @@ void GL_ReleaseFramebufferResources(void)
 	glr.framebuffer_v_min = 0.0f;
 	glr.framebuffer_u_max = 1.0f;
 	glr.framebuffer_v_max = 1.0f;
-	qglBindFramebuffer(GL_FRAMEBUFFER, 0);
+	qglBindFramebuffer(GL_FRAMEBUFFER, framebuffer_binding);
 }
 
 static void gl_partshape_changed(cvar_t *self)


### PR DESCRIPTION
## Summary
- cache the currently bound framebuffer when releasing post-processing FBO resources
- restore the cached framebuffer after zeroing the post-processing textures so the caller's target remains active

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918c91c5740832880d03632d9021a16)