### PR TITLE
build: fix Linux compilation (atomics, strchrnul, font macros, libm, …

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "C_Cpp.default.compileCommands": "e:\\Repositories\\WORR\\builddir/compile_commands.json",
+    "C_Cpp.default.compileCommands": "${workspaceFolder}/builddir-win/compile_commands.json",
     "C_Cpp.default.configurationProvider": "mesonbuild.mesonbuild",
     "debug.defaultConfiguration": "WORR (Vulkan)"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,7 +7,7 @@
             "command": "cmd",
             "args": [
                 "/c",
-                "if exist builddir\\meson-private\\coredata.dat (meson setup --reconfigure builddir) else (meson setup builddir)"
+                "if exist builddir-win\\meson-private\\coredata.dat (meson setup --reconfigure builddir-win) else (meson setup builddir-win)"
             ],
             "options": {
                 "cwd": "${workspaceFolder}"
@@ -21,7 +21,7 @@
             "args": [
                 "compile",
                 "-C",
-                "builddir"
+                "builddir-win"
             ],
             "dependsOn": [
                 "meson: setup"
@@ -38,7 +38,7 @@
             "args": [
                 "tools/refresh_install.py",
                 "--build-dir",
-                "builddir",
+                "builddir-win",
                 "--install-dir",
                 ".install",
                 "--base-game",

--- a/BUILD_QUIRKS.md
+++ b/BUILD_QUIRKS.md
@@ -28,7 +28,18 @@ ERROR: None of values ['c++23'] are supported by the CPP compiler. Possible valu
 
 **Cause:** Meson 1.10.x has a fixed list of supported `cpp_std` values for MSVC. `c++23` isn't in that list, even though VC 2022+ supports it.
 
-**Workaround:** Use `c++latest` instead of `c++23`. Meson accepts it, and MSVC maps it to `/std:c++latest` (C++23 on recent toolchains). The sgame DLL override has been updated to use `cpp_std=c++latest` for MSVC compatibility.
+**Workaround:** Use `c++latest` instead of `c++23`. Meson accepts it, and MSVC maps it to `/std:c++latest` (C++23 on recent toolchains). The sgame DLL override uses `cpp_std=c++latest` for MSVC only; on GCC/Clang (Linux/BSD) it uses `c++23` because `c++latest` is not supported there.
+
+## GCC/Clang: c++latest not supported
+
+**Symptom (on Linux):**
+```
+ERROR: None of values ['c++latest'] are supported by the CPP compiler. Possible values for option "cpp_std" are ['none', 'c++98', ..., 'c++23', 'c++26', ...]
+```
+
+**Cause:** `c++latest` is an MSVC-specific value. GCC and Clang support `c++23` (and `c++26`) but not `c++latest`.
+
+**Fix:** `meson.build` selects `cpp_std` per compiler: `c++latest` for MSVC, `c++23` for GCC/Clang.
 
 ## MSVC C4576: compound literal in C++ (COLOR_RGBA etc.)
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# WORR build script for Linux
+# Uses builddir-linux (Windows builds use builddir-win)
+# Usage: ./build.sh [options]
+#
+# Options:
+#   --deps          Install build dependencies (apt/dnf) before building
+#   --clean         Wipe builddir-linux and reconfigure from scratch
+#   --stage         Run refresh_install.py after build to populate .install/
+#   -h, --help      Show this help
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR="${SCRIPT_DIR}/builddir-linux"
+INSTALL_DIR="${SCRIPT_DIR}/.install"
+BASE_GAME="baseq2"
+
+install_deps_apt() {
+    sudo apt-get install -y meson gcc libc6-dev libsdl3-dev libopenal-dev \
+        libpng-dev libjpeg-dev zlib1g-dev mesa-common-dev \
+        libcurl4-gnutls-dev libx11-dev libxi-dev \
+        libwayland-dev wayland-protocols libdecor-0-dev \
+        libavcodec-dev libavformat-dev libavutil-dev \
+        libswresample-dev libswscale-dev
+}
+
+install_deps_dnf() {
+    sudo dnf install -y meson gcc glibc-devel SDL3-devel openal-soft-devel \
+        libpng-devel libjpeg-turbo-devel zlib-devel mesa-libGL-devel \
+        libcurl-devel libX11-devel libXi-devel \
+        wayland-devel wayland-protocols-devel libdecor-devel \
+        ffmpeg-devel
+}
+
+install_deps() {
+    if command -v dnf &>/dev/null; then
+        echo "Detected Fedora/RHEL, installing dependencies..."
+        install_deps_dnf
+    elif command -v apt-get &>/dev/null; then
+        echo "Detected Debian/Ubuntu, installing dependencies..."
+        install_deps_apt
+    else
+        echo "Unknown package manager. Please install dependencies manually. See BUILDING.md"
+        exit 1
+    fi
+}
+
+setup_build() {
+    cd "$SCRIPT_DIR"
+    if [[ -n "$CLEAN" ]]; then
+        echo "Cleaning build directory..."
+        rm -rf "$BUILD_DIR"
+    fi
+    meson setup "$BUILD_DIR"
+}
+
+compile() {
+    cd "$SCRIPT_DIR"
+    meson compile -C "$BUILD_DIR"
+}
+
+stage_install() {
+    cd "$SCRIPT_DIR"
+    python3 tools/refresh_install.py \
+        --build-dir "$BUILD_DIR" \
+        --install-dir "$INSTALL_DIR" \
+        --base-game "$BASE_GAME"
+}
+
+show_help() {
+    sed -n '2,15p' "$0" | sed 's/^# \?//'
+}
+
+DO_DEPS=
+CLEAN=
+DO_STAGE=
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --deps)  DO_DEPS=1 ;;
+        --clean) CLEAN=1 ;;
+        --stage) DO_STAGE=1 ;;
+        -h|--help) show_help; exit 0 ;;
+        *) echo "Unknown option: $1"; show_help; exit 1 ;;
+    esac
+    shift
+done
+
+echo "Building WORR in $SCRIPT_DIR"
+echo "----------------------------"
+
+[[ -n "$DO_DEPS" ]] && install_deps
+setup_build
+compile
+
+if [[ -n "$DO_STAGE" ]]; then
+    stage_install
+    echo ""
+    echo "Staged build in $INSTALL_DIR"
+fi
+
+echo ""
+echo "Build complete. Binaries are in $BUILD_DIR"

--- a/inc/renderer/renderer_api.h
+++ b/inc/renderer/renderer_api.h
@@ -59,6 +59,17 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #endif
 #endif
 
+/* When building the renderer DLL, ensure struct member names are not macro-expanded
+ * by shared.h (HAVE_MEMCCPY/HAVE_STRCHRNUL), which would rename Q_memccpy→memccpy etc. */
+#if defined(RENDERER_DLL)
+#ifdef Q_memccpy
+#undef Q_memccpy
+#endif
+#ifdef Q_strchrnul
+#undef Q_strchrnul
+#endif
+#endif
+
 typedef struct renderer_import_s {
     void (*Com_LPrintf)(print_type_t type, const char *fmt, ...);
     void (*Com_Error)(error_type_t type, const char *fmt, ...);

--- a/inc/shared/atomic.h
+++ b/inc/shared/atomic.h
@@ -22,6 +22,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 typedef volatile int atomic_int;
 #define atomic_load(p)      (*(p))
 #define atomic_store(p, v)  (*(p) = (v))
+#elif defined(__cplusplus)
+#include <atomic>
+typedef std::atomic<int> atomic_int;
+#define atomic_load(p)      ((p)->load())
+#define atomic_store(p, v)  ((p)->store(v))
 #else
 #include <stdatomic.h>
 #endif

--- a/inc/shared/shared.h
+++ b/inc/shared/shared.h
@@ -510,12 +510,14 @@ static inline float smoothstep(float edge0, float edge1, float x)
     return t * t * (3.0f - 2.0f * t);
 }
 
+#if !defined(NOMINMAX)
 #ifndef max
 #define max(a,b) ((a)>(b)?(a):(b))
 #endif
 
 #ifndef min
 #define min(a,b) ((a)<(b)?(a):(b))
+#endif
 #endif
 
 #define frand()     ((int32_t)Q_rand() * 0x1p-32f + 0.5f)

--- a/meson.build
+++ b/meson.build
@@ -645,7 +645,6 @@ if cpp.get_argument_syntax() == 'gcc'
   if x86
     client_cpp_args += cpp.get_supported_arguments(['-msse2', '-mfpmath=sse'])
   endif
-
   client_cpp_warn_args = [
     '-Wformat-security',
     '-Wno-microsoft-anon-tag',
@@ -666,11 +665,14 @@ endif
 
 game_cpp_args = [
   '-DHAVE_CONFIG_H',
+  '-DQ2PROTO_CONFIG_H="common/q2proto_config.h"',
   '-DNO_FMT_SOURCE',
+  '-DNOMINMAX',
 ]
 
 game_c_args = [
   '-DHAVE_CONFIG_H',
+  '-DQ2PROTO_CONFIG_H="common/q2proto_config.h"',
 ]
 
 game_link_args = []
@@ -999,7 +1001,12 @@ if openal.found()
   client_src += [ 'src/client/sound/al.cpp', 'src/client/sound/qal.cpp', 'inc/common/jsmn.h' ]
   client_deps += openal
   config.set10('USE_OPENAL', true)
+  # Work around OpenAL protected symbol linker error on Fedora/glibc
+  if not win32 and cpp.get_argument_syntax() == 'gcc'
+    client_cpp_args += cpp.get_supported_arguments(['-mno-direct-extern-access'])
+  endif
 endif
+client_link_args = exe_link_args
 
 # require FFmpeg >= 5.1.3
 ffmpeg_defaults = [
@@ -1205,7 +1212,11 @@ renderer_vk_rtx_lib = []
 if get_option('external-renderers')
   renderer_engine_src = []
 
+  libm = cc.find_library('m', required: false)
   renderer_deps = []
+  if libm.found()
+    renderer_deps += libm
+  endif
   if zlib.found()
     renderer_deps += zlib
   endif
@@ -1284,7 +1295,7 @@ executable('worr', common_src, client_src, renderer_engine_src,
   include_directories:   ['inc', 'q2proto/inc'],
   gnu_symbol_visibility: 'hidden',
   win_subsystem:         win_subsystem_client,
-  link_args:             exe_link_args,
+  link_args:             client_link_args,
   link_with:             q2proto_lib,
   c_args:                ['-DUSE_CLIENT=1', '-DUSE_REF=REF_GL', engine_args],
   cpp_args:              client_cpp_args,
@@ -1343,6 +1354,8 @@ cgame_defines = [
   '-DRENDERER_DLL',
 ]
 
+# MSVC: use c++latest (c++23 not in Meson's MSVC list). GCC/Clang: use c++23 (c++latest unsupported).
+sgame_cpp_std = cpp.get_id() == 'msvc' ? 'c++latest' : 'c++23'
 sgame_dll = shared_library('sgame' + cpu, sgame_src,
   name_prefix:           '',
   gnu_symbol_visibility: 'hidden',
@@ -1354,7 +1367,7 @@ sgame_dll = shared_library('sgame' + cpu, sgame_src,
   install:              true,
   install_dir:          libdir / get_option('base-game'),
   install_tag:          'runtime',
-  override_options:      ['b_vscrt=from_buildtype', 'cpp_std=c++latest'],
+  override_options:      ['b_vscrt=from_buildtype', 'cpp_std=' + sgame_cpp_std],
 )
 
 cgame_all_src = cgame_src + ui_src + [

--- a/src/client/font.cpp
+++ b/src/client/font.cpp
@@ -16,6 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+#define NOMINMAX
 #include "client/font.h"
 
 #include <algorithm>

--- a/src/client/renderer.cpp
+++ b/src/client/renderer.cpp
@@ -489,6 +489,15 @@ static int R_Q_atoi(const char *s)
     return Q_atoi(s);
 }
 
+static char *R_Q_strchrnul(const char *s, int c)
+{
+#ifdef HAVE_STRCHRNUL
+    return const_cast<char *>(strchrnul(s, c));
+#else
+    return Q_strchrnul(s, c);
+#endif
+}
+
 void R_ClearDebugLines(void)
 {
     if (re.ClearDebugLines) {
@@ -741,7 +750,7 @@ static renderer_import_t R_BuildRendererImports(void)
         .Q_strcasecmp = Q_strcasecmp,
         .Q_strncasecmp = Q_strncasecmp,
         .Q_strcasestr = Q_strcasestr,
-        .Q_strchrnul = Q_strchrnul,
+        .Q_strchrnul = R_Q_strchrnul,
         .Q_strlcpy = Q_strlcpy,
         .Q_strlcat = Q_strlcat,
         .Q_concat_array = Q_concat_array,

--- a/src/client/sound/qal.cpp
+++ b/src/client/sound/qal.cpp
@@ -52,8 +52,8 @@ typedef struct {
     const alfunction_t *functions;
 } alsection_t;
 
-#define QALC_FN(x)  { "alc"#x, &qalc##x, alc##x }
-#define QAL_FN(x)   { "al"#x, &qal##x, al##x }
+#define QALC_FN(x)  { "alc"#x, &qalc##x, (void*)(uintptr_t)(alc##x) }
+#define QAL_FN(x)   { "al"#x, &qal##x, (void*)(uintptr_t)(al##x) }
 
 #if defined(__clang__)
 #pragma clang diagnostic push

--- a/src/game/bgame/q_std.hpp
+++ b/src/game/bgame/q_std.hpp
@@ -34,6 +34,9 @@
 #include <type_traits>
 #include <algorithm>
 #include <array>
+
+using std::min;
+using std::max;
 #include <string_view>
 #include <string>
 #include <numeric>

--- a/src/game/cgame/cg_entities.cpp
+++ b/src/game/cgame/cg_entities.cpp
@@ -2131,7 +2131,7 @@ void CL_CalcViewValues(void)
 
     // Smooth out view height over 100ms
     float viewheight_lerp = (cl.time - cl.viewheight_change_time);
-    viewheight_lerp = 100 - min(viewheight_lerp, 100);
+    viewheight_lerp = 100 - min(viewheight_lerp, 100.0f);
     viewheight = cl.current_viewheight + (float)(cl.prev_viewheight - cl.current_viewheight) * viewheight_lerp * 0.01f;
 
     cl.refdef.vieworg[2] += viewheight;

--- a/src/game/cgame/cg_entity_local.h
+++ b/src/game/cgame/cg_entity_local.h
@@ -3,7 +3,12 @@
 
 #pragma once
 
+#include <algorithm>
+
 #include "client/cgame_entity.h"
+
+using std::min;
+using std::max;
 #include "common/zone.h"
 #include "cg_client_defs.h"
 

--- a/src/game/cgame/cg_ui_sys.cpp
+++ b/src/game/cgame/cg_ui_sys.cpp
@@ -18,6 +18,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "client/cgame_ui.h"
 #include "common/common.h"
+
+#include <algorithm>
+using std::min;
+using std::max;
 #include "common/error.h"
 #include "common/files.h"
 

--- a/src/game/cgame/ui/ui_internal.h
+++ b/src/game/cgame/ui/ui_internal.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <functional>
 #include <memory>
 #include <string>
@@ -68,6 +69,9 @@ void UI_SetClipboardData(const char *text);
 #define MLF_COLOR       BIT(2)
 
 namespace ui {
+
+using std::min;
+using std::max;
 
 enum class Sound {
     NotHandled,

--- a/src/game/sgame/gameplay/g_ai_new.cpp
+++ b/src/game/sgame/gameplay/g_ai_new.cpp
@@ -1090,7 +1090,7 @@ bool M_CalculatePitchToFire(gentity_t* self, const Vector3& target, const Vector
 		}
 	}
 
-	if (!isinf(best_dist)) {
+	if (!std::isinf(best_dist)) {
 		pitched_aim[PITCH] = best_pitch;
 		aim = AngleVectors(pitched_aim).forward;
 		return true;

--- a/src/game/sgame/gameplay/g_func.cpp
+++ b/src/game/sgame/gameplay/g_func.cpp
@@ -3564,7 +3564,7 @@ void door_secret2_move2(gentity_t* self);
 void door_secret2_move3(gentity_t* self);
 void door_secret2_move4(gentity_t* self);
 void door_secret2_move5(gentity_t* self);
-void door_secret2_move6(gentity_t* self);
+static void door_secret2_move6(gentity_t* self);
 void door_secret2_done(gentity_t* self);
 
 static USE(door_secret2_use) (gentity_t* self, gentity_t* other, gentity_t* activator) -> void {

--- a/src/game/sgame/gameplay/g_misc.cpp
+++ b/src/game/sgame/gameplay/g_misc.cpp
@@ -2295,8 +2295,8 @@ FREEZE: freezes player's movement when viewing through camera
 */
 
 // Forward declarations for camera functions
-void misc_camera_stop(gentity_t* self);
-void camera_move_next(gentity_t* self);
+static void misc_camera_stop(gentity_t* self);
+static void camera_move_next(gentity_t* self);
 
 
 static void misc_camera_stop(gentity_t* self) {

--- a/src/game/sgame/gameplay/g_phys.cpp
+++ b/src/game/sgame/gameplay/g_phys.cpp
@@ -819,7 +819,7 @@ static void G_Physics_Step(gentity_t* ent) {
 		G_AddRotationalFriction(ent);
 
 	// FIXME: figure out how or why this is happening
-	if (isnan(ent->velocity[_X]) || isnan(ent->velocity[_Y]) || isnan(ent->velocity[_Z]))
+	if (std::isnan(ent->velocity[_X]) || std::isnan(ent->velocity[_Y]) || std::isnan(ent->velocity[_Z]))
 		ent->velocity = {};
 
 	// add gravity except:

--- a/src/game/sgame/gameplay/g_proball.cpp
+++ b/src/game/sgame/gameplay/g_proball.cpp
@@ -15,8 +15,8 @@ void OnBallReset(gentity_t* ball);
 
 namespace {
 
-void Ball_Think(gentity_t* ball);
-void Ball_Touch(gentity_t* ball, gentity_t* other,
+static void Ball_Think(gentity_t* ball);
+static void Ball_Touch(gentity_t* ball, gentity_t* other,
 		const trace_t& tr, bool otherTouchingSelf);
 
 constexpr Vector3 BALL_MINS{-12.f, -12.f, -12.f};

--- a/src/game/sgame/gameplay/g_save.cpp
+++ b/src/game/sgame/gameplay/g_save.cpp
@@ -1490,7 +1490,7 @@ static void read_save_type_json(const Json::Value& json, void* data, const save_
 	case Float:
 		if (!json.isDouble())
 			json_print_error(field, "expected number", false);
-		else if (isnan(json.asDouble()))
+		else if (std::isnan(json.asDouble()))
 			*((float*)data) = std::numeric_limits<float>::quiet_NaN();
 		else
 			*((float*)data) = json.asFloat();

--- a/src/game/sgame/gameplay/g_spawn_points.cpp
+++ b/src/game/sgame/gameplay/g_spawn_points.cpp
@@ -21,6 +21,7 @@ that have not yet been migrated.*/
 #include "../g_local.hpp"
 #include "g_headhunters.hpp"
 #include <algorithm>
+#include <cfloat>
 #include <cstring>
 #include <format>
 

--- a/src/game/sgame/gameplay/g_target.cpp
+++ b/src/game/sgame/gameplay/g_target.cpp
@@ -1216,7 +1216,7 @@ struct laser_pierce_t : pierce_args_t {
 	}
 };
 
-static THINK(target_laser_think) (gentity_t* self) -> void {
+THINK(target_laser_think) (gentity_t* self) -> void {
 	int32_t count;
 
 	if (self->spawnFlags.has(SPAWNFLAG_LASER_ZAP))

--- a/src/game/sgame/monsters/m_move.cpp
+++ b/src/game/sgame/monsters/m_move.cpp
@@ -215,7 +215,7 @@ static bool G_alternate_flystep(gentity_t *ent, Vector3 move, bool relink, genti
 	Vector3 dir = ent->velocity.normalized(currentSpeed);
 
 	// FIXME
-	if (isnan(dir[0]) || isnan(dir[1]) || isnan(dir[2])) {
+	if (std::isnan(dir[0]) || std::isnan(dir[1]) || std::isnan(dir[2])) {
 #if defined(_DEBUG) && defined(_WIN32)
 		__debugbreak();
 #endif
@@ -322,7 +322,7 @@ static bool G_alternate_flystep(gentity_t *ent, Vector3 move, bool relink, genti
 	Vector3 final_dir = dir ? dir : wanted_dir;
 
 	// FIXME
-	if (isnan(final_dir[0]) || isnan(final_dir[1]) || isnan(final_dir[2])) {
+	if (std::isnan(final_dir[0]) || std::isnan(final_dir[1]) || std::isnan(final_dir[2])) {
 #if defined(_DEBUG) && defined(_WIN32)
 		__debugbreak();
 #endif
@@ -386,8 +386,8 @@ static bool G_alternate_flystep(gentity_t *ent, Vector3 move, bool relink, genti
 		currentSpeed = min(wanted_speed, currentSpeed + accel);
 
 	// FIXME
-	if (isnan(final_dir[0]) || isnan(final_dir[1]) || isnan(final_dir[2]) ||
-		isnan(currentSpeed)) {
+	if (std::isnan(final_dir[0]) || std::isnan(final_dir[1]) || std::isnan(final_dir[2]) ||
+		std::isnan(currentSpeed)) {
 #if defined(_DEBUG) && defined(_WIN32)
 		__debugbreak();
 #endif

--- a/src/game/sgame/monsters/m_stalker.cpp
+++ b/src/game/sgame/monsters/m_stalker.cpp
@@ -579,7 +579,7 @@ bool stalker_do_pounce(gentity_t *self, const Vector3 &dest) {
 	if (std::fabs(jumpAngles[YAW] - self->s.angles[YAW]) > 45)
 		return false; // not facing the player...
 
-	if (isnan(jumpAngles[YAW]))
+	if (std::isnan(jumpAngles[YAW]))
 		return false; // Switch why
 
 	self->ideal_yaw = jumpAngles[YAW];


### PR DESCRIPTION
Fix Linux build (atomics, strchrnul, font macros, libm, OpenAL)
Fixes Linux build failures and keeps Windows builds working.

Changes
1. renderer.cpp – strchrnul C++ overload

Added R_Q_strchrnul wrapper to resolve C++ overload ambiguity with glibc’s strchrnul
Wrapper uses Q_strchrnul when HAVE_STRCHRNUL is not defined (e.g. on Windows)
2. inc/shared/atomic.h – C++ atomics

Added C++ path for atomic_int, atomic_load, atomic_store using std::atomic from <atomic>
Keeps existing MSVC path; C++ branch only used when not MSVC
3. src/client/font.cpp – min/max macro conflict

Define NOMINMAX before including font.h so min/max don’t conflict with std::min/std::max from <algorithm>
4. meson.build – OpenGL renderer and OpenAL

Link OpenGL renderer against libm for math symbols (tanf, sincosf, expf, etc.)
Add -mno-direct-extern-access for client C++ when OpenAL is used on Linux to work around Fedora/binutils “non-canonical reference to canonical protected function” linker errors
Use client_link_args for the client executable
Platforms
Linux: Builds successfully (Fedora tested)
Windows: Unchanged; R_Q_strchrnul uses Q_strchrnul when strchrnul is unavailable