### PR TITLE
Implement chat prompt retrieval for cgame

### DIFF
--- a/src/client/cgame.cpp
+++ b/src/client/cgame.cpp
@@ -438,10 +438,19 @@ static float CG_SCR_GetVirtualScale(void)
 	return scr.virtual_scale > 0.0f ? scr.virtual_scale : 1.0f;
 }
 
+/*
+=============
+CG_CL_GetTextInput
+
+Return any pending chat input text and whether it is for team chat.
+=============
+*/
 static bool CG_CL_GetTextInput(const char** msg, bool* is_team)
 {
-	// FIXME: Hook up with chat prompt
-	return false;
+	if (!msg || !is_team)
+		return false;
+
+	return Con_GetTextInput(msg, is_team);
 }
 
 static int32_t CG_CL_GetWarnAmmoCount(int32_t weapon_id)

--- a/src/client/client.hpp
+++ b/src/client/client.hpp
@@ -1177,6 +1177,7 @@ void Con_Popup(bool force);
 void Con_SkipNotify(bool skip);
 void Con_RegisterMedia(void);
 void Con_CheckResize(void);
+bool Con_GetTextInput(const char** msg, bool* is_team);
 
 void Key_Console(int key);
 void Key_Message(int key);

--- a/src/client/console.cpp
+++ b/src/client/console.cpp
@@ -99,11 +99,12 @@ namespace {
 		void loadState(load_state_t state);
 
 		void print(std::string_view text);
-		void draw();
-		void run();
-		void registerMedia();
-		void checkResize();
-		void clearNotify();
+void draw();
+void run();
+void registerMedia();
+void checkResize();
+void clearNotify();
+bool getTextInput(const char** msg, bool* is_team) const;
 
 		void keyEvent(int key);
 		void charEvent(int key);
@@ -833,6 +834,27 @@ namespace {
 		R_SetScale(1.0f);
 	}
 
+/*
+=============
+Console::getTextInput
+
+Return the current chat input text and whether it is a team message.
+=============
+*/
+	bool Console::getTextInput(const char** msg, bool* is_team) const
+	{
+		if (!msg || !is_team)
+			return false;
+
+		if (!(cls.key_dest & KEY_MESSAGE) || chatMode_ == ChatMode::None)
+			return false;
+
+		*msg = chatPrompt_.inputLine.text;
+		*is_team = chatMode_ == ChatMode::Team;
+
+		return true;
+	}
+
 	void Console::run()
 	{
 		if (cls.disable_screen) {
@@ -1469,6 +1491,18 @@ void Con_RegisterMedia(void)
 void Con_CheckResize(void)
 {
 	Console::instance().checkResize();
+}
+
+/*
+=============
+Con_GetTextInput
+
+Provide the current chat input text and whether the chat is team-only.
+=============
+*/
+bool Con_GetTextInput(const char** msg, bool* is_team)
+{
+	return Console::instance().getTextInput(msg, is_team);
 }
 
 void Con_ClearNotify_f(void)


### PR DESCRIPTION
## Summary
- add console helper to surface current chat input and team-chat status
- hook CG_CL_GetTextInput to return pending chat prompt data to cgame callers

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f73b96f408328b34e7f912bf2dd5c)