### PR TITLE
Fix missing string include for mapdb lookups

### DIFF
--- a/src/server/save.cpp
+++ b/src/server/save.cpp
@@ -18,6 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "server.hpp"
 #include "common/mapdb.hpp"
+#include <string>
 #include <unordered_map>
 
 #define SAVE_MAGIC1     MakeLittleLong('S','S','V','2')


### PR DESCRIPTION
## Summary
- add the missing <string> include needed for unordered_map keys

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691edd7856cc8328ad53af5bcfcbb5e3)