### PR TITLE
Add manifest-based menu script controller

### DIFF
--- a/menus/index.json
+++ b/menus/index.json
@@ -1,0 +1,5 @@
+{
+  "main": "worr.menu.json",
+  "ingame": "worr.menu.json",
+  "overrides": {}
+}

--- a/src/client/ui/ui.hpp
+++ b/src/client/ui/ui.hpp
@@ -543,6 +543,20 @@ extern list_t       ui_menus;
 
 extern cvar_t       *ui_debug;
 
+typedef enum uiScriptContext_e {
+	UI_SCRIPT_MAIN,
+	UI_SCRIPT_INGAME
+} uiScriptContext_t;
+
+	void	UI_InitScriptController(void);
+	void	UI_SyncMenuContext(void);
+	void	UI_SetMenuContext(const char *context);
+	const char	*UI_ActiveMenuContextName(void);
+	void	UI_RequestMenuReload(void);
+
+	void	UI_ClearMenus(void);
+	void	UI_RegisterBuiltinMenus(void);
+
 	void        UI_PushMenu(menuFrameWork_t *menu);
 	void        UI_ForceMenuOff(void);
 	void        UI_PopMenu(void);


### PR DESCRIPTION
## Summary
- add a menu manifest parser that stages in-game, main, and embedded menu script loading with fallbacks
- track active menu script contexts based on game state with a configurable cvar and console commands to reload or switch
- add a default menus/index.json manifest pointing both contexts at the current menu script

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921932ae7f08328814449982f84df20)