### PR TITLE
Fix SDL3_ttf/HarfBuzz TTF path: avoid dropped segments, robust glyph caching, and init hardening

### DIFF
--- a/docs-dev/proposals/swot-feature-development-roadmap-2026-02-27.md
+++ b/docs-dev/proposals/swot-feature-development-roadmap-2026-02-27.md
@@ -151,6 +151,11 @@ Create a repository-grounded SWOT and convert it into actionable, task-based pro
     - Unmerged projectile/autosound loops now use a stable per-entity phase offset so identical loop samples do not all start in lockstep.
     - This reduces crackle/noise when many projectile loop emitters are active simultaneously while preserving per-entity Doppler spatialization.
   - Implementation log: `docs-dev/audio-eax-loop-doppler-mix-stability-2026-03-22.md`.
+- `FR-06-T03` In Progress:
+  - Hardened the SDL3_ttf/HarfBuzz text path in `src/client/font.cpp` so failed `TTF_CreateText(...)` or `TTF_GetStringSize(...)` calls no longer silently drop render/measure segments.
+  - Updated TTF glyph cache generation to keep HarfBuzz-shaped glyphs renderable when metrics lookup fails but glyph image extraction succeeds (`TTF_GetGlyphImageForIndex(...)`).
+  - Added SDL3_ttf surface text-engine startup validation so TTF mode only stays active when both library init and text engine creation succeed.
+  - Implementation log: `docs-dev/ttf-sdl3-harfbuzz-render-path-hardening-2026-03-27.md`.
 
 ## Baseline Snapshot (Repository-Derived)
 - Codebase scale is substantial: approximately 733 `*.c`/`*.cpp`/`*.h`/`*.hpp` files and approximately 426k lines across `src/` and `inc/`.

--- a/docs-dev/ttf-sdl3-harfbuzz-render-path-hardening-2026-03-27.md
+++ b/docs-dev/ttf-sdl3-harfbuzz-render-path-hardening-2026-03-27.md
@@ -1,0 +1,52 @@
+# SDL3_ttf + HarfBuzz Render Path Hardening (2026-03-27)
+
+Task ID: `FR-06-T03`
+
+## Summary
+- Fixed a drop-on-failure bug in the TTF draw path where a failed SDL3_ttf text object build would skip rendering entirely instead of falling back to existing glyph-by-glyph rendering.
+- Hardened glyph-cache generation for HarfBuzz-shaped glyph indices by no longer requiring `TTF_GetGlyphMetrics(...)` to succeed before a glyph can be considered renderable.
+- Added guardrails so TTF mode is only marked ready when both SDL3_ttf and the SDL3_ttf surface text engine are actually initialized.
+- Hardened measurement so failed SDL3_ttf width queries no longer produce silent zero-width segments.
+
+## Problem Statement
+The current TTF path depended on successful creation of `TTF_Text` and successful metrics queries for every shaped glyph. In practice, this introduced two failure modes that could produce an apparent "no font rendered" result:
+
+1. **Segment drop on shaping object failure**
+   - `Font_DrawString(...)` unconditionally `continue`d after entering the SDL3_ttf branch, even when `TTF_CreateText(...)` failed.
+   - That meant no draw work and no fallback draw happened for the segment.
+
+2. **Cache population dependent on metrics call**
+   - Glyph caching used HarfBuzz-shaped glyph indices (from SDL3_ttf text draw ops).
+   - If `TTF_GetGlyphMetrics(...)` failed for that index, glyph cache generation aborted early for that glyph, even when `TTF_GetGlyphImageForIndex(...)` could still provide raster data.
+
+## Implementation Details
+### 1) Draw-path fallback recovery
+- Added a local `drew_ttf_segment` guard in `Font_DrawString(...)`.
+- The function now only short-circuits (`continue`) when a segment was actually emitted through SDL3_ttf draw operations.
+- If SDL3_ttf text object creation fails, the code now naturally falls back to the existing glyph-by-glyph rendering path (kfont/legacy fallback chain), preserving visible output instead of dropping text.
+
+### 2) Glyph cache robustness for HarfBuzz indices
+- Updated `font_ttf_render_bitmap(...)` to treat metrics as optional:
+  - Keep attempting `TTF_GetGlyphMetrics(...)`.
+  - Do **not** early-return on metrics failure.
+  - If `TTF_GetGlyphImageForIndex(...)` succeeds, mark glyph as valid and cache bitmap data.
+- Added conservative advance fallback (`surface->w`) when metrics are unavailable, so fixed-size fallback behavior remains stable.
+
+This aligns the cache behavior with SDL3_ttf + HarfBuzz shaping output by prioritizing the shaped glyph image path used for actual rendering.
+
+### 3) Initialization safety improvements
+- Updated `Font_Init(...)` to require successful creation of `TTF_CreateSurfaceTextEngine()` before enabling TTF mode.
+- If the engine object cannot be created, TTF mode remains disabled and emits a warning.
+
+### 4) Measurement safety
+- Updated `Font_MeasureString(...)` so the SDL3_ttf segment fast path only applies when `TTF_GetStringSize(...)` succeeds.
+- On failure, control now falls through to the existing per-codepoint fallback measurement path.
+
+## Why this better utilizes SDL3_ttf + HarfBuzz
+- The render path now consistently uses SDL3_ttf’s shaped draw operations when available.
+- Failures in shaping/metrics no longer zero out rendering; fallback rendering remains active.
+- HarfBuzz-shaped glyph indices now remain renderable as long as SDL3_ttf can produce glyph image data, reducing false-negative cache misses.
+
+## Files Updated
+- `src/client/font.cpp`
+- `docs-dev/proposals/swot-feature-development-roadmap-2026-02-27.md`

--- a/src/client/font.cpp
+++ b/src/client/font.cpp
@@ -452,11 +452,11 @@ static bool font_ttf_render_bitmap(font_t *font, uint32_t glyph_index,
   if (!font || !out_glyph || !out_bitmap || !out_pitch || !font->ttf.sdl_font)
     return false;
 
-  int minx, maxx, miny, maxy, advance;
-  if (!TTF_GetGlyphMetrics(font->ttf.sdl_font, glyph_index, &minx, &maxx, &miny, &maxy, &advance))
-    return false;
+  int minx = 0, maxx = 0, miny = 0, maxy = 0, advance = 0;
+  bool have_metrics = TTF_GetGlyphMetrics(font->ttf.sdl_font, glyph_index, &minx,
+	&maxx, &miny, &maxy, &advance);
 
-  out_glyph->valid = true;
+  out_glyph->valid = have_metrics;
   out_glyph->left = minx;
   out_glyph->top = maxy;
   out_glyph->bottom = miny;
@@ -465,7 +465,7 @@ static bool font_ttf_render_bitmap(font_t *font, uint32_t glyph_index,
   out_glyph->w = std::max(0, maxx - minx);
   out_glyph->h = std::max(0, maxy - miny);
 
-  if (out_glyph->w <= 0 || out_glyph->h <= 0) {
+  if (have_metrics && out_glyph->w <= 0 && out_glyph->h <= 0) {
     *out_pitch = 0;
     out_bitmap->clear();
     return true;
@@ -478,8 +478,13 @@ static bool font_ttf_render_bitmap(font_t *font, uint32_t glyph_index,
     return true;
   }
 
+  out_glyph->valid = true;
   out_glyph->w = surface->w;
   out_glyph->h = surface->h;
+  if (!have_metrics && out_glyph->x_skip <= 0) {
+	out_glyph->x_skip = surface->w;
+	out_glyph->advance_26_6 = surface->w << 6;
+  }
   *out_pitch = surface->w;
   out_bitmap->assign((size_t)surface->w * (size_t)surface->h, 0);
 
@@ -1089,8 +1094,13 @@ void Font_Init(void) {
       g_ttf_ready = false;
     } else {
       g_ttf_engine = TTF_CreateSurfaceTextEngine();
-      g_ttf_ready = true;
-      font_debug_printf("Font: SDL3_ttf initialized\n");
+      if (!g_ttf_engine) {
+        Com_WPrintf("SDL3_ttf text engine creation failed, TTF fonts disabled\n");
+        g_ttf_ready = false;
+      } else {
+        g_ttf_ready = true;
+        font_debug_printf("Font: SDL3_ttf initialized\n");
+      }
     }
   }
 #else
@@ -1267,6 +1277,7 @@ int Font_DrawString(font_t *font, int x, int y, int scale, int flags,
 
 #if USE_SDL3_TTF
     if (font->kind == FONT_TTF && g_ttf_engine) {
+      bool drew_ttf_segment = false;
       TTF_Text *text_obj = TTF_CreateText(g_ttf_engine, font->ttf.sdl_font, seg_start, seg_len);
       if (text_obj && text_obj->internal && text_obj->internal->ops) {
         float glyph_scale = font_draw_scale(font, draw_scale);
@@ -1292,11 +1303,13 @@ int Font_DrawString(font_t *font, int x, int y, int scale, int flags,
         }
         x_f += (float)text_obj->internal->w * glyph_scale;
         x_i = Q_rint(x_f);
+        drew_ttf_segment = true;
         TTF_DestroyText(text_obj);
       } else {
         if (text_obj) TTF_DestroyText(text_obj);
       }
-      continue;
+      if (drew_ttf_segment)
+        continue;
     }
 #endif
 
@@ -1379,10 +1392,11 @@ int Font_MeasureString(const font_t *font, int scale, int flags,
 #if USE_SDL3_TTF
     if (font->kind == FONT_TTF && g_ttf_engine) {
       int w = 0, h = 0;
-      TTF_GetStringSize(font->ttf.sdl_font, seg_start, seg_len, &w, &h);
-      pen_x += (float)w * font_draw_scale(font, draw_scale);
-      max_width = std::max(max_width, pen_x);
-      continue;
+      if (TTF_GetStringSize(font->ttf.sdl_font, seg_start, seg_len, &w, &h)) {
+        pen_x += (float)w * font_draw_scale(font, draw_scale);
+        max_width = std::max(max_width, pen_x);
+        continue;
+      }
     }
 #endif
 


### PR DESCRIPTION
### Motivation
- SDL3_ttf + HarfBuzz shaped text path could silently drop whole segments when `TTF_CreateText(...)` or `TTF_GetStringSize(...)` failed, producing no visible font output.  
- Glyph cache population relied on successful `TTF_GetGlyphMetrics(...)`, which caused HarfBuzz-shaped glyph indices to be treated as missing even when `TTF_GetGlyphImageForIndex(...)` could provide raster data.  
- TTF mode was enabled on `TTF_Init()` alone, leaving the client vulnerable to a missing/failed SDL3_ttf surface text engine and resulting in inconsistent behavior.

### Description
- Made glyph metrics optional in `font_ttf_render_bitmap(...)` and no longer early-return on metrics failure, allowing glyphs to be cached/rendered if `TTF_GetGlyphImageForIndex(...)` succeeds, and supplying a conservative advance fallback based on `surface->w` when metrics are unavailable.  
- Changed `Font_DrawString(...)` so the SDL3_ttf branch only short-circuits when it actually emitted draw operations; when `TTF_CreateText(...)` fails the code now falls through to existing per-codepoint (kfont/legacy/fallback) rendering instead of dropping the segment.  
- Hardened `Font_Init(...)` to require successful creation of the SDL3_ttf surface text engine (`TTF_CreateSurfaceTextEngine()`) before enabling TTF mode and emit a warning when engine creation fails.  
- Made `Font_MeasureString(...)` resilient by using `TTF_GetStringSize(...)` only when it succeeds and otherwise falling back to per-codepoint advance measurement to avoid zero-width measurement segments.  
- Added implementation documentation and tracking: new `docs-dev/ttf-sdl3-harfbuzz-render-path-hardening-2026-03-27.md` and updated roadmap entry (`docs-dev/proposals/swot-feature-development-roadmap-2026-02-27.md`) under Task ID `FR-06-T03`.

### Testing
- Ran `git diff --check` which returned clean results (success).  
- Attempted a local build setup with `meson setup builddir --buildtype=debugoptimized`, but the environment lacks `meson` so the configure step failed (not a code failure in the patch).  
- Repository changes were committed and the new docs file created; no automated unit tests exist for the font path in this environment so runtime verification should be performed in a machine with SDL3_ttf/meson available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6ad28e00c83288fc361282861484a)