### PR TITLE
Add effect culling implementation to client build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -179,6 +179,7 @@ client_src = [
   'src/client/cgame_classic.hpp',
   'src/common/async.cpp',
   'src/common/gamedll.cpp',
+  'src/server/effect_cull.cpp',
   'src/server/commands.cpp',
   'src/server/entities.cpp',
   'src/server/game.cpp',


### PR DESCRIPTION
## Summary
- include the server effect culling implementation in the client build sources
- ensure the client build links SV_ShouldDistanceCullEffect

## Testing
- not run (build directory missing)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fa93b6fe08328946a9eae4ceb087d)