### PR TITLE
HUD: top-center match state / countdown; dev_ready solo testing bypass

### DIFF
--- a/src/client/cgame_classic.cpp
+++ b/src/client/cgame_classic.cpp
@@ -331,7 +331,8 @@ static void SCR_SkipToEndif(const char **s)
             continue;
         }
 
-        if (!strcmp(token, "num") || !strcmp(token, "health_bars")) {
+        if (!strcmp(token, "num") || !strcmp(token, "num_center") ||
+            !strcmp(token, "health_bars")) {
             COM_SkipToken(s);
             COM_SkipToken(s);
             continue;
@@ -481,6 +482,33 @@ static void layout_num(vrect_t hud_vrect, const char **s, const player_state_t *
     }
     value = ps->stats[value];
     HUD_DrawNumber(x, y, 0, width, value);
+}
+
+static void layout_num_center(vrect_t hud_vrect, const char **s, const player_state_t *ps, int x, int y)
+{
+    char* token = COM_Parse(s);
+    int width = atoi(token);
+    token = COM_Parse(s);
+    int stat = atoi(token);
+    if (stat < 0 || stat >= MAX_STATS) {
+        cgi.Com_Error(va("%s: invalid stat index", __func__));
+    }
+    const int value = ps->stats[stat];
+    constexpr int band_w = 320;
+    int w = width;
+    if (w > 5)
+        w = 5;
+    char num[16];
+    const int l_full = Q_scnprintf(num, sizeof(num), "%i", value);
+    int l = l_full;
+    if (l > w)
+        l = w;
+    if (l < 1)
+        l = 1;
+    const int digit_start = 2 + DIGIT_WIDTH * (w - l);
+    const int digit_span = l * DIGIT_WIDTH;
+    const int left_x = x + band_w / 2 - digit_start - digit_span / 2;
+    HUD_DrawNumber(left_x, y, 0, width, value);
 }
 
 static void layout_hnum(vrect_t hud_vrect, const char **s, const player_state_t *ps, int x, int y)
@@ -694,6 +722,11 @@ static void SCR_ExecuteLayoutString(vrect_t hud_vrect, const char *s, int32_t pl
 
         if (!strcmp(token, "num")) {
             layout_num(hud_vrect, &s, ps, x, y);
+            continue;
+        }
+
+        if (!strcmp(token, "num_center")) {
+            layout_num_center(hud_vrect, &s, ps, x, y);
             continue;
         }
 

--- a/src/game/cgame/cg_draw.cpp
+++ b/src/game/cgame/cg_draw.cpp
@@ -3727,6 +3727,38 @@ static void CG_ExecuteLayoutString (const char *s, vrect_t hud_vrect, vrect_t hu
             }
             continue;
         }
+        if (!strcmp(token, "num_center"))
+        {   // x = left edge of virtual 320 strip (xv 0). Center digit *glyphs* in band;
+            // CG_DrawField right-pads in `width` cells, so centering the full field
+            // shifts one-digit values to the right.
+            token = COM_Parse (&s);
+            if (!skip_depth)
+                width = atoi(token);
+            token = COM_Parse (&s);
+            if (!skip_depth)
+            {
+                value = ps->stats[atoi(token)];
+                int wfield = width;
+                if (wfield > 5)
+                    wfield = 5;
+                char numbuf[16];
+                auto result =
+                    std::to_chars(numbuf, numbuf + sizeof(numbuf) - 1, value);
+                *result.ptr = '\0';
+                int l = static_cast<int>(result.ptr - numbuf);
+                if (l > wfield)
+                    l = wfield;
+                if (l < 1)
+                    l = 1;
+                const int band_w = hx * 2 * scale;
+                const int digit_start = (2 + CHAR_WIDTH * (wfield - l)) * scale;
+                const int digit_span = l * CHAR_WIDTH * scale;
+                const int left_x =
+                    x + band_w / 2 - digit_start - digit_span / 2;
+                CG_DrawField(left_x, y, 0, width, value, scale);
+            }
+            continue;
+        }
         // [Paril-KEX] special handling for the lives number
         else if (!strcmp(token, "lives_num"))
         {
@@ -4570,6 +4602,11 @@ struct cg_statusbar_builder_t {
         sb += G_Fmt("num {} {} ", width, static_cast<int>(stat)).data();
         return *this;
     }
+    inline cg_statusbar_builder_t &num_center(int32_t width, player_stat_t stat)
+    {
+        sb += G_Fmt("num_center {} {} ", width, static_cast<int>(stat)).data();
+        return *this;
+    }
 
     inline cg_statusbar_builder_t &loc_stat_string(player_stat_t stat)
     {
@@ -4589,6 +4626,11 @@ struct cg_statusbar_builder_t {
     inline cg_statusbar_builder_t &stat_string2(player_stat_t stat)
     {
         sb += G_Fmt("stat_string2 {} ", static_cast<int>(stat)).data();
+        return *this;
+    }
+    inline cg_statusbar_builder_t &loc_stat_cstring(player_stat_t stat)
+    {
+        sb += G_Fmt("loc_stat_cstring {} ", static_cast<int>(stat)).data();
         return *this;
     }
     inline cg_statusbar_builder_t &loc_stat_cstring2(player_stat_t stat)
@@ -4714,8 +4756,8 @@ static void CG_Statusbar_AddDeathmatchStatus(cg_statusbar_builder_t &sb, bool is
         sb.ifstat(STAT_TEAMPLAY_INFO).xl(0).yb(-88).stat_string(STAT_TEAMPLAY_INFO).endifstat();
     }
 
-    sb.ifstat(STAT_COUNTDOWN).xv(136).yb(-256).num(3, STAT_COUNTDOWN).endifstat();
-    sb.ifstat(STAT_MATCH_STATE).xv(0).yb(-78).stat_string(STAT_MATCH_STATE).endifstat();
+    sb.ifstat(STAT_MATCH_STATE).xv(0).yt(12).loc_stat_cstring(STAT_MATCH_STATE).endifstat();
+    sb.ifstat(STAT_COUNTDOWN).xv(0).yt(28).num_center(3, STAT_COUNTDOWN).endifstat();
 
     sb.ifstat(STAT_FOLLOWING).xv(0).yb(-68).string2("FOLLOWING").xv(80).stat_string(STAT_FOLLOWING).endifstat();
     sb.ifstat(STAT_SPECTATOR).xv(0).yb(-68).string2("SPECTATING").xv(0).yb(-58).string("Use TAB Menu to join the match.").xv(80).endifstat();

--- a/src/game/sgame/commands/command_client.cpp
+++ b/src/game/sgame/commands/command_client.cpp
@@ -1365,6 +1365,47 @@ Toggles the eyecam view when following other players.
 			HandleReadyResult(ent, result, false, true);
 		}
 
+		/*
+		=============
+		DevReady / DevReadyOff
+
+		Solo developer testing: bypass warmup minimum-player / fill gates and mark
+		the caller ready. Requires cheats (cheats 1). Cleared on map load; use
+		dev_ready_off to disable early (also requires cheats).
+		=============
+		*/
+		void DevReady(gentity_t* ent, const CommandArgs& args) {
+			(void)args;
+			if (!CheatsOk(ent))
+				return;
+			if (!deathmatch->integer) {
+				gi.LocClient_Print(ent, PRINT_HIGH,
+					"dev_ready: only available in deathmatch.\n");
+				return;
+			}
+			if (!ent || !ent->client || !ClientIsPlaying(ent->client)) {
+				gi.LocClient_Print(ent, PRINT_HIGH,
+					"dev_ready: join the match (not spectator) first.\n");
+				return;
+			}
+			level.devWarmupReadyBypass = true;
+			ClientSetReadyStatus(ent, true, false);
+			gi.LocClient_Print(ent, PRINT_HIGH,
+				"dev_ready: warmup bypass enabled; marked ready. "
+				"Map reload clears it; use dev_ready_off to disable.\n");
+		}
+
+		void DevReadyOff(gentity_t* ent, const CommandArgs& args) {
+			(void)args;
+			if (!CheatsOk(ent))
+				return;
+			level.devWarmupReadyBypass = false;
+			if (ent && ent->client) {
+				gi.LocClient_Print(ent, PRINT_HIGH,
+					"dev_ready_off: warmup bypass disabled.\n");
+			}
+		}
+
 	} // namespace readiness
 
 	namespace inventory {
@@ -2504,6 +2545,8 @@ Toggles the eyecam view when following other players.
 		RegisterCommand("ready", &readiness::Ready, AllowDead);
 		RegisterCommand("ready_up", &readiness::ReadyUp, AllowDead);
 		RegisterCommand("readyup", &readiness::ReadyUp, AllowDead);
+		RegisterCommand("dev_ready", &readiness::DevReady, AllowDead);
+		RegisterCommand("dev_ready_off", &readiness::DevReadyOff, AllowDead);
 	}
 
 	/*

--- a/src/game/sgame/g_local.hpp
+++ b/src/game/sgame/g_local.hpp
@@ -3234,6 +3234,10 @@ struct LevelLocals {
   GameTime matchStateTimer = 0_ms; // change match state at this time
   int32_t
       warmupModificationCount; // for detecting if g_warmup_countdown is changed
+  /// When true, skip min-player / team-fill warmup gates, relax CheckReady, and
+  /// skip the CheckDMExitRules minplayers intermission (solo dev testing). Set by
+  /// `dev_ready` with cheats enabled; cleared on map load or `dev_ready_off`.
+  bool devWarmupReadyBypass = false;
 
   GameTime countdownTimerCheck = 0_ms;
   GameTime matchEndWarnTimerCheck = 0_ms;

--- a/src/game/sgame/gameplay/g_statusbar.cpp
+++ b/src/game/sgame/gameplay/g_statusbar.cpp
@@ -118,8 +118,8 @@ static void AddDeathmatchStatus(statusbar_t& sb) {
 		sb.ifstat(STAT_TEAMPLAY_INFO).xl(0).yb(-88).stat_string(STAT_TEAMPLAY_INFO).endifstat();
 	}
 
-	sb.ifstat(STAT_COUNTDOWN).xv(136).yb(-256).num(3, STAT_COUNTDOWN).endifstat();
-	sb.ifstat(STAT_MATCH_STATE).xv(0).yb(-78).stat_string(STAT_MATCH_STATE).endifstat();
+	sb.ifstat(STAT_MATCH_STATE).xv(0).yt(12).loc_stat_cstring(STAT_MATCH_STATE).endifstat();
+	sb.ifstat(STAT_COUNTDOWN).xv(0).yt(28).num_center(3, STAT_COUNTDOWN).endifstat();
 
 	sb.ifstat(STAT_FOLLOWING).xv(0).yb(-68).string2("FOLLOWING").xv(80).stat_string(STAT_FOLLOWING).endifstat();
 	sb.ifstat(STAT_SPECTATOR).xv(0).yb(-68).string2("SPECTATING").xv(0).yb(-58).string("Use TAB Menu to join the match.").xv(80).endifstat();

--- a/src/game/sgame/gameplay/g_statusbar.hpp
+++ b/src/game/sgame/gameplay/g_statusbar.hpp
@@ -39,11 +39,17 @@ struct statusbar_t {
 	inline auto& rnum() { sb << "rnum "; return *this; }
 	inline auto& hnum() { sb << "hnum "; return *this; }
 	inline auto& num(int32_t width, player_stat_t stat) { sb << "num " << width << ' ' << stat << ' '; return *this; }
+	inline auto& num_center(int32_t width, player_stat_t stat)
+	{
+		sb << "num_center " << width << ' ' << stat << ' ';
+		return *this;
+	}
 
 	inline auto& loc_stat_string(player_stat_t stat) { sb << "loc_stat_string " << stat << ' '; return *this; }
 	inline auto& loc_stat_rstring(player_stat_t stat) { sb << "loc_stat_rstring " << stat << ' '; return *this; }
 	inline auto& stat_string(player_stat_t stat) { sb << "stat_string " << stat << ' '; return *this; }
 	inline auto& stat_string2(player_stat_t stat) { sb << "stat_string2 " << stat << ' '; return *this; }
+	inline auto& loc_stat_cstring(player_stat_t stat) { sb << "loc_stat_cstring " << stat << ' '; return *this; }
 	inline auto& loc_stat_cstring2(player_stat_t stat) { sb << "loc_stat_cstring2 " << stat << ' '; return *this; }
 	inline auto& string2(const char* str)
 	{

--- a/src/game/sgame/gameplay/g_utilities.cpp
+++ b/src/game/sgame/gameplay/g_utilities.cpp
@@ -2193,6 +2193,11 @@ bool ReadyConditions(gentity_t *ent, bool admin_cmd) {
   if (level.matchState == MatchState::Warmup_ReadyUp)
     return true;
 
+  if (level.devWarmupReadyBypass && deathmatch->integer && ent &&
+      ent->client && ClientIsPlaying(ent->client) &&
+      level.matchState <= MatchState::Warmup_ReadyUp)
+    return true;
+
   const char *reason = admin_cmd ? "You cannot force ready status until "
                                  : "You cannot change your ready status until ";
   switch (level.warmupState) {

--- a/src/game/sgame/match/match_state.cpp
+++ b/src/game/sgame/match/match_state.cpp
@@ -1857,7 +1857,8 @@ static bool CheckReady() {
 
   // wait if below minimum players
   if (minplayers->integer > 0 &&
-      (count_humans + count_bots) < minplayers->integer)
+      (count_humans + count_bots) < minplayers->integer &&
+      !level.devWarmupReadyBypass)
     return false;
 
   // start if only bots
@@ -2041,11 +2042,12 @@ static void CheckDMWarmupState() {
       forceBalance &&
       std::abs(level.pop.num_playing_red - level.pop.num_playing_blue) > 1;
   const bool notEnoughPlayers =
-      (Teams() &&
-       (level.pop.num_playing_red < 1 || level.pop.num_playing_blue < 1)) ||
-      (duel && level.pop.num_playing_clients != 2) ||
-      (!Teams() && !duel && level.pop.num_playing_clients < min_players) ||
-      (!match_startNoHumans->integer && !level.pop.num_playing_human_clients);
+      !level.devWarmupReadyBypass &&
+      ((Teams() &&
+        (level.pop.num_playing_red < 1 || level.pop.num_playing_blue < 1)) ||
+       (duel && level.pop.num_playing_clients != 2) ||
+       (!Teams() && !duel && level.pop.num_playing_clients < min_players) ||
+       (!match_startNoHumans->integer && !level.pop.num_playing_human_clients));
 
   if (teamsImbalanced || notEnoughPlayers) {
     if (level.matchState <= MatchState::Countdown) {
@@ -2486,7 +2488,8 @@ void CheckDMExitRules() {
 
   // --- Not enough players for match ---
   if (minplayers->integer > 0 &&
-      level.pop.num_playing_clients < minplayers->integer) {
+      level.pop.num_playing_clients < minplayers->integer &&
+      !level.devWarmupReadyBypass) {
     graceScope.MarkConditionActive();
     if (!level.endmatch_grace) {
       level.endmatch_grace = level.time;


### PR DESCRIPTION
Summary

Moves STAT_MATCH_STATE and STAT_COUNTDOWN to the top center of the statusbar (virtual 320 band): loc_stat_cstring for the label, num_center for digits (glyph-centered for single-digit values).
Keeps server and classic clients in sync via g_statusbar and cgame_classic num_center handling.
Dev tooling (cheats)

dev_ready / dev_ready_off, gated by CheatsOk (cheats 1 in DM).
level.devWarmupReadyBypass: relaxes warmup / CheckReady constraints and skips the CheckDMExitRules minplayers intermission so single-player listen-server testing can run a full countdown and match start.
Testing

Local DM listen server: confirm top HUD text + countdown alignment with cg_hud_cgame 1 and 0 (CS_STATUSBAR).
cheats 1, join match, dev_ready: solo warmup → countdown → In_Progress without “Not enough players remaining.”