### PR TITLE
Handle extended image limits

### DIFF
--- a/src/client/client.hpp
+++ b/src/client/client.hpp
@@ -296,7 +296,7 @@ typedef struct client_state_s {
 	int             keyservertime;
 #endif
 
-	size_t          dcs[BC_COUNT(MAX_CONFIGSTRINGS)];
+	size_t          dcs[BC_COUNT(MAX_MAX_CONFIGSTRINGS)];
 
 	// the client maintains its own idea of view angles, which are
 	// sent to the server each frame.  It is cleared to 0 upon entering each level.
@@ -355,8 +355,8 @@ typedef struct client_state_s {
 	frametime_t frametime;
 	float       frametime_inv;  // 1/frametime
 
-	configstring_t  baseconfigstrings[MAX_CONFIGSTRINGS];
-	configstring_t  configstrings[MAX_CONFIGSTRINGS];
+	configstring_t  baseconfigstrings[MAX_MAX_CONFIGSTRINGS];
+	configstring_t  configstrings[MAX_MAX_CONFIGSTRINGS];
 	cs_remap_t      csr;
 	q2proto_game_api_t game_api;
 
@@ -376,7 +376,7 @@ typedef struct client_state_s {
 	const mmodel_t* model_clip[MAX_MODELS];
 
 	qhandle_t sound_precache[MAX_SOUNDS];
-	qhandle_t image_precache[MAX_IMAGES];
+	qhandle_t image_precache[MAX_IMAGES_EX];
 	qhandle_t sfx_hit_marker;
 
 	clientinfo_t    clientinfo[MAX_CLIENTS];

--- a/src/client/demo.cpp
+++ b/src/client/demo.cpp
@@ -447,7 +447,7 @@ static const cmd_option_t o_record[] = {
 };
 
 // Data needed for write_gamestate in CL_Record_f. Too large for stack, so store statically.
-static q2proto_svc_configstring_t configstrings[MAX_CONFIGSTRINGS];
+static q2proto_svc_configstring_t configstrings[MAX_MAX_CONFIGSTRINGS];
 static q2proto_svc_spawnbaseline_t spawnbaselines[MAX_EDICTS];
 
 /*

--- a/src/server/mvd/client.hpp
+++ b/src/server/mvd/client.hpp
@@ -163,9 +163,9 @@ typedef struct mvd_s {
     vec3_t          spawnOrigin;
     vec3_t          spawnAngles;
     pmtype_t        pm_type;
-    size_t          dcs[BC_COUNT(MAX_CONFIGSTRINGS)];
-    configstring_t  baseconfigstrings[MAX_CONFIGSTRINGS];
-    configstring_t  configstrings[MAX_CONFIGSTRINGS];
+    size_t          dcs[BC_COUNT(MAX_MAX_CONFIGSTRINGS)];
+    configstring_t  baseconfigstrings[MAX_MAX_CONFIGSTRINGS];
+    configstring_t  configstrings[MAX_MAX_CONFIGSTRINGS];
     const cs_remap_t *csr;
     msgEsFlags_t    esFlags;
     msgPsFlags_t    psFlags;

--- a/src/server/user.cpp
+++ b/src/server/user.cpp
@@ -101,7 +101,7 @@ static void SV_CreateBaselines(void)
 }
 
 // Data needed for write_gamestate. Too large for stack, so store statically.
-static q2proto_svc_configstring_t configstrings[MAX_CONFIGSTRINGS];
+static q2proto_svc_configstring_t configstrings[MAX_MAX_CONFIGSTRINGS];
 static q2proto_svc_spawnbaseline_t spawnbaselines[MAX_EDICTS];
 
 /*


### PR DESCRIPTION
## Summary
- expand client and server configstring buffers to cover extended protocol limits
- allow client image precache to accommodate the extended image count

## Testing
- ninja -C build *(fails: build directory not configured)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f74e000548328a2482509ebd2f20b)