### PR TITLE
Allow UTF-8 filenames

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -843,11 +843,19 @@ worr_ded = executable('worr.ded', common_src, server_src,
   install_dir:           bindir,
 )
 
-if get_option('tests') and zlib.found()
+if get_option('tests')
   python_mod = import('python')
   python3 = python_mod.find_installation('python3')
-  test('fs_sfx_pkz', python3,
-    args: [files('tests/test_sfx_pkz.py'), worr_ded.full_path()],
+
+  if zlib.found()
+    test('fs_sfx_pkz', python3,
+      args: [files('tests/test_sfx_pkz.py'), worr_ded.full_path()],
+      depends: worr_ded,
+    )
+  endif
+
+  test('fs_unicode_filename', python3,
+    args: [files('tests/test_unicode_filename.py'), worr_ded.full_path()],
     depends: worr_ded,
   )
 endif

--- a/tests/test_unicode_filename.py
+++ b/tests/test_unicode_filename.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import pathlib
+import subprocess
+import tempfile
+
+
+CONFIG_NAME = "unicodé.cfg"
+CONFIG_CONTENT = "echo UNICODE_FILENAME_OK\n"
+
+
+def run_test(worr_ded: pathlib.Path) -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = pathlib.Path(tmpdir)
+        base = tmp_path / "baseq2"
+        home = tmp_path / "home"
+        base.mkdir(parents=True)
+        home.mkdir(parents=True)
+
+        config_path = base / CONFIG_NAME
+        config_path.write_text(CONFIG_CONTENT, encoding="utf-8")
+
+        cmd = [
+            str(worr_ded),
+            "+set",
+            "basedir",
+            str(tmp_path),
+            "+set",
+            "homedir",
+            str(home),
+            "+set",
+            "game",
+            "baseq2",
+            "+set",
+            "fs_autoexec",
+            "0",
+            "+set",
+            "developer",
+            "1",
+            "+exec",
+            CONFIG_NAME,
+            "+quit",
+        ]
+
+        env = os.environ.copy()
+        env.setdefault("HOME", str(home))
+        proc = subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            check=False,
+            env=env,
+        )
+
+        output = proc.stdout
+        if proc.returncode != 0:
+            raise SystemExit(
+                f"worr.ded exited with {proc.returncode}\n--- OUTPUT ---\n{output}\n------------"
+            )
+        if "UNICODE_FILENAME_OK" not in output:
+            raise SystemExit(f"expected marker missing from output\n{output}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("worr_ded", type=pathlib.Path)
+    args = parser.parse_args()
+    run_test(args.worr_ded)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- relax `validate_char()`/`FS_ValidatePath()` so UTF-8 bytes are accepted while keeping control and OS-reserved characters filtered, and document the new behavior
- add a regression test that creates and executes a config file with a non-ASCII filename and make it part of the default Meson test suite

## Testing
- `meson setup build` *(fails: wrap-redirect /workspace/WORR/subprojects/ffmpeg/subprojects/nasm.wrap filename does not exist)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a2cdda2608328b4a49d3117588201)