### PR TITLE
Add MenuItem interface for UI lifecycle management

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -208,6 +208,7 @@ client_src = [
 ]
 
 ui_src = [
+  'src/client/ui/MenuItem.cpp',
   'src/client/ui/demos.cpp',
   'src/client/ui/menu.cpp',
   'src/client/ui/playerconfig.cpp',

--- a/src/client/ui/MenuItem.cpp
+++ b/src/client/ui/MenuItem.cpp
@@ -1,0 +1,142 @@
+#include "MenuItem.h"
+
+#include <algorithm>
+#include <utility>
+
+/*
+==============
+MenuItem
+
+Constructs a menu item with ownership-aware resources and optional children.
+==============
+*/
+MenuItem::MenuItem(std::string name,
+	TextureHandle texture,
+	Callback onActivate,
+	std::vector<std::shared_ptr<MenuItem>> children)
+	: m_name(std::move(name)),
+	m_texture(std::move(texture)),
+	m_onActivate(std::move(onActivate)),
+	m_children(std::move(children))
+{
+}
+
+/*
+==============
+~MenuItem
+
+Virtual destructor to ensure derived classes release resources cleanly.
+==============
+*/
+MenuItem::~MenuItem() = default;
+
+/*
+==============
+GetName
+
+Returns the immutable name assigned during construction.
+==============
+*/
+const std::string &MenuItem::GetName() const
+{
+	return m_name;
+}
+
+/*
+==============
+GetTexture
+
+Provides read-only access to the retained texture handle. The shared pointer
+keeps the underlying texture alive for the lifetime of the menu item.
+==============
+*/
+const MenuItem::TextureHandle &MenuItem::GetTexture() const
+{
+	return m_texture;
+}
+
+/*
+==============
+GetChildren
+
+Exposes shared ownership of child items. Holding on to the returned references
+keeps children alive as long as the caller retains a shared_ptr reference.
+==============
+*/
+const std::vector<std::shared_ptr<MenuItem>> &MenuItem::GetChildren() const
+{
+	return m_children;
+}
+
+/*
+==============
+SetActivateCallback
+
+Updates the activation callback. The std::function allows callers to provide
+RAII-friendly functors that manage captured resources safely.
+==============
+*/
+void MenuItem::SetActivateCallback(Callback callback)
+{
+	m_onActivate = std::move(callback);
+}
+
+/*
+==============
+AddChild
+
+Appends a child to the ownership-tracking collection. Shared ownership ensures
+children remain valid independently of the menu hierarchy.
+==============
+*/
+void MenuItem::AddChild(std::shared_ptr<MenuItem> child)
+{
+	m_children.emplace_back(std::move(child));
+}
+
+/*
+==============
+RemoveChild
+
+Removes a matching child instance from the container while leaving other
+shared references untouched.
+==============
+*/
+void MenuItem::RemoveChild(const std::shared_ptr<MenuItem> &child)
+{
+	m_children.erase(
+		std::remove(m_children.begin(), m_children.end(), child),
+		m_children.end());
+}
+
+/*
+==============
+ForEachChild
+
+Invokes a visitor for every child entry, preserving shared ownership during the
+iteration.
+==============
+*/
+void MenuItem::ForEachChild(const std::function<void(const std::shared_ptr<MenuItem> &)> &visitor) const
+{
+	for (const auto &child : m_children)
+	{
+		visitor(child);
+	}
+}
+
+/*
+==============
+TriggerActivate
+
+Invokes the activation callback when set. The callback owns its captured state
+through std::function and follows normal RAII semantics.
+==============
+*/
+void MenuItem::TriggerActivate()
+{
+	if (m_onActivate)
+	{
+		m_onActivate(*this);
+	}
+}

--- a/src/client/ui/MenuItem.h
+++ b/src/client/ui/MenuItem.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+/*
+==============================================================================
+MenuItem
+
+Interface describing the ownership and lifecycle expectations for UI menu
+items. Texture handles and children are stored via shared ownership to keep
+resources alive as long as a menu item exists. Callbacks are supplied via
+std::function so callers can pass lambdas or other RAII-friendly callables
+without leaking state.
+==============================================================================
+*/
+class MenuItem {
+public:
+	using TextureHandle = std::shared_ptr<void>;
+	using Callback = std::function<void(MenuItem &)>;
+
+	struct MenuEvent {
+		enum class Type {
+			Key,
+			Pointer,
+			Controller
+		};
+
+		Type type{Type::Key};
+		int key{0};
+		int x{0};
+		int y{0};
+	};
+
+	MenuItem(std::string name,
+		TextureHandle texture,
+		Callback onActivate,
+		std::vector<std::shared_ptr<MenuItem>> children = {});
+
+	MenuItem(const MenuItem &) = delete;
+	MenuItem(MenuItem &&) = delete;
+	MenuItem &operator=(const MenuItem &) = delete;
+	MenuItem &operator=(MenuItem &&) = delete;
+
+	virtual ~MenuItem();
+
+	const std::string &GetName() const;
+	const TextureHandle &GetTexture() const;
+	const std::vector<std::shared_ptr<MenuItem>> &GetChildren() const;
+
+	void SetActivateCallback(Callback callback);
+
+protected:
+	void AddChild(std::shared_ptr<MenuItem> child);
+	void RemoveChild(const std::shared_ptr<MenuItem> &child);
+	void ForEachChild(const std::function<void(const std::shared_ptr<MenuItem> &)> &visitor) const;
+	void TriggerActivate();
+
+	virtual void Draw() const = 0;
+	virtual bool HandleEvent(const MenuEvent &event) = 0;
+	virtual bool Activate() = 0;
+	virtual void SetFocus(bool hasFocus) = 0;
+	virtual bool HasFocus() const = 0;
+	virtual void OnAttach() = 0;
+	virtual void OnDetach() = 0;
+
+private:
+	std::string m_name;
+	TextureHandle m_texture;
+	Callback m_onActivate;
+	std::vector<std::shared_ptr<MenuItem>> m_children;
+};


### PR DESCRIPTION
## Summary
- add a pure virtual MenuItem interface capturing drawing, activation, focus, and lifecycle hooks
- document ownership expectations for textures, callbacks, and child items using RAII-friendly types
- register the new interface implementation in the UI build sources

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920b62956148328933d6c9edd3a5eb6)