### PR TITLE
Improve copy-game-dll error handling

### DIFF
--- a/copy-game-dll.py
+++ b/copy-game-dll.py
@@ -7,6 +7,7 @@ import os
 import pathlib
 import shutil
 import stat
+import sys
 
 args = argparse.ArgumentParser()
 args.add_argument('output_name', help="output file name")
@@ -17,14 +18,40 @@ game_dll_path = pathlib.Path(arg_values.game_dll)
 dest_path = pathlib.Path(arg_values.output_name)
 output_path = dest_path.parent
 
-# Copy game DLL to output directory
-shutil.copy2(game_dll_path, dest_path)
+if not game_dll_path.is_file():
+    print(f"Source DLL not found: {game_dll_path}", file=sys.stderr)
+    sys.exit(1)
+
+try:
+    output_path.mkdir(parents=True, exist_ok=True)
+except OSError as exc:
+    print(f"Failed to create output directory {output_path}: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+if not output_path.is_dir():
+    print(f"Output path is not a directory: {output_path}", file=sys.stderr)
+    sys.exit(1)
+
+try:
+    shutil.copy2(game_dll_path, dest_path)
+except OSError as exc:
+    print(f"Failed to copy {game_dll_path} to {dest_path}: {exc}", file=sys.stderr)
+    sys.exit(1)
 
 # Additional file extensions which are copied over as well, if existing.
 # Currently, Windows debug symbols.
 ADDITIONAL_EXTS = [".pdb"]
 for ext in ADDITIONAL_EXTS:
     candidate = game_dll_path.with_suffix(ext)
-    if candidate.exists():
-        dest_path = output_path / candidate.name
+    if not candidate.exists():
+        continue
+    if not candidate.is_file():
+        print(f"Symbol file is not a regular file: {candidate}", file=sys.stderr)
+        sys.exit(1)
+
+    dest_path = output_path / candidate.name
+    try:
         shutil.copy2(candidate, dest_path)
+    except OSError as exc:
+        print(f"Failed to copy {candidate} to {dest_path}: {exc}", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
## Summary
- add explicit checks for missing source DLLs and symbol files with helpful errors
- create the destination directory when missing and validate it is usable
- wrap copy operations with clear failures and exit codes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e4285ed008326ad5f16a3cde14c0f)