### PR TITLE
Prefer static zlib dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -473,7 +473,7 @@ if msvc_link_suppressions.length() > 0
     'cpp_link_args=' + ' '.join(msvc_link_suppressions)]
 endif
 
-zlib = dependency('zlib', required: get_option('zlib'))
+zlib = dependency('zlib', required: get_option('zlib'), static: true)
 if not zlib.found()
   zlib = dependency('zlib-ng',
     fallback:        ['zlib-ng', 'zlib_ng_dep'],


### PR DESCRIPTION
## Summary
- prefer static zlib linkage to avoid missing z-1.dll at runtime on Windows builds

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ee9c20f0883288157357fdfb35a7a)