### PR TITLE
Add sample UI renderer scenes and coverage test

### DIFF
--- a/tests/test_ui_renderer_scenes.py
+++ b/tests/test_ui_renderer_scenes.py
@@ -1,0 +1,47 @@
+import json
+from pathlib import Path
+
+DATA_PATH = Path(__file__).with_name("ui_renderer_scenes.json")
+REQUIRED_PRIMITIVES = {"text", "icon", "fill_rect", "stroke_rect"}
+REQUIRED_STATES = {"normal", "hover", "active", "disabled"}
+
+
+def test_scene_catalog_exists():
+    assert DATA_PATH.exists(), "Sample scene catalog is missing"
+
+
+def test_sample_scenes_cover_primitives_states_and_scaling():
+    payload = json.loads(DATA_PATH.read_text())
+    scenes = payload.get("scenes", [])
+    assert scenes, "Scene catalog must define at least one scene"
+
+    primitives = set()
+    states = set()
+    dpi_scales = set()
+    layout_scales = set()
+
+    for scene in scenes:
+        dpi_scale = scene.get("dpi_scale")
+        layout_scale = scene.get("layout_scale")
+        assert isinstance(dpi_scale, (int, float)), "Each scene needs a numeric dpi_scale"
+        assert isinstance(layout_scale, (int, float)), "Each scene needs a numeric layout_scale"
+        dpi_scales.add(float(dpi_scale))
+        layout_scales.add(float(layout_scale))
+
+        commands = scene.get("commands", [])
+        assert commands, f"Scene '{scene.get('name')}' must include commands"
+        for command in commands:
+            primitive = command.get("primitive")
+            state = command.get("state")
+            assert primitive in REQUIRED_PRIMITIVES, f"Unexpected primitive '{primitive}'"
+            assert state in REQUIRED_STATES, f"Unexpected state '{state}'"
+            primitives.add(primitive)
+            states.add(state)
+
+            # Ensure sample metadata is present to aid manual validation.
+            assert "note" in command, f"Command '{primitive}' in scene '{scene.get('name')}' should describe its intent"
+
+    assert primitives == REQUIRED_PRIMITIVES, "All primitives must be represented in the sample scenes"
+    assert states == REQUIRED_STATES, "All interaction states must be represented in the sample scenes"
+    assert len(dpi_scales) >= 3, "Provide multiple DPI scales to verify scaling behavior"
+    assert any(scale > 1.0 for scale in layout_scales), "Include a layout_scale above 1.0 to stress combined scaling"

--- a/tests/ui_renderer_scenes.json
+++ b/tests/ui_renderer_scenes.json
@@ -1,0 +1,152 @@
+{
+  "description": "Sample UI renderer scenes for exercising primitives, interaction states, and DPI scaling.",
+  "scenes": [
+    {
+      "name": "dpi_1x_primitives",
+      "dpi_scale": 1.0,
+      "layout_scale": 1.0,
+      "commands": [
+        {
+          "primitive": "fill_rect",
+          "state": "normal",
+          "palette": "ui.fill.surface",
+          "x": 32,
+          "y": 32,
+          "width": 240,
+          "height": 64,
+          "corner_radius": 6,
+          "note": "Base surface block for comparing stroke/text overlays."
+        },
+        {
+          "primitive": "stroke_rect",
+          "state": "hover",
+          "palette": "ui.stroke.focus",
+          "x": 36,
+          "y": 36,
+          "width": 232,
+          "height": 56,
+          "corner_radius": 10,
+          "note": "Hover outline around the surface block."
+        },
+        {
+          "primitive": "icon",
+          "state": "active",
+          "icon": "ui.icon.action",
+          "palette": "ui.icon.primary",
+          "x": 52,
+          "y": 52,
+          "size": 24,
+          "note": "Active icon tint against the base surface."
+        },
+        {
+          "primitive": "text",
+          "state": "disabled",
+          "text": "Disabled label",
+          "typography": "ui.label.md",
+          "palette": "ui.text.primary",
+          "x": 88,
+          "y": 68,
+          "note": "Disabled text layered beside the icon."
+        }
+      ]
+    },
+    {
+      "name": "dpi_150_states",
+      "dpi_scale": 1.5,
+      "layout_scale": 1.0,
+      "commands": [
+        {
+          "primitive": "fill_rect",
+          "state": "active",
+          "palette": "ui.fill.accent",
+          "x": 20,
+          "y": 128,
+          "width": 260,
+          "height": 72,
+          "corner_radius": 8,
+          "note": "Scaled active fill for DPI 150%."
+        },
+        {
+          "primitive": "stroke_rect",
+          "state": "disabled",
+          "palette": "ui.stroke.muted",
+          "x": 24,
+          "y": 132,
+          "width": 252,
+          "height": 64,
+          "corner_radius": 12,
+          "note": "Disabled outline at 150% DPI to confirm stroke snapping."
+        },
+        {
+          "primitive": "icon",
+          "state": "normal",
+          "icon": "ui.icon.info",
+          "palette": "ui.icon.secondary",
+          "x": 44,
+          "y": 148,
+          "size": 28,
+          "note": "Normal icon tint next to hover text."
+        },
+        {
+          "primitive": "text",
+          "state": "hover",
+          "text": "Hover text at 150%",
+          "typography": "ui.label.lg",
+          "palette": "ui.text.primary",
+          "x": 88,
+          "y": 164,
+          "note": "Hover label verifying scaled font metrics."
+        }
+      ]
+    },
+    {
+      "name": "dpi_200_layout",
+      "dpi_scale": 2.0,
+      "layout_scale": 1.25,
+      "commands": [
+        {
+          "primitive": "fill_rect",
+          "state": "hover",
+          "palette": "ui.fill.surface_alt",
+          "x": 48,
+          "y": 224,
+          "width": 288,
+          "height": 88,
+          "corner_radius": 10,
+          "note": "Hover fill with enlarged layout scale for dense DPI."
+        },
+        {
+          "primitive": "stroke_rect",
+          "state": "active",
+          "palette": "ui.stroke.accent",
+          "x": 52,
+          "y": 228,
+          "width": 280,
+          "height": 80,
+          "corner_radius": 14,
+          "note": "Active outline aligned to scaled hover block."
+        },
+        {
+          "primitive": "icon",
+          "state": "disabled",
+          "icon": "ui.icon.lock",
+          "palette": "ui.icon.disabled",
+          "x": 76,
+          "y": 248,
+          "size": 36,
+          "note": "Disabled icon tint at 200% DPI with layout zoom."
+        },
+        {
+          "primitive": "text",
+          "state": "normal",
+          "text": "Normal text @2x/1.25x",
+          "typography": "ui.label.sm",
+          "palette": "ui.text.secondary",
+          "x": 124,
+          "y": 268,
+          "note": "Normal text aligned to disabled icon for mixed-state layering."
+        }
+      ]
+    }
+  ]
+}

--- a/tests/ui_renderer_scenes.md
+++ b/tests/ui_renderer_scenes.md
@@ -1,0 +1,17 @@
+# UI Renderer Sample Scenes
+
+These sample scenes exercise every primitive described in `doc/ui_drawing_interface.md` across all interaction states and a few DPI/layout scale combinations. Use them as reference data when validating rendering changes or authoring automated fixtures.
+
+## Coverage highlights
+- **Primitives**: `fill_rect`, `stroke_rect`, `icon`, and `text` appear in every scene so stateful styling can be compared side-by-side.
+- **States**: `normal`, `hover`, `active`, and `disabled` assignments are distributed across commands to surface per-state palette or typography overrides.
+- **Scaling**: Scenes step through 1.0×, 1.5×, and 2.0× DPI values, with the last scene also applying a 1.25× layout zoom to stress combined scaling.
+
+## Manual validation checklist
+1. Load a scene and verify that hover/active/disabled variants respect the expected palette keys.
+2. Check that icon and text rendering stay crisp and aligned after DPI/layout scaling.
+3. Confirm that stroke widths and corner radii remain visually balanced against the fills at each scale.
+4. Toggle theme palettes or fonts to ensure palette/tokens resolve consistently for every state.
+
+## Automated checks
+The accompanying `test_ui_renderer_scenes.py` test ensures the JSON stays exhaustive. If you add new primitives or states, update both the sample scenes and the assertions to keep coverage aligned.


### PR DESCRIPTION
## Summary
- add UI renderer sample scenes covering primitives, states, and DPI/layout scaling
- document manual validation steps for hover/active/disabled text and icons
- verify scene catalog coverage with a focused pytest

## Testing
- python -m pytest tests/test_ui_renderer_scenes.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69218b970e308328bd3e3cedf0821259)