### PR TITLE
Expand classic installation path search

### DIFF
--- a/src/unix/system.cpp
+++ b/src/unix/system.cpp
@@ -508,38 +508,50 @@ GAME PATH DETECTION
 
 #if defined(DEFAULT_PREFIX)
 
+// Installation paths are checked in declaration order; the first match wins.
 static const char* check_paths_classic[] = {
-    DEFAULT_PREFIX "/share/q2pro",
-    // TODO: consider other default data locations
-    NULL
-    };
+	DEFAULT_PREFIX "/share/q2pro",
+	"/usr/local/share/q2pro",
+	"/usr/share/q2pro",
+	"/usr/local/share/games/q2pro",
+	"/usr/share/games/q2pro",
+	"/usr/share/games/quake2",
+	NULL
+	};
 static const char* check_paths_rr[] = {
-    DEFAULT_PREFIX "/share/q2repro",
-    NULL
-    };
+	DEFAULT_PREFIX "/share/q2repro",
+	NULL
+	};
 
+/*
+=============
+find_system_installation_path
+
+Locate a system installation directory by checking known prefixes in order.
+=============
+*/
 static bool find_system_installation_path(rerelease_mode_t rr_mode, char *out_dir, size_t out_dir_length)
 {
-    const char** check_paths = rr_mode == RERELEASE_MODE_YES ? check_paths_rr : check_paths_classic;
+	const char** check_paths = rr_mode == RERELEASE_MODE_YES ? check_paths_rr : check_paths_classic;
 
-    while(*check_paths)
-    {
-        const char* path = *check_paths++;
-        Com_DPrintf("Checking for installation: %s\n", path);
+	while(*check_paths)
+	{
+		const char* path = *check_paths++;
+		Com_DPrintf("Checking for installation: %s\n", path);
 
-        Q_STATBUF st;
+		Q_STATBUF st;
 
-        if (os_stat(path, &st) == -1)
-            continue;
+		if (os_stat(path, &st) == -1)
+			continue;
 
-        if (Q_ISDIR(st.st_mode))
-        {
-            Q_strlcpy(out_dir, path, out_dir_length);
-            return true;
-        }
-    }
+		if (Q_ISDIR(st.st_mode))
+		{
+			Q_strlcpy(out_dir, path, out_dir_length);
+			return true;
+		}
+	}
 
-    return false;
+	return false;
 }
 #endif
 


### PR DESCRIPTION
## Summary
- add more common prefixes to detect classic installations and note precedence
- document how system installation lookup proceeds in find_system_installation_path

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f73f76fc083288db58081ba6a7048)