### PR TITLE
Fix underwater effect activation for scene FBO

### DIFF
--- a/src/refresh/gl.hpp
+++ b/src/refresh/gl.hpp
@@ -269,6 +269,7 @@ typedef struct {
     bool            prev_view_proj_valid;
     bool            view_proj_valid;
     bool            motion_blur_enabled;
+    bool            framebuffer_underwater_effect_active;
     bool            motion_blur_ready;
     bool            motion_history_textures_ready;
     float           motion_blur_scale;

--- a/src/refresh/main.cpp
+++ b/src/refresh/main.cpp
@@ -1811,6 +1811,7 @@ static pp_flags_t GL_BindFramebuffer(void)
 	const bool post_processing_requested = gl_static.use_shaders && post_processing_enabled && fbo_enabled;
 	const bool post_processing_disabled = !post_processing_requested;
 	const bool post_processing_paused = post_processing_requested && !world_visible;
+	const bool underwater_effect_active = (glr.fd.rdflags & RDF_UNDERWATER) && !r_skipUnderWaterFX->integer;
 	const bool had_framebuffer_resources = glr.framebuffer_resources_resident;
 	const GLenum prev_internal_format = gl_static.postprocess_internal_format;
 	const GLenum prev_format = gl_static.postprocess_format;
@@ -1827,6 +1828,7 @@ static pp_flags_t GL_BindFramebuffer(void)
 	const bool motion_blur_enabled = motion_blur_requested;
 
 	if (post_processing_disabled) {
+		glr.framebuffer_underwater_effect_active = false;
 		glr.motion_blur_enabled = false;
 		GL_UpdateBloomEffect(false, scene_target_w, scene_target_h);
 		HDR_DisableFramebufferResources();
@@ -1836,6 +1838,8 @@ static pp_flags_t GL_BindFramebuffer(void)
 			GL_ReleaseFramebufferResources();
 		return PP_NONE;
 	}
+
+	glr.framebuffer_underwater_effect_active = underwater_effect_active;
 
 	HDR_UpdateConfig();
 
@@ -1863,7 +1867,7 @@ static pp_flags_t GL_BindFramebuffer(void)
 		prev_format != gl_static.postprocess_format ||
 		prev_type != gl_static.postprocess_type;
 
-	if ((glr.fd.rdflags & RDF_UNDERWATER) && !r_skipUnderWaterFX->integer)
+	if (underwater_effect_active)
 		flags |= PP_WATERWARP;
 
 	if (r_bloom->integer && (gl_config.caps & QGL_CAP_DRAW_BUFFERS) && qglDrawBuffers)

--- a/src/refresh/texture.cpp
+++ b/src/refresh/texture.cpp
@@ -1296,7 +1296,7 @@ bool GL_InitFramebuffers(void)
 	const bool dof_active = gl_dof->integer && glr.fd.depth_of_field;
 	const bool dof_reduced = dof_active && gl_dof_quality && gl_dof_quality->integer;
 	const bool motion_blur_active = glr.motion_blur_enabled;
-	const bool underwater_effect_active = !r_skipUnderWaterFX->integer;
+	const bool underwater_effect_active = glr.framebuffer_underwater_effect_active;
 	const bool bloom_effect_active = r_bloom->integer;
 	const bool hdr_effect_active = gl_static.hdr.active;
 	const bool crt_effect_active = R_CRTEnabled();


### PR DESCRIPTION
## Summary
- ensure underwater post-processing only activates when the renderer is actually underwater and store the state for framebuffer setup
- reuse the stored underwater state when deciding whether to allocate scene framebuffers and textures

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918c91fc3c88328881369a31fabadff)