### PR TITLE
Add bitwriter bit count validation

### DIFF
--- a/q2proto/src/q2proto_internal_bit_read_write.h
+++ b/q2proto/src/q2proto_internal_bit_read_write.h
@@ -25,108 +25,187 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef Q2PROTO_INTERNAL_BIT_READ_WRITE_H_
 #define Q2PROTO_INTERNAL_BIT_READ_WRITE_H_
 
+#include <assert.h>
+
 typedef struct bitwriter_s {
-    uintptr_t io_arg;
-    uint32_t buf;
-    uint32_t left;
+	uintptr_t io_arg;
+	uint32_t buf;
+	uint32_t left;
 } bitwriter_t;
 
+/*
+=============
+bitwriter_init
+
+Initialize a bitwriter structure with the provided IO argument.
+=============
+*/
 static inline void bitwriter_init(bitwriter_t *bitwriter, uintptr_t io_arg)
 {
-    bitwriter->io_arg = io_arg;
-    bitwriter->buf = 0;
-    bitwriter->left = 32;
+	bitwriter->io_arg = io_arg;
+	bitwriter->buf = 0;
+	bitwriter->left = 32;
 }
 
+#if defined(__has_builtin)
+#define Q2P_HAS_BUILTIN(BUILTIN) __has_builtin(BUILTIN)
+#else
+#define Q2P_HAS_BUILTIN(BUILTIN) 0
+#endif
+
+#if defined(__GNUC__) || defined(__clang__)
+#define Q2P_CAN_STATIC_ASSERT_BITS 1
+#else
+#define Q2P_CAN_STATIC_ASSERT_BITS 0
+#endif
+
+#define Q2P_BITWRITER_BITS_VALID(BITS) ((BITS) >= -31 && (BITS) <= 31 && (BITS) != 0)
+
+#if Q2P_CAN_STATIC_ASSERT_BITS
+#define Q2P_BITWRITER_STATIC_ASSERT(BITS)                                                                 \
+	do {                                                                                               \
+	if (Q2P_HAS_BUILTIN(__builtin_constant_p) && __builtin_constant_p(BITS)) {                   \
+	_Static_assert(Q2P_BITWRITER_BITS_VALID(BITS), "bit count for bitwriter_write is out of range"); \
+	}                                                                                            \
+	} while (0)
+#else
+#define Q2P_BITWRITER_STATIC_ASSERT(BITS)                                                                 \
+	do {                                                                                               \
+	} while (0)
+#endif
+
+#define Q2P_BITWRITER_DEBUG_ASSERT(BITS)                                                                   \
+	do {                                                                                               \
+	Q2P_BITWRITER_STATIC_ASSERT(BITS);                                                             \
+	assert(Q2P_BITWRITER_BITS_VALID(BITS));                                                        \
+	} while (0)
+
+/*
+=============
+bitwriter_write
+
+Write a value using the specified number of bits into the bitwriter buffer.
+=============
+*/
 static inline q2proto_error_t bitwriter_write(bitwriter_t *bitwriter, int value, int bits)
 {
-    if (bits == 0 || bits < -31 || bits > 31) // FIXME?: assert
-        return Q2P_ERR_BAD_DATA;
+	Q2P_BITWRITER_DEBUG_ASSERT(bits);
+	if (!Q2P_BITWRITER_BITS_VALID(bits))
+	return Q2P_ERR_BAD_DATA;
 
-    if (bits < 0) {
-        bits = -bits;
-    }
-
-    uint32_t bits_buf = bitwriter->buf;
-    uint32_t bits_left = bitwriter->left;
-    uint32_t v = value & ((1U << bits) - 1);
-
-    bits_buf |= v << (32 - bits_left);
-    if (bits >= bits_left) {
-        WRITE_CHECKED(client_write, bitwriter->io_arg, u32, bits_buf);
-        bits_buf = v >> bits_left;
-        bits_left += 32;
-    }
-    bits_left -= bits;
-
-    bitwriter->buf = bits_buf;
-    bitwriter->left = bits_left;
-    return Q2P_ERR_SUCCESS;
+	if (bits < 0) {
+	bits = -bits;
 }
 
+	uint32_t bits_buf = bitwriter->buf;
+	uint32_t bits_left = bitwriter->left;
+	uint32_t v = value & ((1U << bits) - 1);
+
+	bits_buf |= v << (32 - bits_left);
+	if (bits >= bits_left) {
+	WRITE_CHECKED(client_write, bitwriter->io_arg, u32, bits_buf);
+	bits_buf = v >> bits_left;
+	bits_left += 32;
+}
+	bits_left -= bits;
+
+	bitwriter->buf = bits_buf;
+	bitwriter->left = bits_left;
+	return Q2P_ERR_SUCCESS;
+}
+
+/*
+=============
+bitwriter_flush
+
+Flush any buffered bits to the writer's output.
+=============
+*/
 static inline q2proto_error_t bitwriter_flush(bitwriter_t *bitwriter)
 {
-    uint32_t bits_buf = bitwriter->buf;
-    uint32_t bits_left = bitwriter->left;
+	uint32_t bits_buf = bitwriter->buf;
+	uint32_t bits_left = bitwriter->left;
 
-    while (bits_left < 32) {
-        WRITE_CHECKED(client_write, bitwriter->io_arg, u8, bits_buf & 255);
-        bits_buf >>= 8;
-        bits_left += 8;
-    }
+	while (bits_left < 32) {
+	WRITE_CHECKED(client_write, bitwriter->io_arg, u8, bits_buf & 255);
+	bits_buf >>= 8;
+	bits_left += 8;
+}
 
-    bitwriter->buf = 0;
-    bitwriter->left = 32;
-    return Q2P_ERR_SUCCESS;
+	bitwriter->buf = 0;
+	bitwriter->left = 32;
+	return Q2P_ERR_SUCCESS;
 }
 
 typedef struct bitreader_s {
-    uintptr_t io_arg;
-    uint32_t buf;
-    uint32_t left;
+	uintptr_t io_arg;
+	uint32_t buf;
+	uint32_t left;
 } bitreader_t;
 
+/*
+=============
+bitreader_init
+
+Initialize a bitreader structure with the provided IO argument.
+=============
+*/
 static inline void bitreader_init(bitreader_t *bitreader, uintptr_t io_arg)
 {
-    bitreader->io_arg = io_arg;
-    bitreader->buf = 0;
-    bitreader->left = 0;
+	bitreader->io_arg = io_arg;
+	bitreader->buf = 0;
+	bitreader->left = 0;
 }
 
-static inline int32_t sign_extend(uint32_t v, int bits) { return (int32_t)(v << (32 - bits)) >> (32 - bits); }
+/*
+=============
+sign_extend
+=============
+*/
+static inline int32_t sign_extend(uint32_t v, int bits)
+{
+	return (int32_t)(v << (32 - bits)) >> (32 - bits);
+}
 
 // positive bits: read unsigned. negative bits: read signed.
+/*
+=============
+bitreader_read
+
+Read a value using the specified number of bits from the bitreader buffer.
+=============
+*/
 static inline q2proto_error_t bitreader_read(bitreader_t *bitreader, int bits, int *value)
 {
-    bool sgn = false;
+	bool sgn = false;
 
-    if (bits == 0 || bits < -25 || bits > 25) // FIXME?: assert
-        return Q2P_ERR_BAD_DATA;
+	if (bits == 0 || bits < -25 || bits > 25) // FIXME?: assert
+	return Q2P_ERR_BAD_DATA;
 
-    if (bits < 0) {
-        bits = -bits;
-        sgn = true;
-    }
+	if (bits < 0) {
+	bits = -bits;
+	sgn = true;
+	}
 
-    uint32_t bits_buf = bitreader->buf;
-    uint32_t bits_left = bitreader->left;
+	uint32_t bits_buf = bitreader->buf;
+	uint32_t bits_left = bitreader->left;
 
-    while (bits > bits_left) {
-        uint8_t new_byte;
-        READ_CHECKED(server_read, bitreader->io_arg, new_byte, u8);
-        bits_buf |= new_byte << bits_left;
-        bits_left += 8;
-    }
+	while (bits > bits_left) {
+	uint8_t new_byte;
+	READ_CHECKED(server_read, bitreader->io_arg, new_byte, u8);
+	bits_buf |= new_byte << bits_left;
+	bits_left += 8;
+	}
 
-    *value = bits_buf & ((1U << bits) - 1);
+	*value = bits_buf & ((1U << bits) - 1);
 
-    bitreader->buf = bits_buf >> bits;
-    bitreader->left = bits_left - bits;
+	bitreader->buf = bits_buf >> bits;
+	bitreader->left = bits_left - bits;
 
-    if (sgn)
-        *value = sign_extend(*value, bits);
+	if (sgn)
+	*value = sign_extend(*value, bits);
 
-    return Q2P_ERR_SUCCESS;
+	return Q2P_ERR_SUCCESS;
 }
 
 #endif // Q2PROTO_INTERNAL_BIT_READ_WRITE_H_


### PR DESCRIPTION
## Summary
- add debug and compile-time validation for bitwriter bit count range
- document bit read/write helpers with function headers and tabbed indentation
- ensure bit count checks occur before masking in bitwriter

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f74ed2bd08328ae10440dc5a12ca3)