### PR TITLE
Refactor water jump impulse handling

### DIFF
--- a/inc/common/game3_pmove/waterjump.hpp
+++ b/inc/common/game3_pmove/waterjump.hpp
@@ -1,0 +1,21 @@
+/*
+Copyright (C) 1997-2001 Id Software, Inc.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+float PM_CalcWaterJumpImpulse(float frametime, int contents);

--- a/meson.build
+++ b/meson.build
@@ -43,6 +43,7 @@ common_src = [
   'src/common/game3_convert.cpp',
   'src/common/game3_pmove/new.cpp',
   'src/common/game3_pmove/old.cpp',
+  'src/common/game3_pmove/waterjump.cpp',
   'src/common/natsort.cpp',
   'src/common/hash_map.cpp',
   'src/common/loc.cpp',
@@ -866,6 +867,16 @@ if get_option('tests')
     args: [files('tests/test_whereis_q2game.py'), worr_ded.full_path()],
     depends: worr_ded,
   )
+
+  pmove_waterjump_test = executable('test_pmove_waterjump',
+    ['tests/test_pmove_waterjump.cpp', 'src/common/game3_pmove/waterjump.cpp'],
+    include_directories: 'inc',
+    dependencies:          common_deps,
+    gnu_symbol_visibility: 'hidden',
+    cpp_args:              ['-DUSE_TESTS=1'],
+  )
+
+  test('pmove_waterjump', pmove_waterjump_test)
 endif
 
 shared_library('game' + cpu, game_src,

--- a/src/common/game3_pmove/template.cpp
+++ b/src/common/game3_pmove/template.cpp
@@ -16,6 +16,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+#include "common/game3_pmove/waterjump.hpp"
+
 #define STEPSIZE    18
 
 // all of the locals will be zeroed before each
@@ -640,55 +642,48 @@ PM_CheckJump
 */
 static void PM_CheckJump(void)
 {
-    if (pm->s.pm_flags & G3PMF_TIME_LAND) {
-        // hasn't been long enough since landing to jump again
-        return;
-    }
+	if (pm->s.pm_flags & G3PMF_TIME_LAND) {
+		// hasn't been long enough since landing to jump again
+		return;
+	}
 
-    if (pm->cmd.upmove < 10) {
-        // not holding jump
-        pm->s.pm_flags &= ~G3PMF_JUMP_HELD;
-        return;
-    }
+	if (pm->cmd.upmove < 10) {
+		// not holding jump
+		pm->s.pm_flags &= ~G3PMF_JUMP_HELD;
+		return;
+	}
 
-    // must wait for jump to be released
-    if (pm->s.pm_flags & G3PMF_JUMP_HELD)
-        return;
+	// must wait for jump to be released
+	if (pm->s.pm_flags & G3PMF_JUMP_HELD)
+		return;
 
-    if (pm->s.pm_type == G3PM_DEAD)
-        return;
+	if (pm->s.pm_type == G3PM_DEAD)
+		return;
 
-    if (pm->waterlevel >= 2) {
-        // swimming, not jumping
-        pm->groundentity = NULL;
+	if (pm->waterlevel >= 2) {
+		// swimming, not jumping
+		pm->groundentity = NULL;
 
-        if (pmp->waterhack)
-            return;
+		if (pmp->waterhack)
+			return;
 
-        if (pml.velocity[2] <= -300)
-            return;
+		if (pml.velocity[2] <= -300)
+			return;
 
-        // FIXME: makes velocity dependent on client FPS,
-        // even causes prediction misses
-        if (pm->watertype == CONTENTS_WATER)
-            pml.velocity[2] = 100;
-        else if (pm->watertype == CONTENTS_SLIME)
-            pml.velocity[2] = 80;
-        else
-            pml.velocity[2] = 50;
-        return;
-    }
+		pml.velocity[2] += PM_CalcWaterJumpImpulse(pml.frametime, pm->watertype);
+		return;
+	}
 
-    if (pm->groundentity == NULL)
-        return;     // in air, so no effect
+	if (pm->groundentity == NULL)
+		return;	// in air, so no effect
 
-    pm->s.pm_flags |= G3PMF_JUMP_HELD;
+	pm->s.pm_flags |= G3PMF_JUMP_HELD;
 
-    pm->groundentity = NULL;
-    pm->s.pm_flags &= ~G3PMF_ON_GROUND;
-    pml.velocity[2] += 270;
-    if (pml.velocity[2] < 270)
-        pml.velocity[2] = 270;
+	pm->groundentity = NULL;
+	pm->s.pm_flags &= ~G3PMF_ON_GROUND;
+	pml.velocity[2] += 270;
+	if (pml.velocity[2] < 270)
+		pml.velocity[2] = 270;
 }
 
 /*

--- a/src/common/game3_pmove/waterjump.cpp
+++ b/src/common/game3_pmove/waterjump.cpp
@@ -1,0 +1,45 @@
+/*
+Copyright (C) 1997-2001 Id Software, Inc.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "shared/shared.hpp"
+#include "common/game3_pmove/waterjump.hpp"
+
+/*
+=============
+PM_CalcWaterJumpImpulse
+
+Returns the upward impulse to apply while swimming based on
+frame time and medium contents.
+=============
+*/
+float PM_CalcWaterJumpImpulse(float frametime, int contents)
+{
+	float	impulse;
+
+	if (frametime <= 0.0f)
+	return 0.0f;
+
+	if (contents == CONTENTS_WATER)
+	impulse = 100.0f;
+	else if (contents == CONTENTS_SLIME)
+	impulse = 80.0f;
+	else
+	impulse = 50.0f;
+
+	return impulse * frametime;
+}

--- a/tests/test_pmove_waterjump.cpp
+++ b/tests/test_pmove_waterjump.cpp
@@ -1,0 +1,54 @@
+#include "common/game3_pmove/waterjump.hpp"
+#include "shared/shared.hpp"
+
+#include <cmath>
+#include <cstdio>
+
+/*
+=============
+ApproximatelyEqual
+
+Compares floats within epsilon.
+=============
+*/
+static bool ApproximatelyEqual(float expected, float actual, float epsilon)
+{
+	return std::fabs(expected - actual) <= epsilon;
+}
+
+/*
+=============
+ExpectImpulse
+
+Asserts the impulse matches expected value.
+=============
+*/
+static bool ExpectImpulse(int contents, float frametime, float expected, const char *label)
+{
+	float	impulse = PM_CalcWaterJumpImpulse(frametime, contents);
+
+	if (!ApproximatelyEqual(expected, impulse, 0.0001f)) {
+		std::printf("%s: expected %.4f got %.4f\n", label, expected, impulse);
+		return false;
+	}
+
+	return true;
+}
+
+/*
+=============
+main
+=============
+*/
+int main()
+{
+	bool ok = true;
+
+	ok &= ExpectImpulse(CONTENTS_WATER, 0.016f, 1.6f, "water 16ms");
+	ok &= ExpectImpulse(CONTENTS_WATER, 0.1f, 10.0f, "water 100ms");
+	ok &= ExpectImpulse(CONTENTS_SLIME, 0.05f, 4.0f, "slime 50ms");
+	ok &= ExpectImpulse(CONTENTS_LAVA, 0.033f, 1.65f, "lava 33ms");
+	ok &= ExpectImpulse(CONTENTS_WATER, 0.0f, 0.0f, "no frametime");
+
+	return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- add a shared helper to compute frame time-scaled water jump impulses
- update PM_CheckJump to use frame time-scaled impulses for swimming jumps
- add a regression test covering water, slime, and lava jump impulses

## Testing
- ninja -C build test_pmove_waterjump *(fails: build directory not configured)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a31559b008328a6186eb88a44df90)