### PR TITLE
Refactor UI JSON parsing error handling

### DIFF
--- a/src/client/sound/al.cpp
+++ b/src/client/sound/al.cpp
@@ -494,19 +494,19 @@ static void AL_SetReverbStepIDs(void)
 
 static void AL_LoadReverbEnvironments(void)
 {
-    json_parse_t parser = {0};
-    al_reverb_environment_t *environments = NULL;
-    size_t n = 0;
+	json_parse_t parser = {0};
+	al_reverb_environment_t *environments = NULL;
+	size_t n = 0;
 
-    if (Json_ErrorHandler(parser)) {
-        Com_WPrintf("Couldn't load sound/default.environments[%s]; %s\n", parser.error_loc, parser.error);
-        AL_FreeReverbEnvironments(environments, n);
-        return;
-    }
+	if (Json_ErrorHandler(&parser)) {
+		Com_WPrintf("Couldn't load sound/default.environments[%s]; %s\n", parser.error_loc, parser.error);
+		AL_FreeReverbEnvironments(environments, n);
+		return;
+	}
 
-    Json_Load("sound/default.environments", &parser);
+	Json_Load("sound/default.environments", &parser);
 
-    Json_EnsureNext(&parser, JSMN_OBJECT);
+	Json_EnsureNext(&parser, JSMN_OBJECT);
 
     if (Json_Strcmp(&parser, "environments")) 
         Json_Error(&parser, parser.pos, "expected \"environments\" key\n");

--- a/src/common/mapdb.cpp
+++ b/src/common/mapdb.cpp
@@ -217,13 +217,13 @@ static void MapDB_ParseKeys(json_parse_t *parser, void *obj, const mapdb_key_t *
 void MapDB_Init(void)
 {
 	json_parse_t parser = {0};
-	
-    if (Json_ErrorHandler(parser)) {
+
+	if (Json_ErrorHandler(&parser)) {
 		Com_WPrintf("Failed to load/parse mapdb.json[%s]: %s\n", parser.error_loc, parser.error);
 		MapDB_Shutdown();
-        return;
-    }
-	
+		return;
+	}
+
 	Json_Load("mapdb.json", &parser);
 
 	jsmntok_t *obj = Json_EnsureNext(&parser, JSMN_OBJECT);

--- a/tests/ui_bad.menu.json
+++ b/tests/ui_bad.menu.json
@@ -1,0 +1,22 @@
+{
+  "menus": [
+    {
+      "name": "broken_menu",
+      "title": "Broken Menu",
+      "items": [
+        {
+          "type": "strings",
+          "label": "Bad Options",
+          "cvar": "menu_bad",
+          "options": [
+            {
+              "label": "bad",
+              "value": "broken"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+


### PR DESCRIPTION
## Summary
- add guard tracking and assertions around JSON error handling to avoid unguarded longjmps
- refactor UI menu loading to parse through a shared root helper and handle file/embedded fallbacks safely
- tighten menu option parsing logic and add a malformed menu fixture for error testing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fb442f4a48328a25d14cfe0adf34c)