### PR TITLE
Fix FS_FileExists checks

### DIFF
--- a/inc/common/files.hpp
+++ b/inc/common/files.hpp
@@ -69,14 +69,34 @@ int     FS_CloseFile(qhandle_t f);
 qhandle_t FS_EasyOpenFile(char *buf, size_t size, unsigned mode,
                           const char *dir, const char *name, const char *ext);
 
-#define FS_FileExistsEx(path, flags) \
-    (FS_LoadFileEx(path, NULL, flags, TAG_FREE) != Q_ERR(ENOENT))
-#define FS_FileExists(path) \
-    FS_FileExistsEx(path, 0)
-
 int FS_LoadFileEx(const char *path, void **buffer, unsigned flags, memtag_t tag);
 // a NULL buffer will just return the file length without loading
 // length < 0 indicates error
+
+/*
+=============
+FS_FileExistsEx
+
+Returns true only when FS_LoadFileEx reports a non-negative length.
+=============
+*/
+static inline bool FS_FileExistsEx(const char *path, unsigned flags)
+{
+	int len;
+
+	len = FS_LoadFileEx(path, NULL, flags, TAG_FREE);
+	return len >= 0;
+}
+
+/*
+=============
+FS_FileExists
+=============
+*/
+static inline bool FS_FileExists(const char *path)
+{
+	return FS_FileExistsEx(path, 0);
+}
 
 int FS_WriteFile(const char *path, const void *data, size_t len);
 

--- a/src/common/common.cpp
+++ b/src/common/common.cpp
@@ -121,6 +121,40 @@ cvar_t  *allow_download_textures;
 cvar_t  *allow_download_pics;
 cvar_t  *allow_download_others;
 
+#if USE_TESTS
+/*
+=============
+Com_FSFileExistsPreInitCheck
+
+Ensures FS_FileExists returns false when the filesystem is not yet initialized.
+=============
+*/
+static void Com_FSFileExistsPreInitCheck(void)
+{
+	if (FS_FileExists("__fs_preinit_check__")) {
+		Com_WPrintf("FS_FileExists returned true before FS initialization\n");
+	} else {
+		Com_DPrintf("FS_FileExists pre-init check passed\n");
+	}
+}
+
+/*
+=============
+Com_FSFileExistsInvalidPathCheck
+
+Ensures FS_FileExists rejects invalid paths even after initialization.
+=============
+*/
+static void Com_FSFileExistsInvalidPathCheck(void)
+{
+	if (FS_FileExists("")) {
+		Com_WPrintf("FS_FileExists accepted an invalid path\n");
+	} else {
+		Com_DPrintf("FS_FileExists invalid-path check passed\n");
+	}
+}
+#endif
+
 cvar_t  *rcon_password;
 
 cvar_t  *sys_forcegamelib;
@@ -989,7 +1023,15 @@ void Qcommon_Init(int argc, char **argv)
 
     Sys_RunConsole();
 
+#if USE_TESTS
+	Com_FSFileExistsPreInitCheck();
+#endif
+
     FS_Init();
+
+#if USE_TESTS
+	Com_FSFileExistsInvalidPathCheck();
+#endif
 
     Sys_RunConsole();
 


### PR DESCRIPTION
## Summary
- change FS_FileExists to treat only successful FS_LoadFileEx calls as existing files
- add startup sanity checks that verify FS_FileExists fails before FS initialization and on invalid paths

## Testing
- meson setup build *(fails: wrap-redirect /workspace/WORR/subprojects/ffmpeg/subprojects/nasm.wrap filename does not exist)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a2cdb152483289f977e3d140bfd28)