### PR TITLE
Document MenuItem RAII model and update Windows build

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ For information on using and configuring **WORR**, refer to the manuals in the `
 - Server configuration, match presets and hosting details,
 - Notes on compatibility with Quake II Rerelease assets.
 
+### UI Architecture
+
+The client UI is now driven by a modern `MenuItem` class hierarchy that mirrors the legacy menu widgets while using RAII to manage ownership. Menu textures are reference-counted and shared across items, while child items are owned through `std::unique_ptr`, eliminating manual lifetime management and keeping activation callbacks self-contained.
+
 ---
 
 ## Related Repositories

--- a/doc/client.asciidoc
+++ b/doc/client.asciidoc
@@ -1430,6 +1430,31 @@ store them alongside the rest of the UI artwork (for example under
 `pics/ui/checkbox_checked.tga`, `pics/ui/radio_on.tga`, and
 `pics/ui/dropdown_caret.tga`).
 
+MenuItem developer notes
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The modern menu system layers a C++ `MenuItem` tree over the legacy widget
+structs. The base class keeps texture handles alive through shared ownership
+and manages children with `std::unique_ptr`, so callers do not need to juggle
+manual allocations or cleanup. Each subclass implements the same virtuals as
+the legacy controls (`Draw`, `HandleEvent`, `Activate`, `SetFocus`, `HasFocus`,
+`OnAttach`, and `OnDetach`) so input, focus, and lifecycle hooks stay aligned
+between the old and new code paths.
+
+Migration tips for new menu items
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* Derive from `MenuItem` and honour its ownership model: expose your texture
+  handles as `TextureHandle` (a `std::shared_ptr<qhandle_t>`) and store child
+  items in `std::unique_ptr` containers to keep RAII ownership consistent.
+* Implement the virtuals expected by the legacy wrappers so the menu can route
+  `MenuItem::MenuEvent` keyboard, pointer, or controller input through your
+  control while preserving focus state.
+* When adding a new legacy widget or JSON item type, wire it into the parser in
+  `ParseMenuItem` and register a corresponding constructor in `Menu_BuildMenuItem`
+  so the procedural menu can instantiate your subclass alongside the existing
+  action, static, bitmap, field, list, and slider wrappers.
+
 com_time_format::
     Time format used by ‘com_time’ macro. Default value is "%H.%M" on Win32 and
     "%H:%M" on UNIX. See strftime(3) for syntax description.

--- a/src/windows/meson.build
+++ b/src/windows/meson.build
@@ -1,7 +1,7 @@
 windows = import('windows')
 
 common_src += files('system.cpp', 'hunk.cpp')
-client_src += files('client.cpp', 'wgl.cpp')
+client_src += files('client.cpp', 'wgl.cpp', 'ac.cpp')
 
 common_deps += cc.find_library('ws2_32')
 client_deps += cc.find_library('opengl32')


### PR DESCRIPTION
## Summary
- document the MenuItem RAII ownership model in the README and client developer docs with migration guidance for new menu items
- add contributor notes on routing new menu types through the parser and MenuItem constructors
- include the Windows anti-cheat source in the Meson client sources

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692108f80be88328961f31c4369a4db0)