### PR TITLE
Preserve framebuffer binding across DOF pass

### DIFF
--- a/src/refresh/main.cpp
+++ b/src/refresh/main.cpp
@@ -1429,6 +1429,9 @@ static void GL_RunDepthOfField(void)
 	if (full_w <= 0 || full_h <= 0 || result_w <= 0 || result_h <= 0 || half_w <= 0 || half_h <= 0)
 		return;
 
+	GLint prev_fbo = 0;
+	qglGetIntegerv(GL_FRAMEBUFFER_BINDING, &prev_fbo);
+
 	GL_Setup2D();
 
 	GL_BokehCoCPass(full_w, full_h, full_w, full_h);
@@ -1437,7 +1440,7 @@ static void GL_RunDepthOfField(void)
 	GL_BokehGatherPass(half_w, half_h, half_w, half_h);
 	GL_BokehCombinePass(result_w, result_h, half_w, half_h);
 
-	qglBindFramebuffer(GL_FRAMEBUFFER, 0);
+	qglBindFramebuffer(GL_FRAMEBUFFER, prev_fbo);
 }
 
 typedef enum {


### PR DESCRIPTION
## Summary
- capture the currently bound framebuffer before starting the depth of field post-processing pipeline
- restore the saved framebuffer after the DOF passes so subsequent post-processing resumes on the active target

## Testing
- not run (manual verification of DOF-enabled rendering required)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918c91d0b8c83289bd2b8214e24c1ce)