### PR TITLE
Harden menu item resource ownership

### DIFF
--- a/src/client/ui/MenuItem.cpp
+++ b/src/client/ui/MenuItem.cpp
@@ -154,8 +154,7 @@ Safely unwraps a shared_ptr-backed texture handle for draw routines.
 */
 static qhandle_t UI_ResolveHandle(const MenuItem::TextureHandle &handle)
 {
-	const auto converted = std::static_pointer_cast<qhandle_t>(handle);
-	return converted ? *converted : 0;
+	return handle ? *handle : 0;
 }
 
 /*

--- a/src/client/ui/MenuItem.h
+++ b/src/client/ui/MenuItem.h
@@ -28,7 +28,7 @@ class SliderItem;
 	*/
 class MenuItem {
 public:
-using TextureHandle = std::shared_ptr<void>;
+using TextureHandle = std::shared_ptr<qhandle_t>;
 using Callback = std::function<void(MenuItem &)>;
 
 	struct MenuEvent {

--- a/src/client/ui/menu.cpp
+++ b/src/client/ui/menu.cpp
@@ -2769,10 +2769,12 @@ Creates a shared_ptr-backed texture handle for C++ menu items.
 static MenuItem::TextureHandle Menu_MakeTextureHandle(qhandle_t handle)
 {
 	if (!handle)
-	return nullptr;
+	{
+		return nullptr;
+	}
 
 	return std::make_shared<qhandle_t>(handle);
-	}
+}
 
 /*
 =============


### PR DESCRIPTION
## Summary
- type menu item texture handles as shared_ptr<qhandle_t> to enforce RAII ownership
- simplify texture resolution helper to use typed shared handles
- clean up texture handle factory with proper guarding and indentation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920d2e66d208328a6ea18799b5eeb03)