### PR TITLE
Align fallback deps with C++20

### DIFF
--- a/subprojects/rerelease-game/meson.build
+++ b/subprojects/rerelease-game/meson.build
@@ -224,7 +224,12 @@ endif
 add_project_arguments(args, language: 'cpp')
 add_project_link_arguments(link_args, language: 'cpp')
 
-fallback_opt = ['default_library=static', 'b_vscrt=static_from_buildtype', 'buildtype=' + get_option('buildtype'), ]
+fallback_opt = [
+  'default_library=static',
+  'b_vscrt=static_from_buildtype',
+  'buildtype=' + get_option('buildtype'),
+  'cpp_std=c++20',
+]
 
 deps = [
   dependency('fmt', default_options: fallback_opt),


### PR DESCRIPTION
## Summary
- ensure fallback dependency builds request C++20 to match project standard and avoid MSVC downgrades

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fa953c5388328840771a60af60247)