### PR TITLE
Add cleanup hooks for q2proto zlib streams

### DIFF
--- a/inc/common/q2proto_shared.hpp
+++ b/inc/common/q2proto_shared.hpp
@@ -43,6 +43,7 @@ struct q2protoio_deflate_args_s
 void Q2Proto_IO_Init(void);
 void Q2Proto_IO_ResetInflate(void);
 void Q2Proto_IO_Shutdown(void);
+void Q2Proto_IO_ShutdownDeflate(struct q2protoio_deflate_args_s *deflate_args);
 #endif // USE_ZLIB
 
 typedef struct q2protoio_ioarg_s {

--- a/src/client/demo.cpp
+++ b/src/client/demo.cpp
@@ -1520,9 +1520,12 @@ void CL_CleanupDemos(void)
             Cbuf_Clear(&cl_cmdbuf);
     }
 
-    CL_FreeDemoSnapshots();
+	CL_FreeDemoSnapshots();
+	#if USE_ZLIB
+		Q2Proto_IO_ShutdownDeflate(&cls.demo.q2proto_deflate);
+	#endif
 
-    memset(&cls.demo, 0, sizeof(cls.demo));
+	memset(&cls.demo, 0, sizeof(cls.demo));
 }
 
 /*

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -692,40 +692,44 @@ CL_ClearState
 */
 void CL_ClearState(void)
 {
-    S_GetSoundSystem().StopAllSounds();
-    SCR_StopCinematic();
-    CL_ClearEffects();
-    CL_ClearTEnts();
-    LOC_FreeLocations();
-    CL_FreeDemoSnapshots();
-    SCR_Clear();
+	S_GetSoundSystem().StopAllSounds();
+	SCR_StopCinematic();
+	CL_ClearEffects();
+	CL_ClearTEnts();
+	LOC_FreeLocations();
+	CL_FreeDemoSnapshots();
+	SCR_Clear();
+#if USE_ZLIB
+	Q2Proto_IO_Shutdown();
+#endif
 
-    // wipe the entire cl structure
-    BSP_Free(cl.bsp);
-    memset(&cl, 0, sizeof(cl));
-    memset(&cl_entities, 0, sizeof(cl_entities));
+	// wipe the entire cl structure
+	BSP_Free(cl.bsp);
+	memset(&cl, 0, sizeof(cl));
+	memset(&cl_entities, 0, sizeof(cl_entities));
 
-    cl.slow_time.factor = 1.0f;
-    cl.slow_time.from = 1.0f;
-    cl.slow_time.to = 1.0f;
-    cl.slow_time.start = {};
+	cl.slow_time.factor = 1.0f;
+	cl.slow_time.from = 1.0f;
+	cl.slow_time.to = 1.0f;
+	cl.slow_time.start = {};
 
-    if (cls.state > ca_connected) {
-        cls.state = ca_connected;
-        CL_CheckForPause();
-        CL_UpdateFrameTimes();
-    }
+	if (cls.state > ca_connected) {
+		cls.state = ca_connected;
+		CL_CheckForPause();
+		CL_UpdateFrameTimes();
+	}
 
-    // unprotect game cvar
-    fs_game->flags &= ~CVAR_ROM;
+	// unprotect game cvar
+	fs_game->flags &= ~CVAR_ROM;
 
 #if USE_REF
-    // unprotect our custom modulate cvars
-    gl_modulate_world->flags &= ~CVAR_CHEAT;
-    gl_modulate_entities->flags &= ~CVAR_CHEAT;
-    gl_brightness->flags &= ~CVAR_CHEAT;
+	// unprotect our custom modulate cvars
+	gl_modulate_world->flags &= ~CVAR_CHEAT;
+	gl_modulate_entities->flags &= ~CVAR_CHEAT;
+	gl_brightness->flags &= ~CVAR_CHEAT;
 #endif
 }
+
 
 /*
 =====================

--- a/src/server/main.cpp
+++ b/src/server/main.cpp
@@ -153,30 +153,33 @@ void SV_RemoveClient(client_t *client)
 
 void SV_CleanClient(client_t *client)
 {
-    int i;
+	int i;
 #if USE_AC_SERVER
-    string_entry_t *bad, *next;
+	string_entry_t *bad, *next;
 
-    for (bad = client->ac_bad_files; bad; bad = next) {
-        next = bad->next;
-        Z_Free(bad);
-    }
-    client->ac_bad_files = NULL;
+	for (bad = client->ac_bad_files; bad; bad = next) {
+	    next = bad->next;
+	    Z_Free(bad);
+	}
+	client->ac_bad_files = NULL;
 #endif
 
-    // close any existing download
-    SV_CloseDownload(client);
+	// close any existing download
+	SV_CloseDownload(client);
 
-    Z_Freep(&client->version_string);
+	Z_Freep(&client->version_string);
 
-    // free baselines allocated for this client
-    for (i = 0; i < SV_BASELINES_CHUNKS; i++) {
-        Z_Freep(&client->baselines[i]);
-    }
+	// free baselines allocated for this client
+	for (i = 0; i < SV_BASELINES_CHUNKS; i++) {
+	    Z_Freep(&client->baselines[i]);
+	}
 
-    // free packet entities
-    Z_Freep(&client->entities);
-    client->num_entities = 0;
+	// free packet entities
+	Z_Freep(&client->entities);
+	client->num_entities = 0;
+#if USE_ZLIB
+	Q2Proto_IO_ShutdownDeflate(&client->q2proto_deflate);
+#endif
 }
 
 static void print_drop_reason(client_t *client, const char *reason, clstate_t oldstate)


### PR DESCRIPTION
## Summary
- add helper utilities to tear down inflate/deflate streams and reset initialization state on completion or errors
- hook cleanup calls into client disconnect/demo teardown and server client cleanup paths

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f8a40ebc88328b39fe2e7a09dd442)