### PR TITLE
Refactor menu item construction

### DIFF
--- a/src/client/ui/ui.hpp
+++ b/src/client/ui/ui.hpp
@@ -93,6 +93,11 @@ typedef enum {
 
 #define DOUBLE_CLICK_DELAY    300
 
+#include <memory>
+#include <vector>
+
+class MenuItem;
+
 #define UI_IsItemSelectable(item) \
     ((item)->type != MTYPE_SEPARATOR && \
      (item)->type != MTYPE_STATIC && \
@@ -136,6 +141,8 @@ char    *name, *title, *status;
 	bool allowInputPassthrough;
 	bool drawsBackdrop;
 	float opacity;
+
+	std::vector<std::unique_ptr<MenuItem>> itemsCpp;
 
 	bool (*push)(struct menuFrameWork_s *);
 	void (*pop)(struct menuFrameWork_s *);


### PR DESCRIPTION
## Summary
- create helper factories to build C++ MenuItem subclasses with shared callbacks and texture handles
- attach managed MenuItem instances to menus during item addition and release them when menus are freed
- update test setup to value-initialize menu state instead of raw memory zeroing

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920bce693208328bc2726dd20f52022)