### PR TITLE
Implement auto demo loop detection

### DIFF
--- a/src/client/cgame.cpp
+++ b/src/client/cgame.cpp
@@ -481,10 +481,19 @@ static int32_t CG_SCR_DrawBind(int32_t isplit, const char* binding, const char* 
 	return CONCHAR_HEIGHT;
 }
 
+/*
+=============
+CG_CL_InAutoDemoLoop
+
+Returns true when the client is currently running a demo with a pending
+`nextserver` command, indicating it is in an auto-demo playback loop.
+=============
+*/
 static bool CG_CL_InAutoDemoLoop(void)
 {
-	// FIXME: implement
-	return false;
+	const char* nextserver = Cvar_VariableString("nextserver");
+
+	return cls.demo.playback && nextserver[0] != '\0';
 }
 
 const cgame_export_t* cgame = NULL;


### PR DESCRIPTION
## Summary
- implement CG_CL_InAutoDemoLoop using demo playback status and pending nextserver command to detect auto-demo loops
- document the helper with the required function header comment

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f73c9a02483289f5faae9c93d32c6)