### PR TITLE
README: replace compatibility warning with Quake 4 Steam/GOG buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,15 @@ The goals of WORR are:
   - Competitive and casual multiplayer improvements,
   - Modern rendering and UI systems.
 
-> ⚠️ **Compatibility note:**
-> Future engine updates may break compatibility with non-**WORR** game modules.
+<p align="center">
+  <a href="https://store.steampowered.com/app/2210/Quake_4/" aria-label="Buy Quake 4 on Steam">
+    <img alt="Buy Quake 4 on Steam" src="https://img.shields.io/badge/Buy%20Now-Steam-1b2838?style=for-the-badge&logo=steam&logoColor=white">
+  </a>
+  &nbsp;
+  <a href="https://www.gog.com/en/game/quake_4" aria-label="Buy Quake 4 on GOG">
+    <img alt="Buy Quake 4 on GOG" src="https://img.shields.io/badge/Buy%20Now-GOG-86328A?style=for-the-badge&logo=gog.com&logoColor=white">
+  </a>
+</p>
 
 ---
 


### PR DESCRIPTION
### Motivation
- Replace the agentic AI/compatibility warning callout with prominent storefront CTAs styled like the Quake II Rerelease buttons and point users to Quake 4 purchase pages.

### Description
- Removed the compatibility warning block and added a centered, side-by-side pair of shield-based buttons in `README.md` linking to Steam (`https://store.steampowered.com/app/2210/Quake_4/`) and GOG (`https://www.gog.com/en/game/quake_4`) using `img.shields.io` badges.

### Testing
- Verified content changes with `rg -n "store\.steampowered|gog\.com" README.md` and inspected the diff with `git diff -- README.md`, and committed the update with `git commit`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8eeb2a1f8832896d67e4fe0631941)