### PR TITLE
Fix UI script allocation casts

### DIFF
--- a/src/client/ui/script.cpp
+++ b/src/client/ui/script.cpp
@@ -1215,13 +1215,13 @@ static void UI_ParseJsonBuffer(json_parse_t *parser, const char *buffer, size_t 
 jsmn_parser p;
 
 parser->buffer_len = length;
-parser->buffer = reinterpret_cast<char *>(Z_TagMalloc(length + 1, TAG_FILESYSTEM));
+parser->buffer = static_cast<char *>(Z_TagMalloc(length + 1, TAG_FILESYSTEM));
 memcpy(parser->buffer, buffer, length);
 parser->buffer[length] = '\0';
 
 jsmn_init(&p);
 parser->num_tokens = jsmn_parse(&p, parser->buffer, parser->buffer_len, NULL, 0);
-parser->tokens = reinterpret_cast<jsmntok_t *>(Z_TagMalloc(sizeof(jsmntok_t) * parser->num_tokens, TAG_FILESYSTEM));
+parser->tokens = static_cast<jsmntok_t *>(Z_TagMalloc(sizeof(jsmntok_t) * parser->num_tokens, TAG_FILESYSTEM));
 if (!parser->tokens)
 Json_Errorno(parser, parser->pos, Q_ERR(ENOMEM));
 


### PR DESCRIPTION
## Summary
- replace the reinterpret_cast usages in the UI JSON parser with static_cast so the z_allocation wrapper can convert to the desired pointer types on all compilers

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918e9d42d80832897cddab3800b1afc)