### PR TITLE
Preserve framebuffer when storing motion blur history

### DIFF
--- a/src/refresh/main.cpp
+++ b/src/refresh/main.cpp
@@ -1655,6 +1655,9 @@ static void R_StoreMotionBlurHistory(void)
 	if (!glr.motion_history_textures_ready)
 		return;
 
+	GLint prev_fbo = 0;
+	qglGetIntegerv(GL_FRAMEBUFFER_BINDING, &prev_fbo);
+
 	int composite_x = 0;
 	int composite_y = 0;
 	int composite_w = 0;
@@ -1672,7 +1675,7 @@ static void R_StoreMotionBlurHistory(void)
 	GL_PostProcess(GLS_DEFAULT, 0, 0, composite_w, composite_h,
 		glr.framebuffer_u_min, glr.framebuffer_v_min,
 		glr.framebuffer_u_max, glr.framebuffer_v_max);
-	qglBindFramebuffer(GL_FRAMEBUFFER, 0);
+	qglBindFramebuffer(GL_FRAMEBUFFER, prev_fbo);
 	GL_Setup2D();
 
 	(void)composite_x;


### PR DESCRIPTION
## Summary
- cache the currently bound framebuffer before rendering the motion blur history target
- restore the saved framebuffer binding after copying instead of forcing the default target

## Testing
- not run (not feasible in this environment)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918c91dbbfc8328b1ebd42d5c7035ac)