### PR TITLE
Add hash cache for material footstep lookup

### DIFF
--- a/inc/common/bsp.hpp
+++ b/inc/common/bsp.hpp
@@ -21,6 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "shared/list.hpp"
 #include "common/error.hpp"
+#include "common/hash_map.hpp"
 #include "system/hunk.hpp"
 #include "format/bsp.hpp"
 
@@ -313,6 +314,10 @@ typedef struct {
 #endif
     bool            extended;   // QBSP extended format
     bool            has_bspx;   // has BSPX header
+
+#if USE_CLIENT
+    hash_map_t      *material_step_ids;
+#endif
 
     char            name[1];
 } bsp_t;


### PR DESCRIPTION
## Summary
- add a BSP-level hash map for material-to-step-id lookups with default and ladder entries
- build and free the cache during material loading and BSP cleanup to keep it in sync with map changes
- use the cached mapping in OpenAL step ID lookups to avoid linear scans

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a316c6ea883288d6c46c7fb645c79)