### PR TITLE
Support per-role typography chains and pixel heights

### DIFF
--- a/menus/README.md
+++ b/menus/README.md
@@ -27,3 +27,9 @@ A simple controller example (`menus/controller.json`):
 ```
 
 If the in-game stack is missing, the loader automatically falls back to the `main` stack while retaining the built-in buffer fallback for safety.
+
+Typography configuration can ride alongside the manifest/controller pair:
+
+* The `fonts` block accepts either a string or an array for each typography role (`body`, `label`, `heading`, `monospace`). Entries are tried in order and may mix scalable TTF/OTF, `*.kfont` descriptions, and legacy bitmap assets such as `conchars.pcx`. The `ui_font` and `ui_font_fallback` cvars accept the same comma- or semicolon-delimited chains and prepend/append them to every role.
+* `fontSizes` mirrors the role map and lets a manifest pin pixel heights per role. Values above zero override the default ramps (body/monospace base size, label scaled down slightly, heading scaled up slightly). You can also steer sizes through `ui_font_size` or the role-specific `ui_font_size_body`, `ui_font_size_label`, `ui_font_size_heading`, and `ui_font_size_monospace` cvars.
+* Role-specific font cvars (`ui_font_body`, `ui_font_label`, `ui_font_heading`, `ui_font_monospace`) opt a role into its own chain without affecting the others. When a role supplies no fonts, the loader falls back to the body chain and finally the default renderer font.

--- a/src/client/ui/ui.hpp
+++ b/src/client/ui/ui.hpp
@@ -531,6 +531,7 @@ qhandle_t bitmapCursors[NUM_CURSOR_FRAMES];
 
 std::array<uiPaletteEntry_t, UI_COLOR_ROLE_COUNT> palette;
 std::array<std::vector<std::string>, UI_TYPO_ROLE_COUNT> typographyFonts;
+std::array<int, UI_TYPO_ROLE_COUNT> typographyPixelHeights;
 std::array<std::vector<qhandle_t>, UI_TYPO_ROLE_COUNT> typographyHandles;
 uiTypographySet_t typography;
 


### PR DESCRIPTION
## Summary
- add role-specific typography cvars with comma/semicolon font chains and propagate changes through reload hooks
- honour per-role pixel height overrides from cvars or manifests while keeping independent handle chains with sensible fallbacks
- document the new font chain and pixel height options alongside the menu manifest/controller guidance

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921b31fb9108328aac20fe854a0f6d1)