### PR TITLE
Handle inflate failures in q2repro zdownload

### DIFF
--- a/q2proto/src/q2proto_proto_q2repro.c
+++ b/q2proto/src/q2proto_proto_q2repro.c
@@ -913,32 +913,58 @@ q2proto_error_t q2proto_q2repro_client_read_achievement(uintptr_t io_arg, q2prot
     return Q2P_ERR_SUCCESS;
 }
 
+/*
+=============
+q2repro_client_read_zdownload
+
+Handle compressed download data and reset inflate state on failure.
+=============
+*/
 static q2proto_error_t q2repro_client_read_zdownload(q2proto_clientcontext_t *context, uintptr_t io_arg,
-                                                     q2proto_svc_download_t *download)
+							     q2proto_svc_download_t *download)
 {
 #if Q2PROTO_COMPRESSION_DEFLATE
-    READ_CHECKED(client_read, io_arg, download->size, i16);
-    READ_CHECKED(client_read, io_arg, download->percent, u8);
+	READ_CHECKED(client_read, io_arg, download->size, i16);
+	READ_CHECKED(client_read, io_arg, download->percent, u8);
 
-    // FIXME: should end inflate in case of an error...
-    if (!context->has_zdownload_inflate_io_arg) {
-        CHECKED(client_read, io_arg,
-                q2protoio_inflate_begin(io_arg, Q2P_INFL_DEFL_RAW, &context->zdownload_inflate_io_arg));
-        context->has_zdownload_inflate_io_arg = true;
-    }
-    CHECKED(client_read, io_arg, q2protoio_inflate_data(io_arg, context->zdownload_inflate_io_arg, download->size));
-    size_t uncompressed_len = 0;
-    READ_CHECKED(client_read, context->zdownload_inflate_io_arg, download->data, raw, SIZE_MAX, &uncompressed_len);
-    bool stream_end = false;
-    CHECKED(client_read, io_arg, q2protoio_inflate_stream_ended(context->zdownload_inflate_io_arg, &stream_end));
-    if (stream_end) {
-        CHECKED_IO(client_read, io_arg, q2protoio_inflate_end(context->zdownload_inflate_io_arg), "finishing inflate");
-        context->has_zdownload_inflate_io_arg = false;
-    }
-    download->size = uncompressed_len;
-    return Q2P_ERR_SUCCESS;
+	if (!context->has_zdownload_inflate_io_arg) {
+		CHECKED(client_read, io_arg,
+		        q2protoio_inflate_begin(io_arg, Q2P_INFL_DEFL_RAW, &context->zdownload_inflate_io_arg));
+		context->has_zdownload_inflate_io_arg = true;
+	}
+
+	q2proto_error_t inflate_err = q2protoio_inflate_data(io_arg, context->zdownload_inflate_io_arg, download->size);
+	if (inflate_err != Q2P_ERR_SUCCESS)
+		goto fail_terminate_inflate;
+
+	size_t uncompressed_len = 0;
+	download->data = q2protoio_read_raw(context->zdownload_inflate_io_arg, SIZE_MAX, &uncompressed_len);
+	inflate_err = GET_IO_ERROR(context->zdownload_inflate_io_arg);
+	if (inflate_err != Q2P_ERR_SUCCESS)
+		goto fail_terminate_inflate;
+
+	bool stream_end = false;
+	inflate_err = q2protoio_inflate_stream_ended(context->zdownload_inflate_io_arg, &stream_end);
+	if (inflate_err != Q2P_ERR_SUCCESS)
+		goto fail_terminate_inflate;
+	if (stream_end) {
+		CHECKED_IO(client_read, io_arg, q2protoio_inflate_end(context->zdownload_inflate_io_arg), "finishing inflate");
+		context->has_zdownload_inflate_io_arg = false;
+	}
+
+	download->size = uncompressed_len;
+	return Q2P_ERR_SUCCESS;
+
+fail_terminate_inflate:
+	if (context->has_zdownload_inflate_io_arg) {
+		q2proto_error_t end_err = q2protoio_inflate_end(context->zdownload_inflate_io_arg);
+		context->has_zdownload_inflate_io_arg = false;
+		if (end_err != Q2P_ERR_SUCCESS)
+			inflate_err = end_err;
+	}
+	return HANDLE_ERROR(client_read, io_arg, inflate_err, "%s: zdownload inflation failed", __func__);
 #else
-    return Q2P_ERR_DEFLATE_NOT_SUPPORTED;
+	return Q2P_ERR_DEFLATE_NOT_SUPPORTED;
 #endif
 }
 


### PR DESCRIPTION
## Summary
- document q2repro_client_read_zdownload and restructure flow
- reset and terminate zdownload inflate state when decompression errors occur before stream end
- keep inflate context cleanup when a stream completes normally

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f73fdca5c832898d0bb80037f86c2)