### PR TITLE
Add cached localization for wheel items

### DIFF
--- a/src/client/client.hpp
+++ b/src/client/client.hpp
@@ -452,6 +452,11 @@ typedef struct client_state_s {
 
 		int         selected; // -1 = no selection
 		int         deselect_time; // if non-zero, deselect after < com_localTime
+
+		struct {
+			std::unordered_map<int, std::string> strings;
+			std::string language_token;
+		} name_cache;
 	} wheel;
 
 	int weapon_lock_time; // don't allow BUTTON_ATTACK within this time
@@ -959,6 +964,7 @@ void CL_Wheel_Draw(void);
 void CL_Wheel_Update(void);
 void CL_Wheel_ClearInput(void);
 float CL_Wheel_TimeScale(void);
+void CL_Wheel_ClearNameCache(void);
 
 //
 // tent.c

--- a/src/client/precache.cpp
+++ b/src/client/precache.cpp
@@ -771,7 +771,9 @@ A configstring update has been parsed.
 */
 void CL_UpdateConfigstring(int index)
 {
-    update_configstring(index);
+	update_configstring(index);
 
-    cgame->ParseConfigString(index, cl.configstrings[index]);
+	cgame->ParseConfigString(index, cl.configstrings[index]);
+
+	CL_Wheel_ClearNameCache();
 }


### PR DESCRIPTION
## Summary
- add a localized name cache to the wheel state keyed by item index and language source
- populate and reuse cached names during wheel and carousel draws while clearing on configstring updates
- initialize language tracking for the wheel cache

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e426cda808326b89276d76c1a27d7)