### PR TITLE
Refine menu layout helpers

### DIFF
--- a/src/client/ui/menu.cpp
+++ b/src/client/ui/menu.cpp
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "MenuItem.h"
 #include "common/files.hpp"
 #include "menu_controls.hpp"
+#include "renderer.hpp"
 
 #include <limits.h>
 #include <initializer_list>
@@ -245,6 +246,50 @@ static void Menu_UpdateConditionalState(menuFrameWork_t *menu)
 static void Menu_DrawGroups(menuFrameWork_t *menu);
 static void Menu_DrawGroups(menuFrameWork_t *menu);
 static void Menu_UpdateGroupBounds(menuFrameWork_t *menu);
+
+/*
+=============
+Menu_ControlState
+
+Maps menu interaction flags to renderer-friendly UI states.
+=============
+*/
+static uiControlState_t Menu_ControlState(bool disabled, bool focused, bool active = false)
+{
+	if (disabled) {
+		return UI_STATE_DISABLED;
+	}
+
+	if (active) {
+		return UI_STATE_ACTIVE;
+	}
+
+	if (focused) {
+		return UI_STATE_FOCUSED;
+	}
+
+	return UI_STATE_DEFAULT;
+}
+
+/*
+=============
+Menu_RowLayout
+
+Creates a shared two-column layout split for menu controls.
+=============
+*/
+static uiLayoutSplit_t Menu_RowLayout(const menuCommon_t *generic, float labelPercent)
+{
+	uiLayoutRect_t row{};
+
+	row.x = UI_Pixels(static_cast<float>(generic->x));
+	row.y = UI_Pixels(static_cast<float>(generic->y));
+	row.width = UI_Percent(0.6f);
+	row.height = UI_Pixels(static_cast<float>(UI_CharHeight()));
+	row.spacing = UI_ColumnPadding();
+
+	return UI_SplitLayoutRow(&row, NULL, labelPercent);
+}
 
 /*
 ===================================================================

--- a/src/client/ui/menu_action.cpp
+++ b/src/client/ui/menu_action.cpp
@@ -11,12 +11,13 @@ void Action_Init(menuAction_t *a)
 {
 	Q_assert(a->generic.name);
 
-	if ((a->generic.uiFlags & UI_CENTER) != UI_CENTER) {
-		a->generic.x += RCOLUMN_OFFSET;
-	}
+	uiLayoutRect_t row{};
+	row.x = UI_Pixels(static_cast<float>(a->generic.x));
+	row.y = UI_Pixels(static_cast<float>(a->generic.y));
+	row.width = UI_Percent(0.6f);
+	row.height = UI_Pixels(static_cast<float>(UI_CharHeight()));
 
-	a->generic.rect.x = a->generic.x;
-	a->generic.rect.y = a->generic.y;
+	a->generic.rect = UI_LayoutToPixels(&row, NULL);
 	UI_StringDimensions(&a->generic.rect, a->generic.uiFlags, a->generic.name);
 }
 


### PR DESCRIPTION
## Summary
- add shared renderer and layout helpers for menu controls
- shift action initialization to layout-driven sizing

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69218e2d600c8328a9ff92b70709c5e8)