### PR TITLE
Fix wheel deselection check for slot zero

### DIFF
--- a/src/client/wheel.cpp
+++ b/src/client/wheel.cpp
@@ -513,7 +513,7 @@ void CL_Wheel_Update(void)
                 cl.wheel.deselect_time = 0;
             }
         }
-    } else if (cl.wheel.selected) {
+} else if (cl.wheel.selected != -1) {
         if (!cl.wheel.deselect_time)
             cl.wheel.deselect_time = com_localTime3 + 200;
     }


### PR DESCRIPTION
## Summary
- update wheel selection handling to treat slot 0 as an active selection for deselection timing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e4277d1088326b66799f694441649)