### PR TITLE
Rename history and demo cache constants

### DIFF
--- a/inc/common/common.hpp
+++ b/inc/common/common.hpp
@@ -40,10 +40,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #define COM_CONFIG_CFG      "worr-config.cfg"
 
-// FIXME: rename these
-#define COM_HISTORYFILE_NAME    ".conhistory"
-#define COM_DEMOCACHE_NAME      ".democache"
-#define SYS_HISTORYFILE_NAME    ".syshistory"
+#define COM_CON_HISTORY_FILE    ".conhistory"
+#define COM_DEMO_CACHE_FILE     ".democache"
+#define SYS_CON_HISTORY_FILE    ".syshistory"
+
+#define COM_HISTORYFILE_NAME    COM_CON_HISTORY_FILE
+#define COM_DEMOCACHE_NAME      COM_DEMO_CACHE_FILE
+#define SYS_HISTORYFILE_NAME    SYS_CON_HISTORY_FILE
 
 #define MAXPRINTMSG     4096
 #define MAXERRORMSG     1024

--- a/src/client/console.cpp
+++ b/src/client/console.cpp
@@ -313,7 +313,7 @@ namespace {
 	void Console::postInit()
 	{
 		if (history_->integer > 0) {
-			Prompt_LoadHistory(&prompt_, COM_HISTORYFILE_NAME);
+			Prompt_LoadHistory(&prompt_, COM_CON_HISTORY_FILE);
 		}
 	}
 
@@ -323,7 +323,7 @@ namespace {
 			return;
 
 		if (history_->integer > 0) {
-			Prompt_SaveHistory(&prompt_, COM_HISTORYFILE_NAME, history_->integer);
+			Prompt_SaveHistory(&prompt_, COM_CON_HISTORY_FILE, history_->integer);
 		}
 
 		Prompt_Clear(&prompt_);

--- a/src/client/ui/demos.cpp
+++ b/src/client/ui/demos.cpp
@@ -170,547 +170,547 @@ static void BuildDir(const char *name, int type)
 
 static char *LoadCache(void)
 {
-    char buffer[MAX_OSPATH], *cache;
-    int i, len;
-    uint8_t hash[16];
+	char buffer[MAX_OSPATH], *cache;
+	int i, len;
+	uint8_t hash[16];
 
-    if (Q_concat(buffer, sizeof(buffer), m_demos.browse, "/" COM_DEMOCACHE_NAME) >= sizeof(buffer)) {
-        return NULL;
-    }
-    len = FS_LoadFileEx(buffer, reinterpret_cast<void **>(&cache),
-                        FS_TYPE_REAL | FS_PATH_GAME | FS_DIR_HOME, TAG_FILESYSTEM);
-    if (!cache) {
-        return NULL;
-    }
-    if (len < 33) {
-        goto fail;
-    }
+	if (Q_concat(buffer, sizeof(buffer), m_demos.browse, "/" COM_DEMO_CACHE_FILE) >= sizeof(buffer)) {
+		return NULL;
+	}
+	len = FS_LoadFileEx(buffer, reinterpret_cast<void **>(&cache),
+			             FS_TYPE_REAL | FS_PATH_GAME | FS_DIR_HOME, TAG_FILESYSTEM);
+	if (!cache) {
+		return NULL;
+	}
+	if (len < 33) {
+		goto fail;
+	}
 
-    for (i = 0; i < 16; i++) {
-        int c1 = Q_charhex(cache[i * 2 + 0]);
-        int c2 = Q_charhex(cache[i * 2 + 1]);
-        if (c1 == -1 || c2 == -1) {
-            goto fail;
-        }
-        hash[i] = (c1 << 4) | c2;
-    }
+	for (i = 0; i < 16; i++) {
+		int c1 = Q_charhex(cache[i * 2 + 0]);
+		int c2 = Q_charhex(cache[i * 2 + 1]);
+		if (c1 == -1 || c2 == -1) {
+			goto fail;
+		}
+		hash[i] = (c1 << 4) | c2;
+	}
 
-    if (cache[32] != '\\') {
-        goto fail;
-    }
+	if (cache[32] != '\\') {
+		goto fail;
+	}
 
-    if (memcmp(hash, m_demos.hash, 16)) {
-        goto fail;
-    }
+	if (memcmp(hash, m_demos.hash, 16)) {
+		goto fail;
+	}
 
-    Com_DPrintf("%s: loading from cache\n", __func__);
-    return cache;
+	Com_DPrintf("%s: loading from cache\n", __func__);
+	return cache;
 
 fail:
-    FS_FreeFile(cache);
-    return NULL;
+	FS_FreeFile(cache);
+	return NULL;
 }
 
 static void WriteCache(void)
 {
-    char buffer[MAX_OSPATH];
-    qhandle_t f;
-    int i;
-    char *map, *pov;
+	char buffer[MAX_OSPATH];
+	qhandle_t f;
+	int i;
+	char *map, *pov;
 
-    if (m_demos.list.numItems == m_demos.numDirs) {
-        return;
-    }
-    if (Q_concat(buffer, sizeof(buffer), m_demos.browse, "/" COM_DEMOCACHE_NAME) >= sizeof(buffer)) {
-        return;
-    }
-    FS_OpenFile(buffer, &f, FS_MODE_WRITE);
-    if (!f) {
-        return;
-    }
+	if (m_demos.list.numItems == m_demos.numDirs) {
+		return;
+	}
+	if (Q_concat(buffer, sizeof(buffer), m_demos.browse, "/" COM_DEMO_CACHE_FILE) >= sizeof(buffer)) {
+		return;
+	}
+	FS_OpenFile(buffer, &f, FS_MODE_WRITE);
+	if (!f) {
+		return;
+	}
 
-    for (i = 0; i < 16; i++) {
-        FS_FPrintf(f, "%02x", m_demos.hash[i]);
-    }
-    FS_FPrintf(f, "\\");
+	for (i = 0; i < 16; i++) {
+		FS_FPrintf(f, "%02x", m_demos.hash[i]);
+	}
+	FS_FPrintf(f, "\\");
 
-    for (i = m_demos.numDirs; i < m_demos.list.numItems; i++) {
-        auto *e = static_cast<demoEntry_t *>(m_demos.list.items[i]);
-        map = UI_GetColumn(e->name, COL_MAP);
-        pov = UI_GetColumn(e->name, COL_POV);
-        FS_FPrintf(f, "%s\\%s\\", map, pov);
-    }
-    FS_CloseFile(f);
+	for (i = m_demos.numDirs; i < m_demos.list.numItems; i++) {
+		auto *e = static_cast<demoEntry_t *>(m_demos.list.items[i]);
+		map = UI_GetColumn(e->name, COL_MAP);
+		pov = UI_GetColumn(e->name, COL_POV);
+		FS_FPrintf(f, "%s\\%s\\", map, pov);
+	}
+	FS_CloseFile(f);
 }
 
 static void CalcHash(void **list)
 {
-    struct mdfour md;
-    file_info_t *info;
-    size_t len;
+	struct mdfour md;
+	file_info_t *info;
+	size_t len;
 
-    mdfour_begin(&md);
-    while (*list) {
-        info = static_cast<file_info_t *>(*list++);
-        len = sizeof(*info) + strlen(info->name) - 1;
-        mdfour_update(&md, reinterpret_cast<const uint8_t *>(info), len);
-    }
-    mdfour_result(&md, m_demos.hash);
+	mdfour_begin(&md);
+	while (*list) {
+		info = static_cast<file_info_t *>(*list++);
+		len = sizeof(*info) + strlen(info->name) - 1;
+		mdfour_update(&md, reinterpret_cast<const uint8_t *>(info), len);
+	}
+	mdfour_result(&md, m_demos.hash);
 }
 
 static menuSound_t Change(menuCommon_t *self)
 {
-    if (!m_demos.list.numItems) {
-        m_demos.menu.status = m_demos.status_no_demos;
-        return QMS_BEEP;
-    }
+	if (!m_demos.list.numItems) {
+		m_demos.menu.status = m_demos.status_no_demos;
+		return QMS_BEEP;
+	}
 
-    auto *e = static_cast<demoEntry_t *>(
-        m_demos.list.items[m_demos.list.curvalue]);
-    switch (e->type) {
-    case ENTRY_DEMO:
-        m_demos.menu.status = m_demos.status_play_demo;
-        break;
-    default:
-        m_demos.menu.status = m_demos.status_change_dir;
-        break;
-    }
+	auto *e = static_cast<demoEntry_t *>(
+		m_demos.list.items[m_demos.list.curvalue]);
+	switch (e->type) {
+	case ENTRY_DEMO:
+		m_demos.menu.status = m_demos.status_play_demo;
+		break;
+	default:
+		m_demos.menu.status = m_demos.status_change_dir;
+		break;
+	}
 
-    return QMS_SILENT;
+	return QMS_SILENT;
 }
 
 static void BuildList(void)
 {
-    int numDirs, numDemos;
-    void **dirlist, **demolist;
-    char *cache, *p;
-    unsigned flags;
-    size_t len;
-    int i;
+	int numDirs, numDemos;
+	void **dirlist, **demolist;
+	char *cache, *p;
+	unsigned flags;
+	size_t len;
+	int i;
 
-    // this can be a lengthy process
-    S_GetSoundSystem().StopAllSounds();
+	// this can be a lengthy process
+	S_GetSoundSystem().StopAllSounds();
 
-    m_demos.menu.status = m_demos.status_building;
-    SCR_UpdateScreen();
+	m_demos.menu.status = m_demos.status_building;
+	SCR_UpdateScreen();
 
-    // list files
-    flags = ui_listalldemos->integer ? 0 : FS_TYPE_REAL | FS_PATH_GAME;
-    dirlist = FS_ListFiles(m_demos.browse, NULL, flags |
-                           FS_SEARCH_DIRSONLY, &numDirs);
-    demolist = FS_ListFiles(m_demos.browse, DEMO_EXTENSIONS, flags |
-                            FS_SEARCH_EXTRAINFO, &numDemos);
-    numDemos = min(numDemos, MAX_LISTED_FILES - numDirs);
+	// list files
+	flags = ui_listalldemos->integer ? 0 : FS_TYPE_REAL | FS_PATH_GAME;
+	dirlist = FS_ListFiles(m_demos.browse, NULL, flags |
+			                FS_SEARCH_DIRSONLY, &numDirs);
+	demolist = FS_ListFiles(m_demos.browse, DEMO_EXTENSIONS, flags |
+			                 FS_SEARCH_EXTRAINFO, &numDemos);
+	numDemos = min(numDemos, MAX_LISTED_FILES - numDirs);
 
-    // alloc entries
-    m_demos.list.items = UI_Malloc(sizeof(demoEntry_t *) * (numDirs + numDemos + 1));
-    m_demos.list.numItems = 0;
-    m_demos.list.curvalue = 0;
-    m_demos.list.prestep = 0;
+	// alloc entries
+	m_demos.list.items = UI_Malloc(sizeof(demoEntry_t *) * (numDirs + numDemos + 1));
+	m_demos.list.numItems = 0;
+	m_demos.list.curvalue = 0;
+	m_demos.list.prestep = 0;
 
-    m_demos.widest_map = 3;
-    m_demos.widest_pov = 3;
-    m_demos.total_bytes = 0;
+	m_demos.widest_map = 3;
+	m_demos.widest_pov = 3;
+	m_demos.total_bytes = 0;
 
-    // start with minimum size
-    m_demos.menu.size(&m_demos.menu);
+	// start with minimum size
+	m_demos.menu.size(&m_demos.menu);
 
-    if (strcmp(m_demos.browse, "/")) {
-        BuildDir("..", ENTRY_UP);
-    }
+	if (strcmp(m_demos.browse, "/")) {
+		BuildDir("..", ENTRY_UP);
+	}
 
-    // add directories
-    if (dirlist) {
-        for (i = 0; i < numDirs; i++) {
-            BuildDir(static_cast<const char *>(dirlist[i]), ENTRY_DN);
-        }
-        FS_FreeList(dirlist);
-    }
+	// add directories
+	if (dirlist) {
+		for (i = 0; i < numDirs; i++) {
+			 BuildDir(static_cast<const char *>(dirlist[i]), ENTRY_DN);
+		}
+		FS_FreeList(dirlist);
+	}
 
-    m_demos.numDirs = m_demos.list.numItems;
+	m_demos.numDirs = m_demos.list.numItems;
 
-    // add demos
-    if (demolist) {
-        CalcHash(demolist);
-        if ((cache = LoadCache()) != NULL) {
-            p = cache + 32 + 1;
-            for (i = 0; i < numDemos; i++) {
-                BuildName(static_cast<file_info_t *>(demolist[i]), &p);
-            }
-            FS_FreeFile(cache);
-        } else {
-            for (i = 0; i < numDemos; i++) {
-                BuildName(static_cast<file_info_t *>(demolist[i]), NULL);
-                if ((i & 7) == 0) {
-                    m_demos.menu.size(&m_demos.menu);
-                    SCR_UpdateScreen();
-                }
-            }
-        }
-        WriteCache();
-        FS_FreeList(demolist);
-    }
+	// add demos
+	if (demolist) {
+		CalcHash(demolist);
+		if ((cache = LoadCache()) != NULL) {
+			 p = cache + 32 + 1;
+			 for (i = 0; i < numDemos; i++) {
+			     BuildName(static_cast<file_info_t *>(demolist[i]), &p);
+			 }
+			 FS_FreeFile(cache);
+		} else {
+			 for (i = 0; i < numDemos; i++) {
+			     BuildName(static_cast<file_info_t *>(demolist[i]), NULL);
+			     if ((i & 7) == 0) {
+			         m_demos.menu.size(&m_demos.menu);
+			         SCR_UpdateScreen();
+			     }
+			 }
+		}
+		WriteCache();
+		FS_FreeList(demolist);
+	}
 
-    // update status line and sort
-    Change(&m_demos.list.generic);
-    if (m_demos.list.sortdir) {
-        m_demos.list.sort(&m_demos.list);
-    }
+	// update status line and sort
+	Change(&m_demos.list.generic);
+	if (m_demos.list.sortdir) {
+		m_demos.list.sort(&m_demos.list);
+	}
 
-    // resize columns
-    m_demos.menu.size(&m_demos.menu);
+	// resize columns
+	m_demos.menu.size(&m_demos.menu);
 
-    // format our extra status line
-    i = m_demos.list.numItems - m_demos.numDirs;
-    len = Q_scnprintf(m_demos.status, sizeof(m_demos.status),
-                      "%d demo%s, ", i, i == 1 ? "" : "s");
-    Com_FormatSizeLong(m_demos.status + len, sizeof(m_demos.status) - len,
-                       m_demos.total_bytes);
+	// format our extra status line
+	i = m_demos.list.numItems - m_demos.numDirs;
+	len = Q_scnprintf(m_demos.status, sizeof(m_demos.status),
+			           "%d demo%s, ", i, i == 1 ? "" : "s");
+	Com_FormatSizeLong(m_demos.status + len, sizeof(m_demos.status) - len,
+			            m_demos.total_bytes);
 
-    SCR_UpdateScreen();
+	SCR_UpdateScreen();
 }
 
 static void FreeList(void)
 {
-    int i;
+	int i;
 
-    if (m_demos.list.items) {
-        for (i = 0; i < m_demos.list.numItems; i++) {
-            Z_Free(m_demos.list.items[i]);
-        }
-        Z_Freep(&m_demos.list.items);
-        m_demos.list.numItems = 0;
-    }
+	if (m_demos.list.items) {
+		for (i = 0; i < m_demos.list.numItems; i++) {
+			 Z_Free(m_demos.list.items[i]);
+		}
+		Z_Freep(&m_demos.list.items);
+		m_demos.list.numItems = 0;
+	}
 }
 
 static menuSound_t LeaveDirectory(void)
 {
-    char    *s;
-    int     i;
+	char    *s;
+	int     i;
 
-    s = strrchr(m_demos.browse, '/');
-    if (!s) {
-        return QMS_BEEP;
-    }
+	s = strrchr(m_demos.browse, '/');
+	if (!s) {
+		return QMS_BEEP;
+	}
 
-    if (s == m_demos.browse) {
-        strcpy(m_demos.browse, "/");
-    } else {
-        *s = 0;
-    }
+	if (s == m_demos.browse) {
+		strcpy(m_demos.browse, "/");
+	} else {
+		*s = 0;
+	}
 
-    // rebuild list
-    FreeList();
-    BuildList();
-    MenuList_Init(&m_demos.list);
+	// rebuild list
+	FreeList();
+	BuildList();
+	MenuList_Init(&m_demos.list);
 
-    // move cursor to the previous directory
-    for (i = 0; i < m_demos.numDirs; i++) {
-        auto *e = static_cast<demoEntry_t *>(m_demos.list.items[i]);
-        if (!strcmp(e->name, s + 1)) {
-            MenuList_SetValue(&m_demos.list, i);
-            break;
-        }
-    }
+	// move cursor to the previous directory
+	for (i = 0; i < m_demos.numDirs; i++) {
+		auto *e = static_cast<demoEntry_t *>(m_demos.list.items[i]);
+		if (!strcmp(e->name, s + 1)) {
+			 MenuList_SetValue(&m_demos.list, i);
+			 break;
+		}
+	}
 
-    return QMS_OUT;
+	return QMS_OUT;
 }
 
 static bool FileNameOk(const char *s)
 {
-    while (*s) {
-        if (*s == '\n' || *s == '"' || *s == ';') {
-            return false;
-        }
-        s++;
-    }
-    return true;
+	while (*s) {
+		if (*s == '\n' || *s == '"' || *s == ';') {
+			 return false;
+		}
+		s++;
+	}
+	return true;
 }
 
 static menuSound_t EnterDirectory(demoEntry_t *e)
 {
-    size_t  baselen, len;
+	size_t  baselen, len;
 
-    baselen = strlen(m_demos.browse);
-    len = strlen(e->name);
-    if (baselen + 1 + len >= sizeof(m_demos.browse)) {
-        return QMS_BEEP;
-    }
-    if (!FileNameOk(e->name)) {
-        return QMS_BEEP;
-    }
+	baselen = strlen(m_demos.browse);
+	len = strlen(e->name);
+	if (baselen + 1 + len >= sizeof(m_demos.browse)) {
+		return QMS_BEEP;
+	}
+	if (!FileNameOk(e->name)) {
+		return QMS_BEEP;
+	}
 
-    if (baselen == 0 || m_demos.browse[baselen - 1] != '/') {
-        m_demos.browse[baselen++] = '/';
-    }
+	if (baselen == 0 || m_demos.browse[baselen - 1] != '/') {
+		m_demos.browse[baselen++] = '/';
+	}
 
-    memcpy(m_demos.browse + baselen, e->name, len + 1);
+	memcpy(m_demos.browse + baselen, e->name, len + 1);
 
-    // rebuild list
-    FreeList();
-    BuildList();
-    MenuList_Init(&m_demos.list);
-    return QMS_IN;
+	// rebuild list
+	FreeList();
+	BuildList();
+	MenuList_Init(&m_demos.list);
+	return QMS_IN;
 }
 
 static menuSound_t PlayDemo(demoEntry_t *e)
 {
-    if (strlen(m_demos.browse) + 1 + strlen(e->name) >= sizeof(m_demos.browse)) {
-        return QMS_BEEP;
-    }
-    if (!FileNameOk(e->name)) {
-        return QMS_BEEP;
-    }
-    Cbuf_AddText(&cmd_buffer, va("demo \"%s/%s\"\n", m_demos.browse, e->name));
-    return QMS_SILENT;
+	if (strlen(m_demos.browse) + 1 + strlen(e->name) >= sizeof(m_demos.browse)) {
+		return QMS_BEEP;
+	}
+	if (!FileNameOk(e->name)) {
+		return QMS_BEEP;
+	}
+	Cbuf_AddText(&cmd_buffer, va("demo \"%s/%s\"\n", m_demos.browse, e->name));
+	return QMS_SILENT;
 }
 
 static menuSound_t Activate(menuCommon_t *self)
 {
-    if (!m_demos.list.numItems) {
-        return QMS_BEEP;
-    }
+	if (!m_demos.list.numItems) {
+		return QMS_BEEP;
+	}
 
-    auto *e = static_cast<demoEntry_t *>(
-        m_demos.list.items[m_demos.list.curvalue]);
-    switch (e->type) {
-    case ENTRY_UP:
-        return LeaveDirectory();
-    case ENTRY_DN:
-        return EnterDirectory(e);
-    case ENTRY_DEMO:
-        return PlayDemo(e);
-    }
+	auto *e = static_cast<demoEntry_t *>(
+		m_demos.list.items[m_demos.list.curvalue]);
+	switch (e->type) {
+	case ENTRY_UP:
+		return LeaveDirectory();
+	case ENTRY_DN:
+		return EnterDirectory(e);
+	case ENTRY_DEMO:
+		return PlayDemo(e);
+	}
 
-    return QMS_NOTHANDLED;
+	return QMS_NOTHANDLED;
 }
 
 static int sizecmp(const void *p1, const void *p2)
 {
-    demoEntry_t *e1 = *(demoEntry_t **)p1;
-    demoEntry_t *e2 = *(demoEntry_t **)p2;
+	demoEntry_t *e1 = *(demoEntry_t **)p1;
+	demoEntry_t *e2 = *(demoEntry_t **)p2;
 
-    if (e1->size > e2->size) {
-        return m_demos.list.sortdir;
-    }
-    if (e1->size < e2->size) {
-        return -m_demos.list.sortdir;
-    }
-    return 0;
+	if (e1->size > e2->size) {
+		return m_demos.list.sortdir;
+	}
+	if (e1->size < e2->size) {
+		return -m_demos.list.sortdir;
+	}
+	return 0;
 }
 
 static int timecmp(const void *p1, const void *p2)
 {
-    demoEntry_t *e1 = *(demoEntry_t **)p1;
-    demoEntry_t *e2 = *(demoEntry_t **)p2;
+	demoEntry_t *e1 = *(demoEntry_t **)p1;
+	demoEntry_t *e2 = *(demoEntry_t **)p2;
 
-    if (e1->mtime > e2->mtime) {
-        return m_demos.list.sortdir;
-    }
-    if (e1->mtime < e2->mtime) {
-        return -m_demos.list.sortdir;
-    }
-    return 0;
+	if (e1->mtime > e2->mtime) {
+		return m_demos.list.sortdir;
+	}
+	if (e1->mtime < e2->mtime) {
+		return -m_demos.list.sortdir;
+	}
+	return 0;
 }
 
 static int namecmp(const void *p1, const void *p2)
 {
-    demoEntry_t *e1 = *(demoEntry_t **)p1;
-    demoEntry_t *e2 = *(demoEntry_t **)p2;
-    char *s1 = UI_GetColumn(e1->name, m_demos.list.sortcol);
-    char *s2 = UI_GetColumn(e2->name, m_demos.list.sortcol);
+	demoEntry_t *e1 = *(demoEntry_t **)p1;
+	demoEntry_t *e2 = *(demoEntry_t **)p2;
+	char *s1 = UI_GetColumn(e1->name, m_demos.list.sortcol);
+	char *s2 = UI_GetColumn(e2->name, m_demos.list.sortcol);
 
-    return Q_stricmp(s1, s2) * m_demos.list.sortdir;
+	return Q_stricmp(s1, s2) * m_demos.list.sortdir;
 }
 
 static menuSound_t Sort(menuList_t *self)
 {
-    switch (m_demos.list.sortcol) {
-    case COL_NAME:
-    case COL_MAP:
-    case COL_POV:
-        MenuList_Sort(&m_demos.list, m_demos.numDirs, namecmp);
-        break;
-    case COL_DATE:
-        MenuList_Sort(&m_demos.list, m_demos.numDirs, timecmp);
-        break;
-    case COL_SIZE:
-        MenuList_Sort(&m_demos.list, m_demos.numDirs, sizecmp);
-        break;
-    }
+	switch (m_demos.list.sortcol) {
+	case COL_NAME:
+	case COL_MAP:
+	case COL_POV:
+		MenuList_Sort(&m_demos.list, m_demos.numDirs, namecmp);
+		break;
+	case COL_DATE:
+		MenuList_Sort(&m_demos.list, m_demos.numDirs, timecmp);
+		break;
+	case COL_SIZE:
+		MenuList_Sort(&m_demos.list, m_demos.numDirs, sizecmp);
+		break;
+	}
 
-    return QMS_SILENT;
+	return QMS_SILENT;
 }
 
 static void Size(menuFrameWork_t *self)
 {
-    int w1, w2;
+	int w1, w2;
 
-    m_demos.list.generic.x      = 0;
-    m_demos.list.generic.y      = CONCHAR_HEIGHT;
-    m_demos.list.generic.width  = 0;
-    m_demos.list.generic.height = uis.height - CONCHAR_HEIGHT * 2 - 1;
+	m_demos.list.generic.x      = 0;
+	m_demos.list.generic.y      = CONCHAR_HEIGHT;
+	m_demos.list.generic.width  = 0;
+	m_demos.list.generic.height = uis.height - CONCHAR_HEIGHT * 2 - 1;
 
-    w1 = 17 + m_demos.widest_map + m_demos.widest_pov;
-    w2 = uis.width - w1 * CONCHAR_WIDTH - MLIST_PADDING * 4 - MLIST_SCROLLBAR_WIDTH;
-    if (w2 > 8 * CONCHAR_WIDTH) {
-        // everything fits
-        m_demos.list.columns[0].width = w2;
-        m_demos.list.columns[1].width = 12 * CONCHAR_WIDTH + MLIST_PADDING;
-        m_demos.list.columns[2].width = 5 * CONCHAR_WIDTH + MLIST_PADDING;
-        m_demos.list.columns[3].width = m_demos.widest_map * CONCHAR_WIDTH + MLIST_PADDING;
-        m_demos.list.columns[4].width = m_demos.widest_pov * CONCHAR_WIDTH + MLIST_PADDING;
-        m_demos.list.numcolumns = COL_MAX;
-    } else {
-        // map and pov don't fit
-        w2 = uis.width - 17 * CONCHAR_WIDTH - MLIST_PADDING * 2 - MLIST_SCROLLBAR_WIDTH;
-        m_demos.list.columns[0].width = w2;
-        m_demos.list.columns[1].width = 12 * CONCHAR_WIDTH + MLIST_PADDING;
-        m_demos.list.columns[2].width = 5 * CONCHAR_WIDTH + MLIST_PADDING;
-        m_demos.list.columns[3].width = 0;
-        m_demos.list.columns[4].width = 0;
-        m_demos.list.numcolumns = COL_MAX - 2;
-    }
+	w1 = 17 + m_demos.widest_map + m_demos.widest_pov;
+	w2 = uis.width - w1 * CONCHAR_WIDTH - MLIST_PADDING * 4 - MLIST_SCROLLBAR_WIDTH;
+	if (w2 > 8 * CONCHAR_WIDTH) {
+		// everything fits
+		m_demos.list.columns[0].width = w2;
+		m_demos.list.columns[1].width = 12 * CONCHAR_WIDTH + MLIST_PADDING;
+		m_demos.list.columns[2].width = 5 * CONCHAR_WIDTH + MLIST_PADDING;
+		m_demos.list.columns[3].width = m_demos.widest_map * CONCHAR_WIDTH + MLIST_PADDING;
+		m_demos.list.columns[4].width = m_demos.widest_pov * CONCHAR_WIDTH + MLIST_PADDING;
+		m_demos.list.numcolumns = COL_MAX;
+	} else {
+		// map and pov don't fit
+		w2 = uis.width - 17 * CONCHAR_WIDTH - MLIST_PADDING * 2 - MLIST_SCROLLBAR_WIDTH;
+		m_demos.list.columns[0].width = w2;
+		m_demos.list.columns[1].width = 12 * CONCHAR_WIDTH + MLIST_PADDING;
+		m_demos.list.columns[2].width = 5 * CONCHAR_WIDTH + MLIST_PADDING;
+		m_demos.list.columns[3].width = 0;
+		m_demos.list.columns[4].width = 0;
+		m_demos.list.numcolumns = COL_MAX - 2;
+	}
 }
 
 static menuSound_t Keydown(menuFrameWork_t *self, int key)
 {
-    if (key == K_BACKSPACE) {
-        LeaveDirectory();
-        return QMS_OUT;
-    }
+	if (key == K_BACKSPACE) {
+		LeaveDirectory();
+		return QMS_OUT;
+	}
 
-    return QMS_NOTHANDLED;
+	return QMS_NOTHANDLED;
 }
 
 static void Draw(menuFrameWork_t *self)
 {
-    Menu_Draw(self);
-    if (uis.width >= 640) {
-        UI_DrawString(uis.width, uis.height - CONCHAR_HEIGHT,
-                      UI_RIGHT, COLOR_WHITE, m_demos.status);
-    }
+	Menu_Draw(self);
+	if (uis.width >= 640) {
+		UI_DrawString(uis.width, uis.height - CONCHAR_HEIGHT,
+			           UI_RIGHT, COLOR_WHITE, m_demos.status);
+	}
 }
 
 static void Pop(menuFrameWork_t *self)
 {
-    // save previous position
-    m_demos.selection = m_demos.list.curvalue;
-    FreeList();
+	// save previous position
+	m_demos.selection = m_demos.list.curvalue;
+	FreeList();
 }
 
 static void Expose(menuFrameWork_t *self)
 {
-    time_t now = time(NULL);
-    struct tm *tm = localtime(&now);
+	time_t now = time(NULL);
+	struct tm *tm = localtime(&now);
 
-    if (tm) {
-        m_demos.year = tm->tm_year;
-    }
+	if (tm) {
+		m_demos.year = tm->tm_year;
+	}
 
-    // check that target directory exists
-    if (strcmp(m_demos.browse, "/")
-        && ui_listalldemos->integer == 0
-        && os_access(va("%s%s", fs_gamedir, m_demos.browse), F_OK)) {
-        strcpy(m_demos.browse, "/");
-    }
+	// check that target directory exists
+	if (strcmp(m_demos.browse, "/")
+		&& ui_listalldemos->integer == 0
+		&& os_access(va("%s%s", fs_gamedir, m_demos.browse), F_OK)) {
+		strcpy(m_demos.browse, "/");
+	}
 
-    BuildList();
+	BuildList();
 
-    // move cursor to previous position
-    MenuList_SetValue(&m_demos.list, m_demos.selection);
+	// move cursor to previous position
+	MenuList_SetValue(&m_demos.list, m_demos.selection);
 }
 
 static void Free(menuFrameWork_t *self)
 {
-    Z_Free(m_demos.menu.items);
-    Z_Free(m_demos.menu_name);
-    Z_Free(m_demos.menu_title);
-    Z_Free(m_demos.status_no_demos);
-    Z_Free(m_demos.status_play_demo);
-    Z_Free(m_demos.status_change_dir);
-    Z_Free(m_demos.status_building);
-    memset(&m_demos, 0, sizeof(m_demos));
+	Z_Free(m_demos.menu.items);
+	Z_Free(m_demos.menu_name);
+	Z_Free(m_demos.menu_title);
+	Z_Free(m_demos.status_no_demos);
+	Z_Free(m_demos.status_play_demo);
+	Z_Free(m_demos.status_change_dir);
+	Z_Free(m_demos.status_building);
+	memset(&m_demos, 0, sizeof(m_demos));
 }
 
 static void ui_sortdemos_changed(cvar_t *self)
 {
-    int i = Cvar_ClampInteger(self, -COL_MAX, COL_MAX);
+	int i = Cvar_ClampInteger(self, -COL_MAX, COL_MAX);
 
-    if (i > 0) {
-        // ascending
-        m_demos.list.sortdir = 1;
-        m_demos.list.sortcol = i - 1;
-    } else if (i < 0) {
-        // descending
-        m_demos.list.sortdir = -1;
-        m_demos.list.sortcol = -i - 1;
-    } else {
-        // don't sort
-        m_demos.list.sortdir = 0;
-        m_demos.list.sortcol = 0;
-    }
+	if (i > 0) {
+		// ascending
+		m_demos.list.sortdir = 1;
+		m_demos.list.sortcol = i - 1;
+	} else if (i < 0) {
+		// descending
+		m_demos.list.sortdir = -1;
+		m_demos.list.sortcol = -i - 1;
+	} else {
+		// don't sort
+		m_demos.list.sortdir = 0;
+		m_demos.list.sortcol = 0;
+	}
 
-    if (m_demos.list.items && m_demos.list.sortdir) {
-        m_demos.list.sort(&m_demos.list);
-    }
+	if (m_demos.list.items && m_demos.list.sortdir) {
+		m_demos.list.sort(&m_demos.list);
+	}
 }
 
 void M_Menu_Demos(void)
 {
-    ui_sortdemos = Cvar_Get("ui_sortdemos", "1", 0);
-    ui_sortdemos->changed = ui_sortdemos_changed;
+	ui_sortdemos = Cvar_Get("ui_sortdemos", "1", 0);
+	ui_sortdemos->changed = ui_sortdemos_changed;
 
-    ui_listalldemos = Cvar_Get("ui_listalldemos", "0", 0);
+	ui_listalldemos = Cvar_Get("ui_listalldemos", "0", 0);
 
-    m_demos.menu_name = UI_CopyString("demos");
-    m_demos.menu_title = UI_CopyString("Demo Browser");
-    m_demos.status_no_demos = UI_CopyString("No demos found");
-    m_demos.status_play_demo = UI_CopyString("Press Enter to play demo");
-    m_demos.status_change_dir = UI_CopyString("Press Enter to change directory");
-    m_demos.status_building = UI_CopyString("Building list...");
+	m_demos.menu_name = UI_CopyString("demos");
+	m_demos.menu_title = UI_CopyString("Demo Browser");
+	m_demos.status_no_demos = UI_CopyString("No demos found");
+	m_demos.status_play_demo = UI_CopyString("Press Enter to play demo");
+	m_demos.status_change_dir = UI_CopyString("Press Enter to change directory");
+	m_demos.status_building = UI_CopyString("Building list...");
 
-    m_demos.menu.name = m_demos.menu_name;
-    m_demos.menu.title = m_demos.menu_title;
-    m_demos.menu.status = m_demos.status_no_demos;
+	m_demos.menu.name = m_demos.menu_name;
+	m_demos.menu.title = m_demos.menu_title;
+	m_demos.menu.status = m_demos.status_no_demos;
 
-    strcpy(m_demos.browse, "/demos");
+	strcpy(m_demos.browse, "/demos");
 
-    m_demos.menu.draw       = Draw;
-    m_demos.menu.expose     = Expose;
-    m_demos.menu.pop        = Pop;
-    m_demos.menu.size       = Size;
-    m_demos.menu.keydown    = Keydown;
-    m_demos.menu.free       = Free;
-    m_demos.menu.image      = uis.backgroundHandle;
-    m_demos.menu.color.u32  = uis.color.background.u32;
-    m_demos.menu.transparent    = uis.transparent;
+	m_demos.menu.draw       = Draw;
+	m_demos.menu.expose     = Expose;
+	m_demos.menu.pop        = Pop;
+	m_demos.menu.size       = Size;
+	m_demos.menu.keydown    = Keydown;
+	m_demos.menu.free       = Free;
+	m_demos.menu.image      = uis.backgroundHandle;
+	m_demos.menu.color.u32  = uis.color.background.u32;
+	m_demos.menu.transparent    = uis.transparent;
 
-    m_demos.list.generic.type   = MTYPE_LIST;
-    m_demos.list.generic.flags  = QMF_HASFOCUS;
-    m_demos.list.generic.activate = Activate;
-    m_demos.list.generic.change = Change;
-    m_demos.list.numcolumns     = COL_MAX;
-    m_demos.list.sortdir        = 1;
-    m_demos.list.sortcol        = COL_NAME;
-    m_demos.list.extrasize      = DEMO_EXTRASIZE;
-    m_demos.list.sort           = Sort;
-    m_demos.list.mlFlags        = MLF_HEADER | MLF_SCROLLBAR;
+	m_demos.list.generic.type   = MTYPE_LIST;
+	m_demos.list.generic.flags  = QMF_HASFOCUS;
+	m_demos.list.generic.activate = Activate;
+	m_demos.list.generic.change = Change;
+	m_demos.list.numcolumns     = COL_MAX;
+	m_demos.list.sortdir        = 1;
+	m_demos.list.sortcol        = COL_NAME;
+	m_demos.list.extrasize      = DEMO_EXTRASIZE;
+	m_demos.list.sort           = Sort;
+	m_demos.list.mlFlags        = MLF_HEADER | MLF_SCROLLBAR;
 
-    m_demos.list.columns[0].name    = m_demos.browse;
-    m_demos.list.columns[0].uiFlags = UI_LEFT;
-    m_demos.list.columns[1].name    = "Date";
-    m_demos.list.columns[1].uiFlags = UI_CENTER;
-    m_demos.list.columns[2].name    = "Size";
-    m_demos.list.columns[2].uiFlags = UI_RIGHT;
-    m_demos.list.columns[3].name    = "Map";
-    m_demos.list.columns[3].uiFlags = UI_CENTER;
-    m_demos.list.columns[4].name    = "POV";
-    m_demos.list.columns[4].uiFlags = UI_CENTER;
+	m_demos.list.columns[0].name    = m_demos.browse;
+	m_demos.list.columns[0].uiFlags = UI_LEFT;
+	m_demos.list.columns[1].name    = "Date";
+	m_demos.list.columns[1].uiFlags = UI_CENTER;
+	m_demos.list.columns[2].name    = "Size";
+	m_demos.list.columns[2].uiFlags = UI_RIGHT;
+	m_demos.list.columns[3].name    = "Map";
+	m_demos.list.columns[3].uiFlags = UI_CENTER;
+	m_demos.list.columns[4].name    = "POV";
+	m_demos.list.columns[4].uiFlags = UI_CENTER;
 
-    ui_sortdemos_changed(ui_sortdemos);
+	ui_sortdemos_changed(ui_sortdemos);
 
-    Menu_AddItem(&m_demos.menu, &m_demos.list);
+	Menu_AddItem(&m_demos.menu, &m_demos.list);
 
-    List_Append(&ui_menus, &m_demos.menu.entry);
+	List_Append(&ui_menus, &m_demos.menu.entry);
 }

--- a/src/unix/tty.cpp
+++ b/src/unix/tty.cpp
@@ -617,16 +617,16 @@ void tty_shutdown_input(void)
 
 void Sys_LoadHistory(void)
 {
-    if (tty_enabled && sys_history && sys_history->integer > 0) {
-        Prompt_LoadHistory(&tty_prompt, SYS_HISTORYFILE_NAME);
-    }
+	if (tty_enabled && sys_history && sys_history->integer > 0) {
+		Prompt_LoadHistory(&tty_prompt, SYS_CON_HISTORY_FILE);
+	}
 }
 
 void Sys_SaveHistory(void)
 {
-    if (tty_enabled && sys_history && sys_history->integer > 0) {
-        Prompt_SaveHistory(&tty_prompt, SYS_HISTORYFILE_NAME, sys_history->integer);
-    }
+	if (tty_enabled && sys_history && sys_history->integer > 0) {
+		Prompt_SaveHistory(&tty_prompt, SYS_CON_HISTORY_FILE, sys_history->integer);
+	}
 }
 
 void Sys_RunConsole(void)

--- a/src/windows/system.cpp
+++ b/src/windows/system.cpp
@@ -1163,18 +1163,18 @@ void WinConsole::setTitle(const char *title)
 
 void WinConsole::loadHistory()
 {
-    if (ready_ && sys_history && sys_history->integer > 0) {
-        Prompt_LoadHistory(&sys_con, SYS_HISTORYFILE_NAME);
-        markInputDirty();
-        showInput();
-    }
+	if (ready_ && sys_history && sys_history->integer > 0) {
+		Prompt_LoadHistory(&sys_con, SYS_CON_HISTORY_FILE);
+		markInputDirty();
+		showInput();
+	}
 }
 
 void WinConsole::saveHistory()
 {
-    if (ready_ && sys_history && sys_history->integer > 0) {
-        Prompt_SaveHistory(&sys_con, SYS_HISTORYFILE_NAME, sys_history->integer);
-    }
+	if (ready_ && sys_history && sys_history->integer > 0) {
+		Prompt_SaveHistory(&sys_con, SYS_CON_HISTORY_FILE, sys_history->integer);
+	}
 }
 
 } // namespace


### PR DESCRIPTION
## Summary
- introduce clearer constant names for console history, demo cache, and system history files
- update code to use the new constant names while keeping compatibility aliases
- align related history handling indentation with tabbed formatting

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f74d52c908328b358ae76f428347a)