### PR TITLE
Handle Windows path separators when creating files

### DIFF
--- a/src/common/files.cpp
+++ b/src/common/files.cpp
@@ -668,61 +668,76 @@ int FS_Seek(qhandle_t f, int64_t offset, int whence)
 }
 
 /*
+=============
+FS_IsPathSeparator
+=============
+*/
+static inline bool FS_IsPathSeparator(char ch)
+{
+	return ch == '/' || ch == '\\';
+}
+
+/*
 ============
 FS_CreatePath
 
 Creates any directories needed to store the given filename.
-Expects a fully qualified, normalized system path (i.e. with / separators).
+Expects a fully qualified system path (tolerates both / and \\ separators).
 ============
 */
 int FS_CreatePath(char *path)
 {
-    char *ofs;
-    int ret;
+	char *ofs;
+	int ret;
 
-    ofs = path;
+	ofs = path;
 
 #ifdef _WIN32
-    // check for UNC path and skip "//computer/share/" part
-    if (*path == '/' && path[1] == '/') {
-        char *p;
+	// check for UNC path and skip "//computer/share/" part
+	if (FS_IsPathSeparator(*path) && FS_IsPathSeparator(path[1])) {
+		char *p = path + 2;
+		int segments = 0;
 
-        p = strchr(path + 2, '/');
-        if (p) {
-            p = strchr(p + 1, '/');
-            if (p) {
-                ofs = p + 1;
-            }
-        }
-    } else if (Q_isalpha(*path) && path[1] == ':') {
-        ofs = path + 2; // skip drive part
-    }
-    
-    // check for drive path and skip N: part
-    if (Q_isalpha(*path) && path[1] == ':') {
-        ofs = path + 2;
-    }
+		while (*p && segments < 2) {
+			if (FS_IsPathSeparator(*p)) {
+				segments++;
+				if (segments == 2) {
+					ofs = p + 1;
+					break;
+				}
+			}
+			p++;
+		}
+	} else if (Q_isalpha(*path) && path[1] == ':') {
+		ofs = path + 2; // skip drive part
+	}
+
+	// check for drive path and skip N: part
+	if (Q_isalpha(*path) && path[1] == ':') {
+		ofs = path + 2;
+	}
 #endif
 
-    // skip leading slash(es)
-    for (; *ofs == '/'; ofs++)
-        ;
+	// skip leading slash(es)
+	for (; FS_IsPathSeparator(*ofs); ofs++)
+		;
 
-    for (; *ofs; ofs++) {
-        if (*ofs == '/') {
-            // create the directory
-            *ofs = 0;
-            ret = os_mkdir(path);
-            *ofs = '/';
-            if (ret == -1) {
-                int err = Q_ERRNO;
-                if (err != Q_ERR(EEXIST))
-                    return err;
-            }
-        }
-    }
+	for (; *ofs; ofs++) {
+		if (FS_IsPathSeparator(*ofs)) {
+			char sep = *ofs;
+			// create the directory
+			*ofs = 0;
+			ret = os_mkdir(path);
+			*ofs = sep;
+			if (ret == -1) {
+				int err = Q_ERRNO;
+				if (err != Q_ERR(EEXIST))
+					return err;
+			}
+		}
+	}
 
-    return Q_ERR_SUCCESS;
+	return Q_ERR_SUCCESS;
 }
 
 /*

--- a/tests/test_windows_console_history.py
+++ b/tests/test_windows_console_history.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+HISTORY_FILE = ".syshistory"
+BASEGAME = "baseq2"
+
+
+def run_test(worr_ded: pathlib.Path) -> None:
+    if os.name != "nt":
+        print("Skipping Windows-only test", file=sys.stderr)
+        return
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = pathlib.Path(tmpdir)
+        base = tmp_path / BASEGAME
+        home = tmp_path / "home"
+        base.mkdir(parents=True)
+        home.mkdir(parents=True)
+
+        home_backslash = str(home).replace("/", "\\")
+
+        cmd = [
+            str(worr_ded),
+            "+set",
+            "basedir",
+            str(tmp_path),
+            "+set",
+            "homedir",
+            home_backslash,
+            "+set",
+            "game",
+            BASEGAME,
+            "+set",
+            "fs_autoexec",
+            "0",
+            "+set",
+            "developer",
+            "1",
+            "+set",
+            "sys_history",
+            "8",
+            "+quit",
+        ]
+
+        env = os.environ.copy()
+        env.setdefault("HOME", str(home))
+
+        proc = subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            check=False,
+            env=env,
+        )
+
+        output = proc.stdout
+        if proc.returncode != 0:
+            raise SystemExit(
+                f"worr.ded exited with {proc.returncode}\n--- OUTPUT ---\n{output}\n------------"
+            )
+
+        history_dir = home / BASEGAME
+        history_file = history_dir / HISTORY_FILE
+        if not history_dir.is_dir():
+            raise SystemExit(f"history directory missing: {history_dir}")
+        if not history_file.is_file():
+            raise SystemExit(f"history file missing: {history_file}\n{output}")
+
+        # Ensure the file can be read even if it is empty
+        history_file.read_text()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("worr_ded", type=pathlib.Path)
+    args = parser.parse_args()
+    run_test(args.worr_ded)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- allow `FS_CreatePath` to treat both forward and back slashes as directory delimiters so Windows homedir values work even when they contain `\`
- add a Windows-only regression test that points `homedir` at a backslash path, saves console history, and verifies the history file is created

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a2cdb1f8c83289a76d3e5e26926df)