### PR TITLE
Derive entity translucency from flags

### DIFF
--- a/src/client/entities.cpp
+++ b/src/client/entities.cpp
@@ -846,9 +846,21 @@ static void CL_AddPacketEntities(void)
             ent.skinnum = 0;
         }
 
-        // only used for black hole model right now, FIXME: do better
-        if ((renderfx & RF_TRANSLUCENT) && !(renderfx & RF_BEAM))
-            ent.alpha = 0.70f;
+		// only used for black hole model right now, FIXME: do better
+		if ((renderfx & RF_TRANSLUCENT) && !(renderfx & RF_BEAM)) {
+			float renderfx_alpha = 0.0f;
+
+			if (s1->alpha)
+				renderfx_alpha = lerp_entity_alpha(cent);
+
+			if (!renderfx_alpha)
+				renderfx_alpha = (renderfx >> 24) * (1.0f / 255.0f);
+
+			if (!renderfx_alpha)
+				renderfx_alpha = 0.30f;
+
+			ent.alpha = renderfx_alpha;
+		}
 
         // render effects (fullbright, translucent, etc)
         if (effects & EF_COLOR_SHELL)


### PR DESCRIPTION
## Summary
- derive translucent entity alpha from server-provided values or renderfx-encoded hints instead of a fixed constant

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f740c1c7c8328be61663df3c6ffa7)