### PR TITLE
Improve UI typography font chaining

### DIFF
--- a/src/client/ui/ui.hpp
+++ b/src/client/ui/ui.hpp
@@ -158,7 +158,7 @@ UI_TYPO_ROLE_COUNT
 } uiTypographyRole_t;
 
 typedef struct uiTypographySpec_s {
-qhandle_t handle;
+std::vector<qhandle_t> handles;
 int pixelHeight;
 } uiTypographySpec_t;
 
@@ -200,6 +200,7 @@ int UI_CharHeight(void);
 
 #include <array>
 #include <memory>
+#include <string>
 #include <vector>
 
 class MenuItem;
@@ -529,6 +530,8 @@ int fontPixelHeight;
 qhandle_t bitmapCursors[NUM_CURSOR_FRAMES];
 
 std::array<uiPaletteEntry_t, UI_COLOR_ROLE_COUNT> palette;
+std::array<std::vector<std::string>, UI_TYPO_ROLE_COUNT> typographyFonts;
+std::array<std::vector<qhandle_t>, UI_TYPO_ROLE_COUNT> typographyHandles;
 uiTypographySet_t typography;
 
     struct {
@@ -550,9 +553,10 @@ class UiManager {
 		
 		void Initialize();
 		void Shutdown();
-		void SyncPalette(const uiStatic_t &state);
-		void SyncLayout(const uiLayoutMetrics_t &metrics);
-		void SyncLegacyMenus(menuFrameWork_t **stack, int depth);
+void SyncPalette(const uiStatic_t &state);
+void SyncTypography(const uiTypographySet_t &typography);
+void SyncLayout(const uiLayoutMetrics_t &metrics);
+void SyncLegacyMenus(menuFrameWork_t **stack, int depth);
 		void RoutePointerEvent(const vrect_t &cursorRegion);
 		void RouteNavigationKey(int key);
 		std::shared_ptr<ui::ux::Widget> MenuRoot() const;
@@ -594,6 +598,7 @@ typedef enum uiScriptContext_e {
 
 	void	UI_ClearMenus(void);
 	void	UI_RegisterBuiltinMenus(void);
+	void	UI_RefreshFonts(void);
 
 	void        UI_PushMenu(menuFrameWork_t *menu);
 	void        UI_ForceMenuOff(void);

--- a/src/client/ui/ux.cpp
+++ b/src/client/ui/ux.cpp
@@ -1246,17 +1246,29 @@ namespace ui::ux {
 	{
 	}
 
-	/*
-	=============
-	ThemeContext::SetPalette
+/*
+=============
+ThemeContext::SetPalette
 
 	Stores a palette for later lookups.
 	=============
 	*/
-	void ThemeContext::SetPalette(std::vector<uiPaletteEntry_t> palette)
-	{
-		m_palette = std::move(palette);
-	}
+void ThemeContext::SetPalette(std::vector<uiPaletteEntry_t> palette)
+{
+	m_palette = std::move(palette);
+}
+
+/*
+=============
+ThemeContext::SetTypography
+
+Stores a typography set for later lookups.
+=============
+*/
+void ThemeContext::SetTypography(uiTypographySet_t typography)
+{
+	m_typography = std::move(typography);
+}
 
 	/*
 	=============
@@ -1265,18 +1277,30 @@ namespace ui::ux {
 	Returns a palette entry for the requested role or a default value.
 	=============
 	*/
-	uiPaletteEntry_t ThemeContext::Resolve(uiColorRole_t role) const
-	{
-		if (role >= 0 && static_cast<size_t>(role) < m_palette.size()) {
-			return m_palette[static_cast<size_t>(role)];
-		}
+uiPaletteEntry_t ThemeContext::Resolve(uiColorRole_t role) const
+{
+if (role >= 0 && static_cast<size_t>(role) < m_palette.size()) {
+return m_palette[static_cast<size_t>(role)];
+}
 
 		uiPaletteEntry_t fallback{};
 		for (int i = 0; i < UI_STATE_COUNT; i++) {
-			fallback.states[i] = color_white;
-		}
-		return fallback;
-	}
+fallback.states[i] = color_white;
+}
+return fallback;
+}
+
+/*
+=============
+ThemeContext::Typography
+
+Returns the stored typography set.
+=============
+*/
+const uiTypographySet_t &ThemeContext::Typography() const
+{
+	return m_typography;
+}
 
 	/*
 	=============

--- a/src/client/ui/ux.hpp
+++ b/src/client/ui/ux.hpp
@@ -278,16 +278,19 @@ namespace ui::ux {
 		std::vector<AnimationClip> m_clips;
 	};
 
-	class ThemeContext {
-		public:
-		ThemeContext();
+class ThemeContext {
+public:
+ThemeContext();
 
-		void SetPalette(std::vector<uiPaletteEntry_t> palette);
-		uiPaletteEntry_t Resolve(uiColorRole_t role) const;
+void SetPalette(std::vector<uiPaletteEntry_t> palette);
+void SetTypography(uiTypographySet_t typography);
+uiPaletteEntry_t Resolve(uiColorRole_t role) const;
+const uiTypographySet_t &Typography() const;
 
-		private:
-		std::vector<uiPaletteEntry_t> m_palette;
-	};
+private:
+std::vector<uiPaletteEntry_t> m_palette;
+uiTypographySet_t m_typography;
+};
 
 	class UIXSystem {
 		public:


### PR DESCRIPTION
## Summary
- allow menu scripts to declare per-role font chains and register matching typography handles
- resolve typography roles through ordered font handles, syncing selection into the UIX theme context
- expand font resolution utilities to honor multiple handles and updated registration fallbacks

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921ac0a0bb08328b217b233300954bb)