### PR TITLE
Handle legacy input routing from UIX events

### DIFF
--- a/src/client/ui/ux.cpp
+++ b/src/client/ui/ux.cpp
@@ -451,7 +451,7 @@ namespace ui::ux {
 	=============
 	*/
 	UIEvent::UIEvent(EventType type, NavigationDirection direction, vrect_t region)
-	: m_type(type), m_direction(direction), m_region(region)
+	: m_type(type), m_direction(direction), m_region(region), m_key(0)
 	{
 	}
 
@@ -463,7 +463,19 @@ namespace ui::ux {
 	=============
 	*/
 	UIEvent::UIEvent(EventType type, vrect_t region)
-	: m_type(type), m_direction(NavigationDirection::Next), m_region(region)
+	: m_type(type), m_direction(NavigationDirection::Next), m_region(region), m_key(0)
+	{
+	}
+
+	/*
+	=============
+	UIEvent::UIEvent
+
+	Builds an event carrying a direct key payload.
+	=============
+	*/
+	UIEvent::UIEvent(EventType type, int key, vrect_t region)
+	: m_type(type), m_direction(NavigationDirection::Next), m_region(region), m_key(key)
 	{
 	}
 
@@ -501,6 +513,18 @@ namespace ui::ux {
 	vrect_t UIEvent::Region() const
 	{
 		return m_region;
+	}
+
+	/*
+	=============
+	UIEvent::Key
+
+	Returns the key payload attached to the event.
+	=============
+	*/
+	int UIEvent::Key() const
+	{
+		return m_key;
 	}
 
 	/*

--- a/src/client/ui/ux.hpp
+++ b/src/client/ui/ux.hpp
@@ -29,13 +29,17 @@ namespace ui::ux {
 		ModalOverlay
 	};
 
-	enum class EventType : uint8_t {
-		Focus,
-		Hover,
-		Activate,
-		Navigate,
-		PointerMove
-	};
+		enum class EventType : uint8_t {
+			Focus,
+			Hover,
+			Activate,
+			Navigate,
+			PointerMove,
+			PointerDown,
+			PointerUp,
+			Scroll,
+			TextInput
+		};
 
 	enum class NavigationDirection : uint8_t {
 		Next,
@@ -115,17 +119,20 @@ namespace ui::ux {
 
 	class UIEvent {
 		public:
-		UIEvent(EventType type, NavigationDirection direction, vrect_t region);
-		UIEvent(EventType type, vrect_t region);
+			UIEvent(EventType type, NavigationDirection direction, vrect_t region);
+			UIEvent(EventType type, vrect_t region);
+			UIEvent(EventType type, int key, vrect_t region);
 
-		EventType Type() const;
-		NavigationDirection Direction() const;
-		vrect_t Region() const;
+			EventType Type() const;
+			NavigationDirection Direction() const;
+			vrect_t Region() const;
+			int Key() const;
 
-		private:
-		EventType m_type;
-		NavigationDirection m_direction;
-		vrect_t m_region;
+			private:
+			EventType m_type;
+			NavigationDirection m_direction;
+			vrect_t m_region;
+			int m_key;
 	};
 
 	class Widget : public std::enable_shared_from_this<Widget> {


### PR DESCRIPTION
## Summary
- extend UIEvent with key payloads and additional event types for pointer, scroll, and text input
- route UIX pointer and text interactions through LegacyMenuWidget to legacy dispatchers while updating pointer coordinates
- declare legacy dispatch helpers up front to support the new routing

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921b160a65c832884034a38d168be12)